### PR TITLE
Some security enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,12 +292,19 @@ cache: {
   enabled: true,
   provider: 'valkey',                 // 'valkey' | 'redis' (wire-compatible)
   // Managed (GKE default): the adapter provisions Memorystore and injects the connection.
-  memorystore: { region: 'us-central1', sizeGb: 1, tier: 'BASIC' },
+  memorystore: {
+    region: 'us-central1',
+    sizeGb: 1,
+    tier: 'BASIC',
+    // auth: true,                    // recommended — Redis AUTH + in-transit encryption
+  },
   // — or bring your own, and the adapter provisions nothing —
   // url: 'redis://my-valkey.internal:6379',
   // password: '...',
 },
 ```
+
+> **Secure the cache endpoint.** Without `auth: true`, the managed instance has no AUTH and no in-transit encryption — any workload that can reach the VPC endpoint can read and write the shared cache (and cached pages can carry PII). With `auth: true` the instance is created with AUTH + TLS (`SERVER_AUTHENTICATION`), and the pods connect over `rediss://` with the instance AUTH string and server CA injected from the connection Secret (`VALKEY_AUTH` / `VALKEY_CA_CERT`). AUTH can only be set at instance creation, so enable it before the first deploy (or destroy the instance first). Treat one Memorystore instance as one tenant: cache keys are namespaced by build id, but that namespace is **not** a security boundary — don't point two unrelated applications at the same instance.
 
 What it does:
 
@@ -322,6 +329,18 @@ routingService: {
                                  // (never bypass auth), fails open otherwise; 'open'/'closed' force it
 },
 ```
+
+## Security Posture
+
+What the generated infrastructure does by default:
+
+- **Non-root, read-only workloads.** Pool and routing-service containers run as `USER node` with `runAsNonRoot`, `readOnlyRootFilesystem`, `allowPrivilegeEscalation: false`, all capabilities dropped, seccomp `RuntimeDefault`, and no service-account token (the traffic-extension Job keeps its Workload Identity token — it needs it — but runs with the same hardening). Writable scratch space is provided by `emptyDir` mounts at `/tmp` and `/app/.next/cache` (per-pod, ephemeral).
+- **NetworkPolicies, fail-closed.** The chart isolates the dataplane: the routing service accepts traffic only from the load balancer / health-check ranges (never from in-cluster pods, which closes off extraction of the internal dispatch secret), and pools accept LB traffic plus sibling-**pool** pods only (the routing service can't originate pool traffic). Deploy discovers the cluster pod CIDR and **aborts** if it can't — pass `--allow-no-network-policy` to explicitly deploy without isolation. Standard clusters are created with `--enable-network-policy`; Autopilot always enforces it.
+- **A shared secret authenticates internal routing headers** between the routing service and pools (`INTERNAL_HEADER_SECRET`, 32 random bytes per deploy, delivered only via a Kubernetes Secret, compared in constant time). Dispatch headers from any other source are stripped.
+- **HTTPS redirect.** When TLS is enabled, the chart emits an HTTP→HTTPS `RequestRedirect` route so plaintext HTTP is never served.
+- **Secrets never touch command lines, logs, or git** (init scaffolds `.k8s-adapter/` into `.gitignore`; secret-bearing chart files are written `0600`).
+- **Input validation at every boundary**: release name, hostnames, registry, namespace, and the build id are charset-validated before they reach Helm values, YAML, or the privileged registration Job. A custom `generateBuildId()` outside `[A-Za-z0-9._-]` fails the build.
+- **Least-privilege deploy identity.** The deploy service account gets a release-scoped custom IAM role for traffic-extension registration and repository-scoped Artifact Registry access — not project-wide LB admin.
 
 ## Architecture
 
@@ -449,15 +468,15 @@ The Helm chart is self-contained -- it includes the traffic-extension registrati
 
 ## Implementation Status
 
-| Phase | Status  | What                                                                                                                                                                                                                                                                  |
-| ----- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 1     | Done    | Adapter core, pool server, CLI (init/deploy/destroy/doctor/describe/rollback/tail/emulate)                                                                                                                                                                            |
-| 2     | Done    | Routing service (ext_proc **traffic extension**), CEL generation, Service Extensions                                                                                                                                                                                  |
-| 3     | Done    | Cloud CDN integration (GCPHTTPFilter, Next.js-aware cache keys, diagnostic headers)                                                                                                                                                                                   |
-| 4     | Done    | Coordinated CDN invalidation — pool servers stamp a per-build `Cache-Tag` on mutable cacheable responses (SSG HTML, `public/` files); `deploy` and `rollback` purge the outgoing build's tag on cutover so a new build never serves the previous build's stale same-URL content from the edge                                    |
-| 5     | Done    | Distributed cache — Valkey `use cache` handler + incremental cache handler shared across replicas (cross-replica `revalidateTag` for `use cache`, ISR, and PPR shells); managed Memorystore or BYO. See [Distributed Cache](#distributed-cache-cache-components--ppr) |
-| 6     | Done    | PPR — pool-native shell resume + `no-store` at the CDN; PPR shells revalidate cross-replica via the incremental cache (needs Node `proxy.ts`)                                                                                                                         |
-| 7     | Planned | Skew protection (versioned routing for zero-mismatch deploys)                                                                                                                                                                                                         |
+| Phase | Status  | What                                                                                                                                                                                                                                                                                          |
+| ----- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1     | Done    | Adapter core, pool server, CLI (init/deploy/destroy/doctor/describe/rollback/tail/emulate)                                                                                                                                                                                                    |
+| 2     | Done    | Routing service (ext_proc **traffic extension**), CEL generation, Service Extensions                                                                                                                                                                                                          |
+| 3     | Done    | Cloud CDN integration (GCPHTTPFilter, Next.js-aware cache keys, diagnostic headers)                                                                                                                                                                                                           |
+| 4     | Done    | Coordinated CDN invalidation — pool servers stamp a per-build `Cache-Tag` on mutable cacheable responses (SSG HTML, `public/` files); `deploy` and `rollback` purge the outgoing build's tag on cutover so a new build never serves the previous build's stale same-URL content from the edge |
+| 5     | Done    | Distributed cache — Valkey `use cache` handler + incremental cache handler shared across replicas (cross-replica `revalidateTag` for `use cache`, ISR, and PPR shells); managed Memorystore or BYO. See [Distributed Cache](#distributed-cache-cache-components--ppr)                         |
+| 6     | Done    | PPR — pool-native shell resume + `no-store` at the CDN; PPR shells revalidate cross-replica via the incremental cache (needs Node `proxy.ts`)                                                                                                                                                 |
+| 7     | Planned | Skew protection (versioned routing for zero-mismatch deploys)                                                                                                                                                                                                                                 |
 
 ## License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -834,9 +834,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -853,9 +850,6 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -874,9 +868,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -893,9 +884,6 @@
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -914,9 +902,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -933,9 +918,6 @@
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -954,9 +936,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -974,9 +953,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -993,9 +969,6 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1020,9 +993,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1045,9 +1015,6 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1072,9 +1039,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1097,9 +1061,6 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1124,9 +1085,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1150,9 +1108,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1175,9 +1130,6 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1362,9 +1314,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1381,9 +1330,6 @@
       "integrity": "sha512-zkN9MQYS7UQBro+FnISUq1itaQjXI9xqISzuQ+2bc921NcJ1x4yPCqrn77tVN6/dOOXaaWVX3k6/bR07pPwK+A==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1402,9 +1348,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1421,9 +1364,6 @@
       "integrity": "sha512-ov2g4H0dHY9bPoOU83m91hWT7Iq5qy13bUnyyshLU3HGR1Ownn0X9QpmDPc5iIUaahTp7f7LeGAhV4DSFtackw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1606,9 +1546,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1626,9 +1563,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1646,9 +1580,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1666,9 +1597,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1686,9 +1614,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1706,9 +1631,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1726,9 +1648,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1746,9 +1665,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1953,9 +1869,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1973,9 +1886,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1993,9 +1903,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2013,9 +1920,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2033,9 +1937,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2053,9 +1954,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2073,9 +1971,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2093,9 +1988,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2266,9 +2158,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2286,9 +2175,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2306,9 +2192,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2326,9 +2209,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2346,9 +2226,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2366,9 +2243,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3219,9 +3093,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3243,9 +3114,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3267,9 +3135,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3291,9 +3156,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -59,7 +59,12 @@ function hasEdgeMiddleware(projectDir: string): boolean {
 import { validateConfig, applyDefaults } from "./config.js";
 import { classifyIntoPools } from "./classify.js";
 import { buildRoutingManifest } from "./manifest.js";
-import { generateHelmChart } from "./emit/helm.js";
+import { generateHelmChart, SECRET_CHART_FILES } from "./emit/helm.js";
+import {
+  assertSafeBuildId,
+  assertSafeImageRegistry,
+  assertSafeNamespace,
+} from "./emit/templates/utils.js";
 import {
   generateDockerfile,
   generatePoolDockerfile,
@@ -80,10 +85,11 @@ async function writeOutputFile(
   relativePath: string,
   content: string,
   baseDir: string = OUTPUT_DIR,
+  mode?: number,
 ): Promise<void> {
   const fullPath = path.join(projectDir, baseDir, relativePath);
   await mkdir(path.dirname(fullPath), { recursive: true });
-  await writeFile(fullPath, content, "utf-8");
+  await writeFile(fullPath, content, mode === undefined ? "utf-8" : { encoding: "utf-8", mode });
 }
 
 // Resolve and copy .next/node_modules/ — Turbopack creates symlinks to
@@ -286,8 +292,9 @@ export function createK8sAdapter(userConfig?: K8sAdapterConfig): NextAdapter {
       // keep it), and the adapter serves them per Next's own header policy (see static-asset-headers).
       // Respect an explicit user opt-out.
       {
-        const userImmutable = (nextConfig.experimental as { supportsImmutableAssets?: boolean } | undefined)
-          ?.supportsImmutableAssets;
+        const userImmutable = (
+          nextConfig.experimental as { supportsImmutableAssets?: boolean } | undefined
+        )?.supportsImmutableAssets;
         // ADAPTER_K8S_DISABLE_IMMUTABLE_ASSETS=1 forces it off — used to A/B whether the immutable
         // asset split regresses client bootstrap (asset URLs move under /_next/static/immutable/).
         const disabled = process.env.ADAPTER_K8S_DISABLE_IMMUTABLE_ASSETS === "1";
@@ -352,6 +359,12 @@ export function createK8sAdapter(userConfig?: K8sAdapterConfig): NextAdapter {
     async onBuildComplete(ctx: BuildCompleteContext) {
       const { routing, outputs, projectDir, config: nextConfig, buildId, nextVersion } = ctx;
       const repoRoot = (ctx as { repoRoot?: string }).repoRoot ?? projectDir;
+
+      // The finalized build id (Next's default or a custom `generateBuildId()` — commonly
+      // a git ref in CI) flows into helm `--set` values, K8s resource names/labels, image
+      // tags, and chart YAML. Validate it here, at the source, so an unsafe id fails the
+      // build with a clear message instead of injecting into any of those sinks.
+      assertSafeBuildId(buildId);
 
       // Regenerate the Helm chart from a clean slate. Chart files are named per
       // pool/build; without wiping, a removed pool's Deployment/Service or a
@@ -467,10 +480,36 @@ export function createK8sAdapter(userConfig?: K8sAdapterConfig): NextAdapter {
 
       const gkeProvider = cfg.provider.gke;
 
+      // infrastructure.json is operator/CI-managed state, but a tampered or hand-edited
+      // value here flows into helm --set, resource names, and chart YAML — validate at
+      // the point of consumption and fail the build rather than emit an unsafe chart.
+      const namespace = infra.namespace ?? "default";
+      try {
+        assertSafeNamespace(namespace);
+      } catch (err) {
+        throw new Error(
+          `[adapter-k8s] Unsafe namespace in .k8s-adapter/infrastructure.json: ${(err as Error).message}`,
+        );
+      }
+
+      const configuredRegistry = infra.containerRegistry ?? process.env.IMAGE_REGISTRY;
+      if (configuredRegistry !== undefined) {
+        try {
+          assertSafeImageRegistry(configuredRegistry);
+        } catch (err) {
+          throw new Error(
+            `[adapter-k8s] Unsafe image registry from ` +
+              `${infra.containerRegistry ? "infrastructure.json containerRegistry" : "the IMAGE_REGISTRY env var"}: ` +
+              `${(err as Error).message}`,
+          );
+        }
+      }
+      const imageRegistry = configuredRegistry ?? "REGISTRY";
+
       const extensionChain = generateExtensionChain({
         celExpression,
         releaseName,
-        namespace: infra.namespace ?? "default",
+        namespace,
         projectId: infra.projectId ?? "",
         region: infra.region ?? "",
         timeout: gkeProvider.serviceExtensions?.routeExtension?.timeout
@@ -484,7 +523,7 @@ export function createK8sAdapter(userConfig?: K8sAdapterConfig): NextAdapter {
         buildId,
         nextVersion,
         config: cfg,
-        imageRegistry: infra.containerRegistry ?? process.env.IMAGE_REGISTRY ?? "REGISTRY",
+        imageRegistry,
         routingManifest,
         releaseName,
         extensionChainJson: extensionChain,
@@ -493,7 +532,15 @@ export function createK8sAdapter(userConfig?: K8sAdapterConfig): NextAdapter {
       });
 
       for (const [filePath, content] of Object.entries(helmFiles)) {
-        await writeOutputFile(projectDir, `chart/${filePath}`, content);
+        // Secret-bearing templates land on disk mode 0600 — they hold the internal
+        // dispatch secret / Valkey AUTH and must not be group/world-readable.
+        await writeOutputFile(
+          projectDir,
+          `chart/${filePath}`,
+          content,
+          OUTPUT_DIR,
+          SECRET_CHART_FILES.has(filePath) ? 0o600 : undefined,
+        );
       }
 
       // 5. Build Stage Area & Dockerfiles

--- a/src/cel.ts
+++ b/src/cel.ts
@@ -8,6 +8,16 @@ export interface CelGenerationInput {
 
 /** Escape a value for safe interpolation into a CEL single-quoted string literal. */
 export function escapeCelString(value: string): string {
+  // The escaped text is later embedded in a YAML scalar (route-extension.yaml) where a
+  // control character (e.g. a newline in a public filename) would silently fold and
+  // corrupt the extension spec — reject anything outside printable ASCII at build time.
+  if (/[^\x20-\x7e]/.test(value)) {
+    throw new Error(
+      `Cannot embed ${JSON.stringify(value)} in the CEL match condition: ` +
+        `control/non-ASCII characters are not supported (they would corrupt the ` +
+        `route-extension YAML). Rename the file to printable ASCII.`,
+    );
+  }
   return value.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
 }
 

--- a/src/cli/deploy.ts
+++ b/src/cli/deploy.ts
@@ -17,6 +17,14 @@ import { routeExtJobName } from "../emit/templates/route-ext-update-job.js";
 // value, so it MUST match the pod label byte-for-byte — a divergent local copy that
 // omitted the `b-` prefix drained the Service to zero endpoints and 503'd the site.
 import { sanitizeK8sName } from "../emit/templates/utils.js";
+import {
+  assertSafeBuildId,
+  assertSafeImageRegistry,
+  assertSafeNamespace,
+  assertSafeProjectId,
+  assertSafeRegion,
+} from "../emit/templates/utils.js";
+import { sanitizeForTerminal } from "./terminal.js";
 import type { GcloudCommand } from "./init.js";
 
 export interface DeployOptions {
@@ -25,6 +33,14 @@ export interface DeployOptions {
   skipBuild?: boolean;
   skipPush?: boolean;
   dryRun?: boolean;
+  /**
+   * Explicit opt-out of the fail-closed NetworkPolicy posture: allow the deploy to
+   * proceed WITHOUT pod-CIDR NetworkPolicies when the cluster CIDR can't be discovered.
+   * Without this flag a discovery failure aborts the deploy — silently shipping the
+   * chart without its network isolation would re-open the in-cluster secret-extraction
+   * path the policies close (H1).
+   */
+  allowNoNetworkPolicy?: boolean;
 }
 
 export interface DockerCommandOptions {
@@ -100,6 +116,18 @@ export function buildDockerCommands(options: DockerCommandOptions): GcloudComman
   return commands;
 }
 
+// L15: pool names are read from build-metadata.json and used in chart file paths and
+// docker build contexts — a malicious or corrupt name (e.g. "../x") could otherwise
+// escape the chart templates directory.
+export function assertSafePoolName(poolName: string): void {
+  if (!/^[a-z0-9-]+$/.test(poolName)) {
+    throw new Error(
+      `Invalid pool name "${poolName}" in build-metadata.json: must match /^[a-z0-9-]+$/ ` +
+        `(lowercase letters, digits, hyphens). Refusing to use it in file paths.`,
+    );
+  }
+}
+
 export function buildHelmUpgradeArgs(options: {
   releaseName: string;
   chartPath: string;
@@ -107,8 +135,16 @@ export function buildHelmUpgradeArgs(options: {
   registry: string;
   previousBuildId: string | null;
   overridesFile?: string;
+  podCidrs?: string | null;
 }): string[] {
-  const { releaseName, chartPath, buildId, registry, previousBuildId, overridesFile } = options;
+  const { releaseName, chartPath, buildId, registry, previousBuildId, overridesFile, podCidrs } =
+    options;
+  // H2: these values land in `helm --set` assignments — reject helm metacharacters
+  // (","  "\"  quotes) before they can split one assignment into several. The buildId
+  // comes from generateBuildId()/git refs and the registry from infrastructure.json.
+  assertSafeBuildId(buildId);
+  assertSafeImageRegistry(registry);
+  if (previousBuildId) assertSafeBuildId(previousBuildId);
   const args = [
     "upgrade",
     "--install",
@@ -133,6 +169,12 @@ export function buildHelmUpgradeArgs(options: {
     args.push("--set", `previousBuildId=${previousBuildId}`);
   }
 
+  // NetworkPolicy interface with the chart: discovered cluster pod CIDR(s), passed as a
+  // helm brace list (CIDRs contain no commas, so no escaping needed).
+  if (podCidrs) {
+    args.push("--set", `global.networkPolicy.podCidrs={${podCidrs}}`);
+  }
+
   if (overridesFile && existsSync(overridesFile)) {
     args.push("-f", overridesFile);
   }
@@ -140,8 +182,58 @@ export function buildHelmUpgradeArgs(options: {
   return args;
 }
 
+/**
+ * Discover the cluster's pod CIDR for the chart-rendered NetworkPolicies. FAIL-CLOSED:
+ * the helm `podCidrs` guard renders NO policy when the value is absent, so a failed or
+ * malformed lookup throws (the NetworkPolicies are what close in-cluster access to the
+ * routing service's dispatch secret, H1) — unless the operator explicitly opts out with
+ * `--allow-no-network-policy`, in which case this warns loudly and returns null.
+ */
+export async function discoverClusterPodCidr({
+  clusterName,
+  region,
+  projectId,
+  allowNoNetworkPolicy = false,
+}: {
+  clusterName: string;
+  region: string;
+  projectId: string;
+  allowNoNetworkPolicy?: boolean;
+}): Promise<string | null> {
+  const cidrResult = await execCapture("gcloud", [
+    "container",
+    "clusters",
+    "describe",
+    clusterName,
+    "--region",
+    region,
+    "--project",
+    projectId,
+    "--format=value(clusterIpv4Cidr)",
+  ]);
+  const discovered = cidrResult.exitCode === 0 ? cidrResult.stdout.trim() : "";
+  // One or more comma-separated IPv4 CIDRs — anything else would corrupt the helm list.
+  const CIDR_LIST_RE = /^(\d{1,3}\.){3}\d{1,3}\/\d{1,2}(,(\d{1,3}\.){3}\d{1,3}\/\d{1,2})*$/;
+  if (CIDR_LIST_RE.test(discovered)) return discovered;
+
+  if (allowNoNetworkPolicy) {
+    console.warn(
+      "  ! Could not discover the cluster pod CIDR — continuing WITHOUT NetworkPolicies " +
+        "(--allow-no-network-policy). The routing service is reachable from any in-cluster " +
+        "pod; re-run without the flag once the cluster is describable.",
+    );
+    return null;
+  }
+  throw new Error(
+    `Could not discover the pod CIDR for cluster "${clusterName}" ` +
+      `(gcloud exited ${cidrResult.exitCode}${discovered ? `, unexpected value ${JSON.stringify(discovered)}` : ", empty output"}). ` +
+      `The chart's NetworkPolicies require it; refusing to deploy without network isolation. ` +
+      `Fix cluster access, or pass --allow-no-network-policy to explicitly deploy without them.`,
+  );
+}
+
 export async function runDeploy(options: DeployOptions): Promise<void> {
-  const { projectDir, releaseName, skipBuild, skipPush, dryRun } = options;
+  const { projectDir, releaseName, skipBuild, skipPush, dryRun, allowNoNetworkPolicy } = options;
 
   const infraPath = path.join(projectDir, ".k8s-adapter", "infrastructure.json");
   if (!existsSync(infraPath)) {
@@ -151,6 +243,14 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
     );
   }
   const infra = JSON.parse(readFileSync(infraPath, "utf-8"));
+
+  // H2: infrastructure.json values reach the privileged route-ext Job script
+  // (projectId/region), extension-chain authority/YAML (namespace), and helm --set
+  // assignments / docker tags (containerRegistry) — validate before any use.
+  if (infra.projectId) assertSafeProjectId(infra.projectId);
+  if (infra.region) assertSafeRegion(infra.region);
+  if (infra.namespace) assertSafeNamespace(infra.namespace);
+  if (infra.containerRegistry) assertSafeImageRegistry(infra.containerRegistry);
 
   // 0. Ensure kubectl is pointing at the right cluster
   if (!dryRun && infra.projectId && infra.region && releaseName) {
@@ -167,6 +267,18 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
       infra.projectId,
       "--quiet",
     ]);
+  }
+
+  // 0b. Discover the cluster pod CIDR for chart-rendered NetworkPolicies (fail-closed —
+  // see discoverClusterPodCidr).
+  let podCidr: string | null = null;
+  if (!dryRun && infra.projectId && infra.region && releaseName) {
+    podCidr = await discoverClusterPodCidr({
+      clusterName: `${releaseName}-cluster`,
+      region: infra.region,
+      projectId: infra.projectId,
+      allowNoNetworkPolicy: allowNoNetworkPolicy ?? false,
+    });
   }
 
   // 1. Run next build (adapter's onBuildComplete generates artifacts)
@@ -187,7 +299,14 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
   }
   const metadata = JSON.parse(readFileSync(metadataPath, "utf-8"));
   const buildId: string = metadata.buildId;
+  // H2: the buildId comes from generateBuildId()/git refs and is spliced into helm
+  // --set assignments and image tags — reject helm/shell metacharacters up front.
+  assertSafeBuildId(buildId);
   const pools: string[] = metadata.pools;
+  if (!Array.isArray(pools)) {
+    throw new Error(`build-metadata.json is missing a "pools" array. Did next build run?`);
+  }
+  for (const poolName of pools) assertSafePoolName(poolName);
 
   console.log(`\n  Build ID: ${buildId}`);
   console.log(`  Pools: ${pools.join(", ")}`);
@@ -206,7 +325,9 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
     }
     console.log("\n  → Provisioning managed cache (Memorystore)...");
     const ms = (
-      metadata as { cacheMemorystore?: { region?: string; sizeGb?: number; tier?: string } }
+      metadata as {
+        cacheMemorystore?: { region?: string; sizeGb?: number; tier?: string; auth?: boolean };
+      }
     ).cacheMemorystore;
     const cacheRegion = ms?.region ?? infra.region;
     const endpoint = await provisionMemorystore({
@@ -215,6 +336,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
       releaseName,
       ...(ms?.sizeGb ? { sizeGb: ms.sizeGb } : {}),
       ...(ms?.tier ? { tier: ms.tier } : {}),
+      ...(ms?.auth ? { auth: true } : {}),
       log: (m: string) => console.log(m),
     });
     // Persist the actual region immediately after provisioning. Any later failure (writing the
@@ -225,9 +347,20 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
       writeFileSync(infraPath, JSON.stringify(infra, null, 2));
     }
 
-    const url = `redis://${endpoint.host}:${endpoint.port}`;
+    // AUTH mode ⇒ TLS endpoint (Memorystore requires in-transit encryption for AUTH).
+    const url = `${endpoint.authString ? "rediss" : "redis"}://${endpoint.host}:${endpoint.port}`;
     const secretPath = path.join(outputDir, "chart", "templates", "valkey-secret.yaml");
-    writeFileSync(secretPath, renderValkeySecret({ releaseName, url }));
+    // M4a: this file carries the cache connection Secret — owner-read/write only.
+    writeFileSync(
+      secretPath,
+      renderValkeySecret({
+        releaseName,
+        url,
+        ...(endpoint.authString ? { password: endpoint.authString } : {}),
+        ...(endpoint.caCert ? { ca: endpoint.caCert } : {}),
+      }),
+      { mode: 0o600 },
+    );
     console.log(`    Cache Secret ${releaseName}-valkey staged for Helm → ${url}`);
   } else if (!metadata.cacheEnabled && !dryRun) {
     // Cache disabled (not just BYO — cacheEnabled distinguishes them). Tear down a previously
@@ -348,8 +481,14 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
   }
 
   // 6. Helm upgrade
-  const state = await readState(projectDir, releaseName);
+  // L13: dry-run must not touch the cluster — skip the cluster ConfigMap read and use
+  // local state only (best-effort).
+  const state = dryRun
+    ? await readState(projectDir).catch(() => null)
+    : await readState(projectDir, releaseName);
   const previousBuildId = state?.buildId ?? null;
+  // H2: previousBuildId is spliced into a helm --set assignment below.
+  if (previousBuildId) assertSafeBuildId(previousBuildId);
 
   const overridesFile = path.join(projectDir, ".k8s-adapter", "helm", "values.override.yaml");
   const helmArgs = buildHelmUpgradeArgs({
@@ -359,6 +498,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
     registry: infra.containerRegistry,
     previousBuildId,
     overridesFile,
+    podCidrs: podCidr,
   });
 
   // Inject previous build's deployment+service into the chart so Helm doesn't delete it.
@@ -389,25 +529,35 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
       // Render retained resources through the same canonical templates as a normal build.
       // Hand-copying this Deployment previously omitted resources, changing the serving pod
       // template and rolling the old build during every upgrade.
-      writeFileSync(
-        path.join(chartTemplatesDir, `${poolName}-prev-deployment.yaml`),
-        renderDeployment({
-          poolName,
-          buildId: previousBuildId,
-          releaseName,
-          imageTag: previousBuildId,
-          replicas: prevReplicas,
-        }),
-      );
-
-      writeFileSync(
-        path.join(chartTemplatesDir, `${poolName}-prev-service.yaml`),
-        renderService({ poolName, buildId: previousBuildId, releaseName }),
-      );
-      writeFileSync(
-        path.join(chartTemplatesDir, `${poolName}-prev-hpa.yaml`),
-        renderHPA({ poolName, buildId: previousBuildId, releaseName }),
-      );
+      // L13: dry-run must not write into the chart — report the planned writes instead.
+      const retainedFiles: [string, string][] = [
+        [
+          `${poolName}-prev-deployment.yaml`,
+          renderDeployment({
+            poolName,
+            buildId: previousBuildId,
+            releaseName,
+            imageTag: previousBuildId,
+            replicas: prevReplicas,
+          }),
+        ],
+        [
+          `${poolName}-prev-service.yaml`,
+          renderService({ poolName, buildId: previousBuildId, releaseName }),
+        ],
+        [
+          `${poolName}-prev-hpa.yaml`,
+          renderHPA({ poolName, buildId: previousBuildId, releaseName }),
+        ],
+      ];
+      for (const [fileName, content] of retainedFiles) {
+        const target = path.join(chartTemplatesDir, fileName);
+        if (dryRun) {
+          console.log(`    [dry-run] would write ${target}`);
+        } else {
+          writeFileSync(target, content);
+        }
+      }
     }
   }
 
@@ -614,7 +764,9 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
             if (errorLines.length > 0) {
               console.error(`  Errors:`);
               for (const err of errorLines.slice(0, 5)) {
-                console.error(`    ${err.trim().slice(0, 150)}`);
+                // L14: pod log lines are cluster-sourced — strip terminal control
+                // characters before printing.
+                console.error(`    ${sanitizeForTerminal(err.trim()).slice(0, 150)}`);
               }
             } else {
               console.error(

--- a/src/cli/describe.ts
+++ b/src/cli/describe.ts
@@ -4,8 +4,6 @@ import path from "node:path";
 import boxen from "boxen";
 import { execCapture } from "./exec.js";
 
-const W = 62; // inner content width for boxen
-
 export async function runDescribe(options: {
   projectDir: string;
   releaseName: string;

--- a/src/cli/destroy.ts
+++ b/src/cli/destroy.ts
@@ -1,12 +1,16 @@
 // src/cli/destroy.ts
 import path from "node:path";
 import { existsSync, readFileSync } from "node:fs";
+import readline from "node:readline";
 import { execCapture } from "./exec.js";
+import { deployExtRoleId } from "./init.js";
 
 export interface DestroyOptions {
   projectDir: string;
   releaseName: string;
   dryRun?: boolean;
+  /** Skip the interactive confirmation prompt (required for non-interactive use). */
+  yes?: boolean;
 }
 
 // Distinguish "the resource is already gone" (idempotent success) from genuine
@@ -97,21 +101,98 @@ export function buildReleaseScopedGcpResources(
         "--quiet",
       ],
     },
+    // The least-privilege custom role bound to the deploy SA (created by init) is
+    // release-scoped — remove it with the rest of the release teardown.
+    {
+      desc: `custom IAM role "${deployExtRoleId(releaseName)}"`,
+      args: [
+        "iam",
+        "roles",
+        "delete",
+        deployExtRoleId(releaseName),
+        `--project=${projectId}`,
+        "--quiet",
+      ],
+    },
   ];
 }
 
-export async function runDestroy(options: DestroyOptions): Promise<void> {
-  const { projectDir, releaseName, dryRun } = options;
+function promptConfirmation(question: string): Promise<string> {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise((resolve) => {
+    rl.question(question, (answer) => {
+      rl.close();
+      resolve(answer);
+    });
+  });
+}
 
-  console.log(`\nDestroying deployment: ${releaseName}\n`);
+export async function runDestroy(options: DestroyOptions): Promise<void> {
+  const { projectDir, releaseName, dryRun, yes } = options;
+
+  const infraPath = path.join(projectDir, ".k8s-adapter", "infrastructure.json");
+  const infra = existsSync(infraPath) ? JSON.parse(readFileSync(infraPath, "utf-8")) : undefined;
+  const projectId: string | undefined = infra?.projectId;
+  const region: string | undefined = infra?.region;
+
+  // L12: destroying is irreversible — gate it. --yes (or -y) skips the prompt and is
+  // REQUIRED non-interactively; --dry-run never deletes and skips the gate entirely.
+  if (!dryRun) {
+    console.log(`\n  *** DESTRUCTIVE: tearing down release "${releaseName}" ***`);
+    if (projectId) {
+      console.log(`  *** Target GCP project: ${projectId} ***\n`);
+      // Best-effort sanity check: warn loudly when the operator's active gcloud project
+      // differs from the project this release was deployed to. gcloud failures are
+      // tolerated (the deletes below all pass --project explicitly anyway).
+      const cfg = await execCapture("gcloud", ["config", "get-value", "project", "--quiet"]).catch(
+        () => null,
+      );
+      const activeProject = cfg && cfg.exitCode === 0 ? cfg.stdout.trim() : "";
+      if (activeProject && activeProject !== projectId) {
+        console.warn(
+          `\n  !!! WARNING: your active gcloud project is "${activeProject}", but this ` +
+            `release was deployed to "${projectId}".\n` +
+            `      Deletion commands target "${projectId}" explicitly. Abort now if this ` +
+            `is unexpected.\n`,
+        );
+      }
+    } else {
+      console.log("");
+    }
+    if (!yes) {
+      if (!process.stdin.isTTY) {
+        throw new Error(
+          "Refusing to destroy without confirmation: stdin is not interactive. " +
+            "Re-run with --yes (or -y) to confirm destruction, or use --dry-run to preview " +
+            "the planned deletions.",
+        );
+      }
+      const answer = await promptConfirmation(
+        `  Type the release name ("${releaseName}") to confirm destruction: `,
+      );
+      if (answer.trim() !== releaseName) {
+        throw new Error(
+          `Destroy aborted: confirmation did not match "${releaseName}". No resources were deleted.`,
+        );
+      }
+      console.log("");
+    }
+  } else {
+    console.log(
+      `\n[dry-run] Destroy plan for release "${releaseName}"` +
+        `${projectId ? ` in GCP project "${projectId}"` : ""} — nothing will be deleted:\n`,
+    );
+  }
 
   // Resources that failed for a reason OTHER than "already gone". These make the
   // destroy incomplete and cause a non-zero exit + preserved local state.
   const failures: string[] = [];
 
   // 1. Helm uninstall
-  console.log("  → Running helm uninstall...");
-  if (!dryRun) {
+  if (dryRun) {
+    console.log(`  [dry-run] helm uninstall ${releaseName}`);
+  } else {
+    console.log("  → Running helm uninstall...");
     const res = await execCapture("helm", ["uninstall", releaseName]);
     if (res.exitCode !== 0) {
       if (isAlreadyGoneError(res.stderr)) {
@@ -123,26 +204,18 @@ export async function runDestroy(options: DestroyOptions): Promise<void> {
         failures.push(`helm release "${releaseName}"`);
       }
     }
-  } else {
-    console.log(`    [dry-run] helm uninstall ${releaseName}`);
   }
 
   // 2. Clean up GCP resources from infrastructure.json
-  const infraPath = path.join(projectDir, ".k8s-adapter", "infrastructure.json");
-  if (existsSync(infraPath)) {
-    const infra = JSON.parse(readFileSync(infraPath, "utf-8"));
-
+  if (infra) {
     // Delete GCS bucket
     if (infra.gcsBucket) {
-      console.log(`  → Deleting GCS bucket: ${infra.gcsBucket}`);
-      if (!dryRun) {
-        const res = await execCapture("gcloud", [
-          "storage",
-          "rm",
-          "-r",
-          `gs://${infra.gcsBucket}`,
-          "--quiet",
-        ]);
+      const bucketArgs = ["storage", "rm", "-r", `gs://${infra.gcsBucket}`, "--quiet"];
+      if (dryRun) {
+        console.log(`  [dry-run] gcloud ${bucketArgs.join(" ")}`);
+      } else {
+        console.log(`  → Deleting GCS bucket: ${infra.gcsBucket}`);
+        const res = await execCapture("gcloud", bucketArgs);
         if (res.exitCode !== 0) {
           if (isAlreadyGoneError(res.stderr)) {
             console.log("    (bucket not found or already deleted)");
@@ -157,26 +230,31 @@ export async function runDestroy(options: DestroyOptions): Promise<void> {
     }
 
     // Delete service account
-    console.log(`  → Deleting deploy service account`);
-    if (!dryRun) {
-      const saEmail = `${releaseName}-deploy@${infra.projectId}.iam.gserviceaccount.com`;
-      const res = await execCapture("gcloud", [
+    if (projectId) {
+      const saEmail = `${releaseName}-deploy@${projectId}.iam.gserviceaccount.com`;
+      const saArgs = [
         "iam",
         "service-accounts",
         "delete",
         saEmail,
         "--project",
-        infra.projectId,
+        projectId,
         "--quiet",
-      ]);
-      if (res.exitCode !== 0) {
-        if (isAlreadyGoneError(res.stderr)) {
-          console.log("    (service account not found or already deleted)");
-        } else {
-          console.warn(
-            `    WARNING: service account deletion failed: ${res.stderr.trim() || `exit ${res.exitCode}`}`,
-          );
-          failures.push(`service account "${saEmail}"`);
+      ];
+      if (dryRun) {
+        console.log(`  [dry-run] gcloud ${saArgs.join(" ")}`);
+      } else {
+        console.log(`  → Deleting deploy service account`);
+        const res = await execCapture("gcloud", saArgs);
+        if (res.exitCode !== 0) {
+          if (isAlreadyGoneError(res.stderr)) {
+            console.log("    (service account not found or already deleted)");
+          } else {
+            console.warn(
+              `    WARNING: service account deletion failed: ${res.stderr.trim() || `exit ${res.exitCode}`}`,
+            );
+            failures.push(`service account "${saEmail}"`);
+          }
         }
       }
     }
@@ -185,7 +263,6 @@ export async function runDestroy(options: DestroyOptions): Promise<void> {
     // extension references the backend, which references the health check). helm uninstall
     // removed the Gateway/Service, but these are provisioned outside the chart and would
     // otherwise be left billing/dangling — the exact "destroy silently leaves infra" gap.
-    const projectId: string | undefined = infra.projectId;
     if (projectId) {
       // The managed cache may live in a different region than the cluster when
       // cache.memorystore.region overrides it — deploy persists that as infra.cacheRegion. Use it
@@ -196,8 +273,10 @@ export async function runDestroy(options: DestroyOptions): Promise<void> {
         infra?.cacheRegion ?? infra?.region,
       );
       for (const { desc, args } of extResources) {
-        console.log(`  → Deleting ${desc}`);
-        if (!dryRun) {
+        if (dryRun) {
+          console.log(`  [dry-run] gcloud ${args.join(" ")}`);
+        } else {
+          console.log(`  → Deleting ${desc}`);
           const res = await execCapture("gcloud", args);
           if (res.exitCode !== 0) {
             if (isAlreadyGoneError(res.stderr)) {
@@ -212,6 +291,14 @@ export async function runDestroy(options: DestroyOptions): Promise<void> {
         }
       }
     }
+  }
+
+  if (dryRun) {
+    console.log(
+      `\n[dry-run] No resources were deleted. Re-run without --dry-run (and with --yes ` +
+        `if non-interactive) to execute the plan above.\n`,
+    );
+    return;
   }
 
   // 3. Report incomplete destroy before touching local state. If real (non-"already
@@ -234,16 +321,9 @@ export async function runDestroy(options: DestroyOptions): Promise<void> {
   // releases and expensive/slow to recreate, so nuking them from a per-release `destroy` is
   // unsafe. Surface them with exact commands instead of silently leaving them AND deleting
   // the state needed to find them (the previous behavior).
-  const infra = existsSync(path.join(projectDir, ".k8s-adapter", "infrastructure.json"))
-    ? JSON.parse(
-        readFileSync(path.join(projectDir, ".k8s-adapter", "infrastructure.json"), "utf-8"),
-      )
-    : {};
-  const projectId: string | undefined = infra.projectId;
-  const region: string | undefined = infra.region;
   console.log("\n✓ Removed: Helm release, GCS bucket, deploy service account, and the");
   console.log("  release-scoped ext_proc resources (traffic extension, routing backend,");
-  console.log("  health check, static IP).\n");
+  console.log("  health check, static IP, custom IAM role).\n");
   if (projectId) {
     console.log("  Left in place (shared / expensive — remove manually if truly unused):");
     console.log(

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -3,6 +3,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { resolve4 } from "node:dns/promises";
 import path from "node:path";
 import { execCapture } from "./exec.js";
+import { sanitizeForTerminal } from "./terminal.js";
 
 interface CheckResult {
   name: string;
@@ -240,7 +241,9 @@ export async function runDoctor(options: {
         results.push({
           name: "Gateway",
           status: "fail",
-          message: reasonResult.stdout.trim() || `Status: ${accepted || "Unknown"}`,
+          // L14: condition messages are cluster-sourced — strip terminal control chars.
+          message:
+            sanitizeForTerminal(reasonResult.stdout.trim()) || `Status: ${accepted || "Unknown"}`,
           fix: `kubectl describe gateway ${releaseName}-gateway`,
         });
       }
@@ -530,7 +533,8 @@ export async function runDoctor(options: {
                 l.includes("Cannot find module"),
             );
           if (errorLines.length > 0) {
-            const firstError = errorLines[0]!.trim().slice(0, 120);
+            // L14: pod log lines are cluster-sourced — strip terminal control chars.
+            const firstError = sanitizeForTerminal(errorLines[0]!.trim()).slice(0, 120);
             results.push({
               name: "Pod logs",
               status: "fail",
@@ -646,17 +650,19 @@ export async function runDoctor(options: {
         for (const line of negResult.stdout.trim().split("\n")) {
           if (!line.includes(releaseName)) continue;
           const healthy = line.includes("=True");
+          // L14: NEG condition lines are cluster-sourced — strip terminal control chars.
+          const cleanLine = sanitizeForTerminal(line);
           results.push(
             healthy
               ? {
                   name: "Backend NEG",
                   status: "pass",
-                  message: line.split(":")[0]?.trim() ?? "Ready",
+                  message: cleanLine.split(":")[0]?.trim() ?? "Ready",
                 }
               : {
                   name: "Backend NEG",
                   status: "warn",
-                  message: line.trim(),
+                  message: cleanLine.trim(),
                   fix: "NEG not yet ready — backend health check may be pending",
                 },
           );

--- a/src/cli/exec.ts
+++ b/src/cli/exec.ts
@@ -1,5 +1,7 @@
 // src/cli/exec.ts
 import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import path from "node:path";
 
 export interface ExecResult {
   exitCode: number;
@@ -11,6 +13,30 @@ export interface ExecCaptureResult {
   stderr: string;
 }
 
+// M2: never spawn through cmd.exe. The old blanket `shell: process.platform === "win32"`
+// routed every argument through `cmd.exe /s /c`, so a metacharacter in any arg (build id,
+// git branch, pool name) was a command-injection sink on Windows. Bare tool names
+// (gcloud, npx, helm) are usually `.cmd` shims on Windows, so resolve the real
+// executable on PATH — trying `<cmd>.cmd`, `<cmd>.exe`, `<cmd>.bat`, then `<cmd>` —
+// and spawn it directly with `shell: false`. POSIX keeps the bare command.
+export function resolveWindowsCommand(command: string, pathEnv?: string): string {
+  const pathValue = pathEnv ?? process.env.PATH ?? "";
+  for (const dir of pathValue.split(";")) {
+    if (!dir) continue;
+    for (const ext of [".cmd", ".exe", ".bat", ""]) {
+      const candidate = path.join(dir, `${command}${ext}`);
+      if (existsSync(candidate)) return candidate;
+    }
+  }
+  // Not found on PATH: return the bare command and let spawn fail with ENOENT,
+  // matching the pre-existing behavior for a missing tool.
+  return command;
+}
+
+function resolveSpawnCommand(command: string): string {
+  return process.platform === "win32" ? resolveWindowsCommand(command) : command;
+}
+
 // Run a command with inherited stdio (output streams to terminal)
 export function exec(
   command: string,
@@ -18,10 +44,10 @@ export function exec(
   options?: { cwd?: string },
 ): Promise<ExecResult> {
   return new Promise((resolve, reject) => {
-    const child = spawn(command, args, {
+    const child = spawn(resolveSpawnCommand(command), args, {
       stdio: "inherit",
       cwd: options?.cwd,
-      shell: process.platform === "win32", // Support Windows
+      shell: false, // M2: args must never pass through a shell (see resolveWindowsCommand)
     });
     child.on("error", reject);
     child.on("close", (code) => resolve({ exitCode: code ?? 1 }));
@@ -35,10 +61,10 @@ export function execCapture(
   options?: { cwd?: string },
 ): Promise<ExecCaptureResult> {
   return new Promise((resolve, reject) => {
-    const child = spawn(command, args, {
+    const child = spawn(resolveSpawnCommand(command), args, {
       stdio: ["inherit", "pipe", "pipe"],
       cwd: options?.cwd,
-      shell: process.platform === "win32",
+      shell: false, // M2: args must never pass through a shell (see resolveWindowsCommand)
     });
 
     let stdout = "";

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -9,6 +9,7 @@ import { runDescribe } from "./describe.js";
 import { runRollback } from "./rollback.js";
 import { runTail } from "./tail.js";
 import { runEmulate } from "./emulate.js";
+import { assertSafeReleaseName } from "../emit/templates/utils.js";
 
 function parseArgs(argv: string[]): { command: string; flags: Record<string, string | boolean> } {
   const args = argv.slice(2);
@@ -26,6 +27,9 @@ function parseArgs(argv: string[]): { command: string; flags: Record<string, str
       } else {
         flags[key] = true;
       }
+    } else if (arg.startsWith("-") && arg.length > 1) {
+      // Short flags (e.g. -y) are always booleans.
+      flags[arg.slice(1)] = true;
     }
   }
 
@@ -57,6 +61,9 @@ Options:
   --release-name <name>    Helm release name (default: current directory name)
   --skip-build             Skip next build (use existing artifacts)
   --skip-push              Skip docker build + push
+  --allow-no-network-policy  Deploy even if the cluster pod CIDR can't be discovered
+                             (NetworkPolicies skipped — the routing service stays
+                             reachable from in-cluster pods; not recommended)
   --dry-run                Show what would be done without executing
   `);
 }
@@ -74,10 +81,18 @@ async function main(): Promise<void> {
   //      `e2e/` dir that deployed release "test-app") derives the wrong cluster name
   //      (`e2e-cluster` vs `test-app-cluster`) and doctor fails to connect.
   //   3. the sanitized directory name (default for a fresh, un-inited project)
-  const defaultReleaseName = path
-    .basename(projectDir)
-    .toLowerCase()
-    .replace(/[^a-z0-9]/g, "-");
+  // The directory-name default must degrade gracefully: truncate to the 40-char
+  // release-name limit and strip trailing hyphens so a long directory name never
+  // throws (only the explicit --release-name flag and the persisted
+  // infrastructure.json value hard-fail validation below). If nothing usable
+  // survives (e.g. a directory named "!!!"), fall back to a constant.
+  const defaultReleaseName =
+    path
+      .basename(projectDir)
+      .toLowerCase()
+      .replace(/[^a-z0-9]/g, "-")
+      .slice(0, 40)
+      .replace(/-+$/, "") || "app";
   let persistedReleaseName: string | undefined;
   const infraPath = path.join(projectDir, ".k8s-adapter", "infrastructure.json");
   if (existsSync(infraPath)) {
@@ -92,6 +107,10 @@ async function main(): Promise<void> {
   }
   const releaseName =
     (flags["release-name"] as string) ?? persistedReleaseName ?? defaultReleaseName;
+  // M3: the release name is prefixed into GKE cluster names, K8s resources, IAM role
+  // ids, and helm invocations — reject anything outside the safe charset at the CLI
+  // boundary (main()'s catch prints the error and exits 1).
+  assertSafeReleaseName(releaseName);
   const dryRun = flags["dry-run"] === true;
 
   switch (command) {
@@ -141,6 +160,7 @@ async function main(): Promise<void> {
         releaseName,
         skipBuild: flags["skip-build"] === true,
         skipPush: flags["skip-push"] === true,
+        allowNoNetworkPolicy: flags["allow-no-network-policy"] === true,
         dryRun,
       });
       break;
@@ -177,7 +197,12 @@ async function main(): Promise<void> {
     }
 
     case "destroy": {
-      await runDestroy({ projectDir, releaseName, dryRun });
+      await runDestroy({
+        projectDir,
+        releaseName,
+        dryRun,
+        yes: flags["yes"] === true || flags["y"] === true,
+      });
       break;
     }
 

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -1,9 +1,16 @@
 // src/cli/init.ts
-import { existsSync, writeFileSync, mkdirSync } from "node:fs";
+import { existsSync, writeFileSync, appendFileSync, readFileSync, mkdirSync } from "node:fs";
 import path from "node:path";
 import { execCapture } from "./exec.js";
 import { generateAdapterConfig, generateInfrastructureJson } from "./scaffold.js";
 import { gkeVersionAtLeast, MIN_GKE_VERSION_FOR_CDN } from "./gke-version.js";
+import {
+  assertSafeBucketName,
+  assertSafeHostname,
+  assertSafeImageRegistry,
+  assertSafeProjectId,
+  assertSafeRegion,
+} from "../emit/templates/utils.js";
 
 export interface InitOptions {
   projectId: string;
@@ -16,6 +23,11 @@ export interface InitOptions {
   dryRun?: boolean;
   /** Backoff between IAM-binding retries (ms). Defaults to 5000; tests override to run fast. */
   iamRetryDelayMs?: number;
+  /**
+   * Cluster mode. Defaults to Autopilot (always enforces NetworkPolicy). Standard
+   * clusters are created with --enable-network-policy, which Autopilot rejects.
+   */
+  autopilot?: boolean;
 }
 
 export interface GcloudCommand {
@@ -24,14 +36,36 @@ export interface GcloudCommand {
   args: string[];
 }
 
+// M9: least-privilege stand-in for the project-level roles/networkservices.admin and
+// roles/compute.loadBalancerAdmin grants. Covers exactly the gcloud calls made by the
+// traffic-extension update Job (src/emit/templates/route-ext-update-job.ts).
+export const DEPLOY_EXT_ROLE_PERMISSIONS = [
+  "compute.addresses.get",
+  "compute.forwardingRules.list",
+  "compute.networkEndpointGroups.list",
+  "compute.backendServices.get",
+  "compute.backendServices.update",
+  "networkservices.lbTrafficExtensions.create",
+  "networkservices.lbTrafficExtensions.update",
+  "networkservices.lbTrafficExtensions.get",
+] as const;
+
+// GCP custom role IDs forbid hyphens (^[a-zA-Z0-9_]{3,64}$), so derive the id from the
+// release name with `-` → `_`. The 18-char prefix + 40-char release cap fits the 64-char
+// limit; slice defensively anyway.
+export function deployExtRoleId(releaseName: string): string {
+  return `nextjs_deploy_ext_${releaseName.replace(/-/g, "_")}`.slice(0, 64);
+}
+
 export function buildInitGcloudCommands(options: {
   projectId: string;
   region: string;
   bucket: string;
   releaseName: string;
   hosts?: string[];
+  autopilot?: boolean;
 }): GcloudCommand[] {
-  const { projectId, region, bucket, releaseName, hosts = [] } = options;
+  const { projectId, region, bucket, releaseName, hosts = [], autopilot = true } = options;
   const commands: GcloudCommand[] = [];
 
   // 0. Enable required APIs
@@ -52,22 +86,42 @@ export function buildInitGcloudCommands(options: {
     ],
   });
 
-  // 0.1 Create GKE Autopilot cluster
-  commands.push({
-    description: "Create GKE Autopilot cluster",
-    command: "gcloud",
-    args: [
-      "container",
-      "clusters",
-      "create-auto",
-      `${releaseName}-cluster`,
-      "--location",
-      region,
-      "--project",
-      projectId,
-      "--quiet",
-    ],
-  });
+  // 0.1 Create the GKE cluster. Autopilot always enforces NetworkPolicy and REJECTS
+  // --enable-network-policy, so only pass it for Standard clusters.
+  if (autopilot) {
+    commands.push({
+      description: "Create GKE Autopilot cluster",
+      command: "gcloud",
+      args: [
+        "container",
+        "clusters",
+        "create-auto",
+        `${releaseName}-cluster`,
+        "--location",
+        region,
+        "--project",
+        projectId,
+        "--quiet",
+      ],
+    });
+  } else {
+    commands.push({
+      description: "Create GKE Standard cluster (NetworkPolicy enforced)",
+      command: "gcloud",
+      args: [
+        "container",
+        "clusters",
+        "create",
+        `${releaseName}-cluster`,
+        "--location",
+        region,
+        "--project",
+        projectId,
+        "--enable-network-policy",
+        "--quiet",
+      ],
+    });
+  }
 
   // 0.2 Reserve Global Static IP
   commands.push({
@@ -157,18 +211,24 @@ export function buildInitGcloudCommands(options: {
     ],
   });
 
-  // 4. Grant Artifact Registry writer (for pushing container images)
+  // 4. Grant Artifact Registry writer on the repository only (M9: least privilege —
+  // pushing images must not require project-wide writer).
   commands.push({
-    description: "Grant Artifact Registry writer for container images",
+    description: "Grant Artifact Registry writer on nextjs repository",
     command: "gcloud",
     args: [
-      "projects",
+      "artifacts",
+      "repositories",
       "add-iam-policy-binding",
-      projectId,
+      "nextjs",
+      "--location",
+      region,
       "--member",
       `serviceAccount:${releaseName}-deploy@${projectId}.iam.gserviceaccount.com`,
       "--role",
       "roles/artifactregistry.writer",
+      "--project",
+      projectId,
       "--condition=None",
       "--quiet",
     ],
@@ -197,11 +257,12 @@ export function buildInitGcloudCommands(options: {
   });
 
   // --- Deploy Service Account (Workload Identity for Helm hook Jobs) ---
-  // The route-ext update Job needs:
-  // - networkservices.admin to import LbRouteExtension
-  // - compute.viewer to list forwarding rules (for discovery)
+  // M9: the route-ext update Job gets a release-scoped CUSTOM role (created/updated
+  // imperatively in runInit before these commands run) bound at project level, instead
+  // of the broad networkservices.admin + compute.loadBalancerAdmin roles it used to
+  // receive. compute.viewer remains for generic read-only diagnostics.
   commands.push({
-    description: "Grant deploy SA networkservices.admin role",
+    description: "Grant deploy SA release-scoped traffic-extension role",
     command: "gcloud",
     args: [
       "projects",
@@ -210,7 +271,7 @@ export function buildInitGcloudCommands(options: {
       "--member",
       `serviceAccount:${releaseName}-deploy@${projectId}.iam.gserviceaccount.com`,
       "--role",
-      "roles/networkservices.admin",
+      `projects/${projectId}/roles/${deployExtRoleId(releaseName)}`,
       "--condition=None",
       "--quiet",
     ],
@@ -227,25 +288,6 @@ export function buildInitGcloudCommands(options: {
       `serviceAccount:${releaseName}-deploy@${projectId}.iam.gserviceaccount.com`,
       "--role",
       "roles/compute.viewer",
-      "--condition=None",
-      "--quiet",
-    ],
-  });
-
-  // The traffic-ext Job also attaches the routing-service NEG to the ext_proc backend
-  // service (compute.backendServices.update + networkEndpointGroups.use) — beyond the
-  // read-only compute.viewer above.
-  commands.push({
-    description: "Grant deploy SA compute.loadBalancerAdmin (attach NEG to ext_proc backend)",
-    command: "gcloud",
-    args: [
-      "projects",
-      "add-iam-policy-binding",
-      projectId,
-      "--member",
-      `serviceAccount:${releaseName}-deploy@${projectId}.iam.gserviceaccount.com`,
-      "--role",
-      "roles/compute.loadBalancerAdmin",
       "--condition=None",
       "--quiet",
     ],
@@ -485,9 +527,65 @@ export async function runInit(options: InitOptions): Promise<void> {
     projectDir,
     dryRun,
     iamRetryDelayMs = 5000,
+    autopilot = true,
   } = options;
 
+  // Validate every operator-supplied value BEFORE it reaches a gcloud arg array or the
+  // scaffolded adapter.config.mjs — a `'` in a host/bucket name would otherwise be raw
+  // JS injection into the generated config file.
+  assertSafeProjectId(projectId);
+  assertSafeRegion(region);
+  assertSafeBucketName(bucket);
+  assertSafeImageRegistry(registry);
+  for (const host of hosts) assertSafeHostname(host);
+
   console.log(`\nInitializing @next-community/adapter-k8s for project: ${projectId}\n`);
+
+  // 0. Ensure the least-privilege custom IAM role for the traffic-extension Job exists
+  // BEFORE the command loop binds it. Fail loudly — never fall back to broad admin
+  // roles. Idempotent: create, and on "already exists" update with the same set.
+  const extRoleId = deployExtRoleId(releaseName);
+  const extRoleTitle = `Next.js deploy traffic-extension (${releaseName})`;
+  const extRoleArgs = [
+    "--project",
+    projectId,
+    "--title",
+    extRoleTitle,
+    "--permissions",
+    DEPLOY_EXT_ROLE_PERMISSIONS.join(","),
+    "--quiet",
+  ];
+  console.log(`  → Ensuring custom IAM role ${extRoleId} (traffic-extension Job)`);
+  if (dryRun) {
+    console.log(`    [dry-run] gcloud iam roles create ${extRoleId} ${extRoleArgs.join(" ")}`);
+    console.log(
+      `    [dry-run]   (on "already exists": gcloud iam roles update ${extRoleId} with the same permissions)`,
+    );
+  } else {
+    const created = await execCapture("gcloud", [
+      "iam",
+      "roles",
+      "create",
+      extRoleId,
+      ...extRoleArgs,
+    ]);
+    if (created.exitCode !== 0) {
+      if (/already exists|ALREADY_EXISTS/.test(created.stderr)) {
+        const updated = await execCapture("gcloud", [
+          "iam",
+          "roles",
+          "update",
+          extRoleId,
+          ...extRoleArgs,
+        ]);
+        if (updated.exitCode !== 0) {
+          throw new Error(`Updating custom IAM role ${extRoleId} failed:\n${updated.stderr}`);
+        }
+      } else {
+        throw new Error(`Creating custom IAM role ${extRoleId} failed:\n${created.stderr}`);
+      }
+    }
+  }
 
   // 1. Generate gcloud commands
   const commands = buildInitGcloudCommands({
@@ -496,6 +594,7 @@ export async function runInit(options: InitOptions): Promise<void> {
     bucket,
     releaseName,
     hosts,
+    autopilot,
   });
 
   // 2. Run gcloud commands (idempotent — safe to re-run)
@@ -691,6 +790,28 @@ export async function runInit(options: InitOptions): Promise<void> {
         );
       }
     }
+  }
+
+  // 6. M4b: .k8s-adapter/ holds generated secrets (cache connection Secret, deploy
+  // state) — make sure it can never be committed.
+  if (!dryRun) {
+    const gitignorePath = path.join(projectDir, ".gitignore");
+    const ignoreLine = ".k8s-adapter/";
+    const existing = existsSync(gitignorePath) ? readFileSync(gitignorePath, "utf-8") : null;
+    const alreadyIgnored =
+      existing !== null && existing.split("\n").some((l) => l.trim() === ignoreLine);
+    if (!alreadyIgnored) {
+      if (existing === null) {
+        writeFileSync(gitignorePath, `${ignoreLine}\n`);
+      } else {
+        const prefix = existing.length > 0 && !existing.endsWith("\n") ? "\n" : "";
+        appendFileSync(gitignorePath, `${prefix}${ignoreLine}\n`);
+      }
+      console.log(`  → Added "${ignoreLine}" to .gitignore`);
+    }
+    console.log(
+      "  ℹ .k8s-adapter/ contains generated secrets and state — it must not be committed.",
+    );
   }
 
   console.log("\n✓ Init complete.");

--- a/src/cli/provision-cache.ts
+++ b/src/cli/provision-cache.ts
@@ -15,6 +15,12 @@ export interface ProvisionCacheOptions {
   sizeGb?: number;
   /** Service tier from config ("BASIC" | "STANDARD_HA"). Defaults to basic. */
   tier?: string;
+  /**
+   * Enable Redis AUTH + in-transit encryption (SERVER_AUTHENTICATION). The endpoint then
+   * requires `rediss://` + the instance AUTH string + server CA, returned on the result.
+   * Creation-only on Memorystore — an existing non-AUTH instance is rejected with guidance.
+   */
+  auth?: boolean;
   dryRun?: boolean;
   log?: (msg: string) => void;
 }
@@ -22,6 +28,10 @@ export interface ProvisionCacheOptions {
 export interface CacheEndpoint {
   host: string;
   port: number;
+  /** Instance AUTH string — present only when `auth: true`. */
+  authString?: string;
+  /** PEM of the instance's server CA (in-transit encryption) — present only when `auth: true`. */
+  caCert?: string;
 }
 
 /** Deterministic instance name, so provisioning is idempotent across deploys. */
@@ -77,9 +87,98 @@ async function waitForReady(
   throw new Error(`Memorystore ${name} did not reach READY in time`);
 }
 
+// Full instance details, needed when AUTH is requested: AUTH + in-transit encryption are
+// creation-only on Memorystore, so an existing instance must already have them enabled.
+async function describeInstanceAuth(
+  name: string,
+  region: string,
+  projectId: string,
+): Promise<{ authEnabled: boolean; transitEncryption: boolean } | null> {
+  const res = await execCapture("gcloud", [
+    "redis",
+    "instances",
+    "describe",
+    name,
+    "--region",
+    region,
+    "--project",
+    projectId,
+    "--format=json(authEnabled,transitEncryptionMode)",
+  ]);
+  if (res.exitCode !== 0 || !res.stdout.trim()) return null;
+  try {
+    const parsed = JSON.parse(res.stdout) as {
+      authEnabled?: boolean;
+      transitEncryptionMode?: string;
+    };
+    return {
+      authEnabled: parsed.authEnabled === true,
+      transitEncryption: parsed.transitEncryptionMode === "SERVER_AUTHENTICATION",
+    };
+  } catch {
+    return null;
+  }
+}
+
+// Fetch the instance AUTH string. Requires redis.instances.getAuthString, which the
+// deployer (who created the instance) has.
+async function fetchAuthString(name: string, region: string, projectId: string): Promise<string> {
+  const res = await execCapture("gcloud", [
+    "redis",
+    "instances",
+    "get-auth-string",
+    name,
+    "--region",
+    region,
+    "--project",
+    projectId,
+    "--format=value(authString)",
+  ]);
+  const auth = res.stdout.trim();
+  if (res.exitCode !== 0 || !auth) {
+    throw new Error(
+      `Failed to read the AUTH string for Memorystore instance ${name}: ${res.stderr.trim()}`,
+    );
+  }
+  return auth;
+}
+
+// Fetch the PEM of the instance's server CA for in-transit encryption. The pool pins TLS to
+// this CA — Memorystore certs are not publicly rooted, so default trust stores reject them.
+async function fetchServerCaCert(name: string, region: string, projectId: string): Promise<string> {
+  const res = await execCapture("gcloud", [
+    "redis",
+    "instances",
+    "describe",
+    name,
+    "--region",
+    region,
+    "--project",
+    projectId,
+    "--format=json(serverCaCerts)",
+  ]);
+  if (res.exitCode !== 0) {
+    throw new Error(
+      `Failed to read the server CA for Memorystore instance ${name}: ${res.stderr.trim()}`,
+    );
+  }
+  try {
+    const parsed = JSON.parse(res.stdout) as { serverCaCerts?: { cert?: string }[] };
+    const cert = parsed.serverCaCerts?.find((c) => typeof c.cert === "string" && c.cert)?.cert;
+    if (!cert) throw new Error("no cert in response");
+    return cert;
+  } catch (err) {
+    throw new Error(
+      `Failed to parse the server CA for Memorystore instance ${name}: ${(err as Error).message}`,
+    );
+  }
+}
+
 /**
  * Idempotently provision the managed cache instance and return its private endpoint. Reuses an
  * existing instance (keyed by release name), waiting for READY if a prior run left it mid-create.
+ * With `auth: true`, the instance is created with Redis AUTH + in-transit encryption and the
+ * result carries the AUTH string + server CA for the pods' `rediss://` connection.
  */
 export async function provisionMemorystore(opts: ProvisionCacheOptions): Promise<CacheEndpoint> {
   const {
@@ -89,13 +188,17 @@ export async function provisionMemorystore(opts: ProvisionCacheOptions): Promise
     network = "default",
     sizeGb = 1,
     tier,
+    auth = false,
     dryRun,
     log = console.log,
   } = opts;
   const name = cacheInstanceName(releaseName);
 
   if (dryRun) {
-    log(`    [dry-run] provision Memorystore ${name} (${sizeGb}GB, ${region}, network ${network})`);
+    log(
+      `    [dry-run] provision Memorystore ${name} (${sizeGb}GB, ${region}, network ${network}` +
+        `${auth ? ", AUTH + in-transit encryption" : ""})`,
+    );
     return { host: "0.0.0.0", port: 6379 };
   }
 
@@ -109,19 +212,44 @@ export async function provisionMemorystore(opts: ProvisionCacheOptions): Promise
     "--quiet",
   ]);
 
+  // Attach the AUTH string + CA to a ready endpoint when AUTH mode is on.
+  const withAuth = async (endpoint: CacheEndpoint): Promise<CacheEndpoint> => {
+    if (!auth) return endpoint;
+    const [authString, caCert] = await Promise.all([
+      fetchAuthString(name, region, projectId),
+      fetchServerCaCert(name, region, projectId),
+    ]);
+    return { ...endpoint, authString, caCert };
+  };
+
   const existing = await describeInstance(name, region, projectId);
   if (existing) {
+    // AUTH + in-transit encryption are creation-only: refuse to silently reuse an instance
+    // that doesn't enforce them (the pods would get a rediss:// endpoint they can't use, or
+    // worse, plaintext creds would be expected on a path the operator believes is secured).
+    if (auth) {
+      const details = await describeInstanceAuth(name, region, projectId);
+      if (details && !(details.authEnabled && details.transitEncryption)) {
+        throw new Error(
+          `Memorystore instance ${name} already exists WITHOUT AUTH / in-transit encryption, ` +
+            `but cache.memorystore.auth is enabled. AUTH can only be set at creation: either ` +
+            `delete the instance (\`adapter-k8s destroy\` removes it) and redeploy, or set ` +
+            `cache.memorystore.auth: false.`,
+        );
+      }
+    }
     if (existing.state === "READY" && existing.host) {
       log(`    Reusing Memorystore ${name} at ${existing.host}:${existing.port}`);
-      return { host: existing.host, port: existing.port };
+      return withAuth({ host: existing.host, port: existing.port });
     }
     log(`    Memorystore ${name} exists (state=${existing.state}); waiting for READY…`);
-    return waitForReady(name, region, projectId, log);
+    return withAuth(await waitForReady(name, region, projectId, log));
   }
 
   const gcpTier = (tier ?? "").toUpperCase() === "STANDARD_HA" ? "standard_ha" : "basic";
   log(
-    `    Creating Memorystore ${name} (${sizeGb}GB, tier ${gcpTier}) — this takes a few minutes…`,
+    `    Creating Memorystore ${name} (${sizeGb}GB, tier ${gcpTier}` +
+      `${auth ? ", AUTH + in-transit encryption" : ""}) — this takes a few minutes…`,
   );
   const create = await execCapture("gcloud", [
     "redis",
@@ -138,6 +266,7 @@ export async function provisionMemorystore(opts: ProvisionCacheOptions): Promise
     gcpTier,
     "--connect-mode",
     "DIRECT_PEERING",
+    ...(auth ? ["--auth-enabled", "--transit-encryption-mode", "SERVER_AUTHENTICATION"] : []),
     "--project",
     projectId,
     "--quiet",
@@ -149,7 +278,7 @@ export async function provisionMemorystore(opts: ProvisionCacheOptions): Promise
   }
   const ready = await waitForReady(name, region, projectId, log);
   log(`    Memorystore ${name} ready at ${ready.host}:${ready.port}`);
-  return ready;
+  return withAuth(ready);
 }
 
 /** A release-scoped delete command for the cache instance (for `destroy`). */

--- a/src/cli/rollback.ts
+++ b/src/cli/rollback.ts
@@ -26,6 +26,56 @@ export async function runRollback(options: {
     .replace(/[^a-z0-9]/g, "")
     .slice(0, 10);
 
+  // Pool names come from local build metadata (the same source deploy's cutover uses) —
+  // readable without touching the cluster, so the dry-run plan can be printed before any
+  // cluster interaction.
+  let poolNames: string[] = [];
+  const metaPath = path.join(projectDir, ".k8s-adapter", "output", "build-metadata.json");
+  if (existsSync(metaPath)) {
+    try {
+      const meta = JSON.parse(readFileSync(metaPath, "utf-8"));
+      if (Array.isArray(meta.pools)) {
+        poolNames = meta.pools.filter((p: unknown): p is string => typeof p === "string");
+      }
+    } catch {
+      // fall through to the empty guard
+    }
+  }
+
+  // L13: dry-run must not mutate anything — and get-credentials mutates the operator's
+  // kubeconfig, so it is skipped too. Print the planned steps and return.
+  if (dryRun) {
+    const prevNames = poolNames.map((p) =>
+      sanitizeK8sName(`${releaseName}-${p}-${previousBuildId}`),
+    );
+    const currNames = poolNames.map((p) =>
+      sanitizeK8sName(`${releaseName}-${p}-${currentBuildId}`),
+    );
+    console.log(`\n  [dry-run] Rollback plan: ${currentBuildId} → ${previousBuildId}`);
+    console.log(
+      `  [dry-run] Skipping "gcloud container clusters get-credentials" (it would mutate your kubeconfig).`,
+    );
+    if (prevNames.length > 0)
+      console.log(`  [dry-run] Would scale up previous build: ${prevNames.join(", ")}`);
+    console.log(`  [dry-run] Would wait for the previous build's rollout to complete`);
+    console.log(
+      `  [dry-run] Would patch active Service selectors to app.kubernetes.io/version=${sanitizeK8sName(previousBuildId)}`,
+    );
+    if (currNames.length > 0)
+      console.log(`  [dry-run] Would scale down current build: ${currNames.join(", ")}`);
+    console.log(
+      `  [dry-run] Would swap state: buildId=${previousBuildId}, previousBuildId=${currentBuildId}`,
+    );
+    return;
+  }
+
+  if (poolNames.length === 0) {
+    throw new Error(
+      "Could not determine pool names from .k8s-adapter/output/build-metadata.json; " +
+        "cannot safely roll back. Aborting before touching traffic.",
+    );
+  }
+
   console.log(`\nRolling back: ${currentBuildId} → ${previousBuildId}\n`);
 
   // Ensure kubectl is on the right cluster
@@ -67,29 +117,10 @@ export async function runRollback(options: {
   // Roll back EVERY pool, not just one. Single previous/current vars kept only the LAST
   // pool that matched during discovery, so a multi-pool rollback scaled up one pool's
   // previous Deployment but then switched ALL active Services to the previous build —
-  // every other pool was left at zero replicas with no endpoints. Read the pool list from
-  // build metadata (the same source deploy's cutover uses), resolve each pool's previous
-  // and current Deployment by exact name, and verify every previous pool exists BEFORE
-  // touching traffic.
-  let poolNames: string[] = [];
-  const metaPath = path.join(projectDir, ".k8s-adapter", "output", "build-metadata.json");
-  if (existsSync(metaPath)) {
-    try {
-      const meta = JSON.parse(readFileSync(metaPath, "utf-8"));
-      if (Array.isArray(meta.pools)) {
-        poolNames = meta.pools.filter((p: unknown): p is string => typeof p === "string");
-      }
-    } catch {
-      // fall through to the empty guard
-    }
-  }
-  if (poolNames.length === 0) {
-    throw new Error(
-      "Could not determine pool names from .k8s-adapter/output/build-metadata.json; " +
-        "cannot safely roll back. Aborting before touching traffic.",
-    );
-  }
-
+  // every other pool was left at zero replicas with no endpoints. The pool list was read
+  // from build metadata above (the same source deploy's cutover uses); resolve each
+  // pool's previous and current Deployment by exact name, and verify every previous pool
+  // exists BEFORE touching traffic.
   const scalingByPool = new Map<string, { min: number; max: number; targetCPU: number }>();
   const valuesPath = path.join(projectDir, ".k8s-adapter", "output", "chart", "values.yaml");
   if (existsSync(valuesPath)) {
@@ -129,16 +160,6 @@ export async function runRollback(options: {
         `${previousBuildId}). Rolling back would strand those pools with zero endpoints. ` +
         `Aborting. Only one previous build is retained after each deploy.`,
     );
-  }
-
-  if (dryRun) {
-    console.log(`  [dry-run] Would scale up: ${previousDeploys.join(", ")}`);
-    if (currentDeploys.length)
-      console.log(`  [dry-run] Would scale down: ${currentDeploys.join(", ")}`);
-    console.log(
-      `  [dry-run] Would swap state: buildId=${previousBuildId}, previousBuildId=${currentBuildId}`,
-    );
-    return;
   }
 
   // 1. Scale up every pool's previous deployment

--- a/src/cli/tail.ts
+++ b/src/cli/tail.ts
@@ -3,6 +3,7 @@ import { spawn, type ChildProcess } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { execCapture } from "./exec.js";
+import { sanitizeForTerminal } from "./terminal.js";
 
 const COLORS = [
   "\x1b[36m", // cyan
@@ -75,10 +76,13 @@ export async function runTail(options: { projectDir: string; releaseName: string
     child.stdout?.on("data", (data: Buffer) => {
       for (const line of data.toString().split("\n")) {
         if (!line) continue;
-        const isError = line.includes("Error") || line.includes("error") || line.includes("FATAL");
+        // L14: log lines are cluster-sourced — strip terminal control characters.
+        const clean = sanitizeForTerminal(line);
+        const isError =
+          clean.includes("Error") || clean.includes("error") || clean.includes("FATAL");
         const lineColor = isError ? RED : "";
         process.stdout.write(
-          `${color}${badge.padEnd(25)}${RESET} ${DIM}│${RESET} ${lineColor}${line}${isError ? RESET : ""}\n`,
+          `${color}${badge.padEnd(25)}${RESET} ${DIM}│${RESET} ${lineColor}${clean}${isError ? RESET : ""}\n`,
         );
       }
     });
@@ -86,8 +90,10 @@ export async function runTail(options: { projectDir: string; releaseName: string
     child.stderr?.on("data", (data: Buffer) => {
       for (const line of data.toString().split("\n")) {
         if (!line || line.includes("is waiting to start")) continue;
+        // L14: log lines are cluster-sourced — strip terminal control characters.
+        const clean = sanitizeForTerminal(line);
         process.stderr.write(
-          `${color}${badge.padEnd(25)}${RESET} ${DIM}│${RESET} ${RED}${line}${RESET}\n`,
+          `${color}${badge.padEnd(25)}${RESET} ${DIM}│${RESET} ${RED}${clean}${RESET}\n`,
         );
       }
     });

--- a/src/cli/terminal.ts
+++ b/src/cli/terminal.ts
@@ -1,0 +1,12 @@
+// src/cli/terminal.ts
+
+// L14: cluster-sourced strings (pod logs, condition messages, error snippets) can
+// carry terminal control sequences (ESC, CSI introducers) that rewrite the operator's
+// terminal, forge output, or hide earlier warnings. Strip C0/C1 control characters
+// before printing; keep \n and \t, which are legitimate log formatting.
+// oxlint-disable-next-line no-control-regex
+const CONTROL_CHARS_RE = /[\x00-\x08\x0B-\x1F\x7F-\x9F]/g;
+
+export function sanitizeForTerminal(s: string): string {
+  return s.replace(CONTROL_CHARS_RE, "");
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,7 @@
 // src/config.ts
 import type { K8sAdapterConfig } from "./types.js";
 import { DEFAULT_CDN_CACHE_KEY_HEADERS } from "./emit/templates/gcp-http-filter.js";
+import { assertSafeHostname } from "./emit/templates/utils.js";
 
 export function validateConfig(input: unknown): void {
   const config = input as K8sAdapterConfig;
@@ -36,8 +37,11 @@ export function validateConfig(input: unknown): void {
     if (!hostConfig.hostname) {
       throw new Error("each host in provider.gke.gateway.hosts must have a hostname");
     }
-    // Wildcards are supported via Certificate Manager with DNS authorization.
-    // No restriction needed — init provisions the DNS auth + cert automatically.
+    // The hostname is interpolated into quoted YAML scalars (gateway.ts) and helm
+    // values — a `"`+newline would break out of the scalar and inject chart YAML.
+    // Wildcards ("*.example.com") are supported via Certificate Manager with DNS
+    // authorization; init provisions the DNS auth + cert automatically.
+    assertSafeHostname(hostConfig.hostname);
   }
 
   if (config.cache?.enabled) {

--- a/src/emit/dockerfiles.ts
+++ b/src/emit/dockerfiles.ts
@@ -11,11 +11,12 @@ export function generateDockerfile({
 }): string {
   return `FROM node:${nodeVersion}-slim
 WORKDIR /app
-COPY . .
+COPY --chown=node:node . .
 ENV NODE_ENV=production
 ENV NEXT_BUILD_ID=${buildId}
 ENV CONFIG_DIR=/app/config
 EXPOSE 3000
+USER node
 CMD ["node", "pool-server.cjs"]
 `;
 }
@@ -32,12 +33,13 @@ export function generatePoolDockerfile({
   // context/ is prepared by the adapter with exactly what's needed.
   return `FROM node:${nodeVersion}-slim
 WORKDIR /app
-COPY context/ .
+COPY --chown=node:node context/ .
 ENV NODE_ENV=production
 ENV POOL_NAME=${poolName}
 ENV NEXT_BUILD_ID=${buildId}
 ENV CONFIG_DIR=/app/config
 EXPOSE 3000
+USER node
 CMD ["node", "pool-server.cjs"]
 `;
 }
@@ -51,22 +53,24 @@ export function generateRoutingServiceDockerfile({
 }): string {
   // GCP ext_proc callouts reach the routing service over HTTP/2 *with TLS* (a plaintext
   // gRPC health check still passes, which is why an h2c server looks healthy but the
-  // callout silently fails). Generate a self-signed cert at build — GCP does not validate
-  // the backend certificate for callouts. server.ts serves TLS when TLS_CERT_FILE/
+  // callout silently fails). The cert is NOT baked into the image: the routing service
+  // generates a per-replica self-signed cert at container start (GCP does not validate
+  // the backend certificate for callouts) and writes it under /tmp/tls, which the pod
+  // spec backs with an emptyDir (the root filesystem is read-only). openssl is kept
+  // installed for that runtime generation. server.ts serves TLS when TLS_CERT_FILE/
   // TLS_KEY_FILE exist, and plaintext h2c otherwise (local emulate).
   return `FROM node:${nodeVersion}-slim
 WORKDIR /app
-COPY context/ .
+COPY --chown=node:node context/ .
 RUN apt-get update && apt-get install -y --no-install-recommends openssl \\
- && openssl req -x509 -newkey rsa:2048 -nodes -keyout /app/tls-key.pem -out /app/tls-cert.pem \\
-      -days 3650 -subj "/CN=routing-service" \\
  && rm -rf /var/lib/apt/lists/*
 ENV NODE_ENV=production
 ENV NEXT_BUILD_ID=${buildId}
 ENV CONFIG_DIR=/app/config
-ENV TLS_CERT_FILE=/app/tls-cert.pem
-ENV TLS_KEY_FILE=/app/tls-key.pem
+ENV TLS_CERT_FILE=/tmp/tls/tls-cert.pem
+ENV TLS_KEY_FILE=/tmp/tls/tls-key.pem
 EXPOSE 8443
+USER node
 CMD ["node", "routing-service.cjs"]
 `;
 }

--- a/src/emit/dockerignore.ts
+++ b/src/emit/dockerignore.ts
@@ -8,11 +8,11 @@
 // call @next/env loadEnvConfig at startup, which simply finds no file and falls
 // back to process.env. `**/` covers both context layouts (root-level `.env` in
 // shared-context, `context/.env` in the pool and routing-service contexts).
-// `.env.example` is re-included so committed, non-secret sample files survive.
+// `.env.example` is NOT re-included: example files can drift into real-looking
+// credentials over time, and nothing at runtime needs them inside the image.
 export function generateDockerignore(): string {
   return `# Keep .env secrets out of image layers — env is injected via Kubernetes at runtime.
 **/.env
 **/.env.*
-!**/.env.example
 `;
 }

--- a/src/emit/helm.ts
+++ b/src/emit/helm.ts
@@ -18,6 +18,18 @@ import { renderRoutingServiceHPA } from "./templates/routing-service-hpa.js";
 import { renderRouteExtUpdateJob } from "./templates/route-ext-update-job.js";
 import { renderRouteExtConfigMap } from "./templates/route-ext-configmap.js";
 import { renderDeployServiceAccount } from "./templates/deploy-service-account.js";
+import { renderNetworkPolicies } from "./templates/network-policy.js";
+
+/**
+ * Chart files that carry secret material. The write site (adapter.ts) MUST create these
+ * with mode 0600 — they hold the internal dispatch secret / Valkey AUTH and must not be
+ * group/world-readable on disk. Single source of truth lives here, next to where the
+ * files are generated.
+ */
+export const SECRET_CHART_FILES: ReadonlySet<string> = new Set([
+  "templates/internal-secret.yaml",
+  "templates/valkey-secret.yaml",
+]);
 
 export function generateHelmChart({
   pools,
@@ -132,6 +144,14 @@ export function generateHelmChart({
       cdnFilterName,
     });
   }
+
+  // NetworkPolicies for both workload tiers. Always emitted — the template is wrapped
+  // in a helm `if` on global.networkPolicy.podCidrs, so it renders nothing until the
+  // deploy CLI discovers the cluster pod CIDRs and sets the value.
+  files["templates/network-policy.yaml"] = renderNetworkPolicies({
+    releaseName,
+    poolNames: [...pools.keys()],
+  });
 
   for (const poolName of pools.keys()) {
     files[`templates/${poolName}-deployment.yaml`] = renderDeployment({

--- a/src/emit/templates/deployment.ts
+++ b/src/emit/templates/deployment.ts
@@ -45,9 +45,22 @@ ${replicas !== undefined ? `  replicas: ${replicas}\n` : ""}  selector:
         app.kubernetes.io/component: ${poolName}
         app.kubernetes.io/version: "${safeBuildId}"
     spec:
+      # The pool server never calls the Kubernetes API — don't mount a SA token.
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: pool-server
           image: "{{ .Values.global.image.registry }}/{{ (index .Values.pools "${poolName}").image.repository }}:${imageTag}"
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
           ports:
             - containerPort: 3000
           env:
@@ -62,9 +75,18 @@ ${replicas !== undefined ? `  replicas: ${replicas}\n` : ""}  selector:
             # can't reach sibling pools in any release not named that.
             - name: RELEASE_NAME
               value: "${releaseName}"
-            - name: TRUST_INTERNAL_HEADERS
-              value: "1"
 ${internalSecretEnv}${valkeyEnv}
+          volumeMounts:
+            # readOnlyRootFilesystem makes / read-only; Next still needs a writable
+            # scratch dir, so /tmp is an in-memory emptyDir.
+            - name: tmp
+              mountPath: /tmp
+            # Without the shared Valkey incremental handler wired (cache disabled, or an
+            # edge-middleware app), Next falls back to its FILESYSTEM incremental cache at
+            # .next/cache — which must exist writable or renders fail with EROFS. Per-pod
+            # and ephemeral: correct (if unshared) degradation, never durable state.
+            - name: next-cache
+              mountPath: /app/.next/cache
           readinessProbe:
             httpGet:
               path: /healthz
@@ -82,5 +104,10 @@ ${internalSecretEnv}${valkeyEnv}
             limits:
               cpu: "{{ (index .Values.pools "${poolName}").resources.limits.cpu }}"
               memory: "{{ (index .Values.pools "${poolName}").resources.limits.memory }}"
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: next-cache
+          emptyDir: {}
 `;
 }

--- a/src/emit/templates/gateway.ts
+++ b/src/emit/templates/gateway.ts
@@ -213,16 +213,53 @@ export function renderHTTPRoute({
 
   const hostnameLines = hostnames.map((h) => `    - "${h}"`).join("\n");
 
-  return `apiVersion: gateway.networking.k8s.io/v1
+  // When TLS is enabled the app route must attach ONLY to the https listener —
+  // otherwise http:// traffic is served plaintext. Plain HTTP is instead upgraded by
+  // the redirect route below (attached to the http listener). Without TLS the gateway
+  // has just the http listener, so no sectionName is needed (or valid).
+  const hasTls = hosts.some((h) => h.tls?.enabled);
+  const appParentRef = hasTls
+    ? `    - name: ${releaseName}-gateway
+      sectionName: https`
+    : `    - name: ${releaseName}-gateway`;
+
+  const appRoute = `apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: ${releaseName}-routes
 spec:
   parentRefs:
-    - name: ${releaseName}-gateway
+${appParentRef}
   hostnames:
 ${hostnameLines}
   rules:
 ${rules}
 `;
+
+  if (!hasTls) return appRoute;
+
+  // HTTP -> HTTPS redirect: a rule whose only filter is RequestRedirect short-circuits
+  // before any backendRef (GKE Gateway API supports RequestRedirect with scheme/port/
+  // statusCode), so http:// traffic gets a 302 to https:// instead of plaintext service.
+  const redirectRoute = `---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: ${releaseName}-http-redirect
+spec:
+  parentRefs:
+    - name: ${releaseName}-gateway
+      sectionName: http
+  hostnames:
+${hostnameLines}
+  rules:
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            port: 443
+            statusCode: 302
+`;
+
+  return appRoute + redirectRoute;
 }

--- a/src/emit/templates/network-policy.ts
+++ b/src/emit/templates/network-policy.ts
@@ -1,0 +1,99 @@
+// src/emit/templates/network-policy.ts
+import { assertSafeReleaseName } from "./utils.js";
+
+// Default-deny-by-allowlist NetworkPolicies for the two workload tiers, gated on the
+// deploy CLI discovering the cluster's pod CIDRs (`--set global.networkPolicy.podCidrs=
+// {...}`). The whole file is wrapped in a helm `if` so an empty list renders nothing
+// (no policies) rather than a broken document.
+//
+// Both tiers allow ingress from 0.0.0.0/0 EXCEPT the pod CIDRs: the external LB and
+// Google health-check probes arrive with non-pod source IPs, while in-cluster pods are
+// blocked from talking to these ports directly. Pool pods additionally allow ingress
+// from SIBLING POOL pods only — cross-pool proxy traffic (pool-server/dispatch.ts
+// proxyToPool) is pool-to-pool; the routing service never calls pools, so its
+// `routing-service` component is deliberately NOT in the podSelector union. Any pool
+// may proxy to any other pool of the release, so every pool component is listed.
+export function renderNetworkPolicies({
+  releaseName,
+  poolNames,
+}: {
+  releaseName: string;
+  poolNames: string[];
+}): string {
+  assertSafeReleaseName(releaseName);
+
+  // The CIDR list is only ever expanded by helm from values the deploy CLI sets; keep
+  // the `range` at column 0 so the rendered `- "cidr"` lines indent under `except:`.
+  const exceptCidrs = `            except:
+{{- range .Values.global.networkPolicy.podCidrs }}
+              - {{ . | quote }}
+{{- end }}`;
+
+  const routingPolicy = `apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ${releaseName}-routing-service
+  labels:
+    app.kubernetes.io/name: ${releaseName}
+    app.kubernetes.io/component: routing-service
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: ${releaseName}
+      app.kubernetes.io/component: routing-service
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+${exceptCidrs}
+      ports:
+        - protocol: TCP
+          port: 8443
+        - protocol: TCP
+          port: 8081`;
+
+  // One podSelector entry per pool component: any sibling pool may proxy to this one
+  // (proxyToPool), but the routing service — same release label, different component —
+  // never originates pool traffic and stays blocked.
+  const siblingPoolSelectors = poolNames
+    .map(
+      (p) => `        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: ${releaseName}
+              app.kubernetes.io/component: ${p}`,
+    )
+    .join("\n");
+
+  const poolPolicies = poolNames.map(
+    (poolName) => `apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ${releaseName}-${poolName}
+  labels:
+    app.kubernetes.io/name: ${releaseName}
+    app.kubernetes.io/component: ${poolName}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: ${releaseName}
+      app.kubernetes.io/component: ${poolName}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+${exceptCidrs}
+${siblingPoolSelectors}
+      ports:
+        - protocol: TCP
+          port: 3000`,
+  );
+
+  return `{{- if .Values.global.networkPolicy.podCidrs }}
+${[routingPolicy, ...poolPolicies].join("\n---\n")}
+{{- end }}
+`;
+}

--- a/src/emit/templates/route-ext-configmap.ts
+++ b/src/emit/templates/route-ext-configmap.ts
@@ -18,7 +18,13 @@ export function renderRouteExtConfigMap({
   const chain = chains[0];
   const fwdRule = forwardingRule ?? "FORWARDING_RULE_PLACEHOLDER";
 
-  // Escape CEL expression for YAML (double quotes inside double-quoted string)
+  // Escape CEL expression for YAML. This MUST be a single-quoted YAML scalar: the CEL
+  // text is already CEL-escaped (escapeCelString turns ' into \'), and \' is NOT a valid
+  // escape in a YAML double-quoted scalar — an apostrophe in a public path (o'brien.txt)
+  // would make route-extension.yaml unparseable and the extension would never register.
+  // YAML single-quote escaping doubles the quote (' -> ''), so a CEL \' becomes \'' and
+  // the YAML parser reads it back as \' — an exact round-trip. (escapeCelString also
+  // rejects control characters, so no newline can reach this scalar.)
   const celExpr = chain?.matchCondition?.celExpression ?? "true";
 
   const routeExtYaml = [
@@ -29,7 +35,7 @@ export function renderRouteExtConfigMap({
     `extensionChains:`,
     `  - name: "${chain?.name ?? "nextjs-routing"}"`,
     `    matchCondition:`,
-    `      celExpression: "${celExpr.replace(/"/g, '\\"')}"`,
+    `      celExpression: '${celExpr.replace(/'/g, "''")}'`,
     `    extensions:`,
     `      - name: "${ext?.name ?? "routing-service"}"`,
     `        authority: "${ext?.authority ?? ""}"`,

--- a/src/emit/templates/route-ext-update-job.ts
+++ b/src/emit/templates/route-ext-update-job.ts
@@ -1,18 +1,19 @@
+import { createHash } from "node:crypto";
 import {
   assertSafeReleaseName,
   assertSafeProjectId,
   assertSafeRegion,
-  sanitizeK8sName,
+  assertSafeBuildId,
 } from "./utils.js";
 
 // Single source of truth for the traffic-ext registration Job name. deploy.ts's
-// "delete old jobs" cleanup MUST match this exactly — a mismatch (it previously used a
-// 12-char build-id slice while the name uses 10) deletes the current job mid-run, so the
-// extension never gets registered. sanitizeK8sName keeps the full (DNS-safe) build id, so
-// names stay unique per build — K8s Jobs are immutable, so per-build uniqueness is the
-// requirement — while still fitting the 63-char name limit.
+// "delete old jobs" cleanup MUST match this exactly — a mismatch deletes the current job
+// mid-run, so the extension never gets registered. Kubernetes Jobs are immutable, so each
+// build needs a distinct name. A 12-hex-character SHA-256 suffix preserves 48 bits of the
+// complete build ID while always fitting after the 40-character release-name limit.
 export function routeExtJobName(releaseName: string, buildId: string): string {
-  return sanitizeK8sName(`${releaseName}-route-ext-${buildId}`);
+  const buildDigest = createHash("sha256").update(buildId).digest("hex").slice(0, 12);
+  return `${releaseName}-route-ext-${buildDigest}`;
 }
 
 export function renderRouteExtUpdateJob({
@@ -32,6 +33,7 @@ export function renderRouteExtUpdateJob({
   assertSafeReleaseName(releaseName);
   assertSafeProjectId(projectId);
   assertSafeRegion(region);
+  assertSafeBuildId(buildId);
   // Include buildId in the Job name so each deploy creates a fresh Job
   // (K8s Jobs are immutable — can't update an existing one)
   return `apiVersion: batch/v1
@@ -41,6 +43,10 @@ metadata:
   labels:
     app.kubernetes.io/name: ${releaseName}
     app.kubernetes.io/component: route-ext-job
+  annotations:
+    # The Job name carries only a digest of the build id — record the full id for
+    # operators (an annotation, not a label: build ids may exceed the 63-char label cap).
+    adapter-k8s.dev/build-id: "${buildId}"
 spec:
   # Sweep finished Jobs so re-registrations don't accumulate in the namespace.
   ttlSecondsAfterFinished: 3600

--- a/src/emit/templates/route-ext-update-job.ts
+++ b/src/emit/templates/route-ext-update-job.ts
@@ -1,15 +1,18 @@
-import { assertSafeReleaseName, assertSafeProjectId, assertSafeRegion } from "./utils.js";
+import {
+  assertSafeReleaseName,
+  assertSafeProjectId,
+  assertSafeRegion,
+  sanitizeK8sName,
+} from "./utils.js";
 
 // Single source of truth for the traffic-ext registration Job name. deploy.ts's
 // "delete old jobs" cleanup MUST match this exactly — a mismatch (it previously used a
 // 12-char build-id slice while the name uses 10) deletes the current job mid-run, so the
-// extension never gets registered.
+// extension never gets registered. sanitizeK8sName keeps the full (DNS-safe) build id, so
+// names stay unique per build — K8s Jobs are immutable, so per-build uniqueness is the
+// requirement — while still fitting the 63-char name limit.
 export function routeExtJobName(releaseName: string, buildId: string): string {
-  const safeBuildId = buildId
-    .toLowerCase()
-    .replace(/[^a-z0-9]/g, "")
-    .slice(0, 10);
-  return `${releaseName}-route-ext-${safeBuildId}`;
+  return sanitizeK8sName(`${releaseName}-route-ext-${buildId}`);
 }
 
 export function renderRouteExtUpdateJob({
@@ -39,12 +42,27 @@ metadata:
     app.kubernetes.io/name: ${releaseName}
     app.kubernetes.io/component: route-ext-job
 spec:
+  # Sweep finished Jobs so re-registrations don't accumulate in the namespace.
+  ttlSecondsAfterFinished: 3600
   template:
     spec:
       serviceAccountName: ${releaseName}-deploy-sa
+      # NOTE: the SA token stays automounted — this Job needs Workload Identity to call
+      # gcloud. It still runs as an unprivileged user with a locked-down container.
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        fsGroup: 65534
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: update-ext
           image: gcr.io/google.com/cloudsdktool/cloud-sdk:slim
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
           command: ["/bin/sh", "-c"]
           args:
             - |
@@ -140,13 +158,21 @@ spec:
           env:
             - name: CLOUDSDK_CORE_PROJECT
               value: "${projectId}"
+            # gcloud refuses to run when its config home is unwritable; running as
+            # non-root with a read-only root FS, point it at the /tmp emptyDir.
+            - name: CLOUDSDK_CONFIG
+              value: /tmp/.config/gcloud
           volumeMounts:
             - name: config
               mountPath: /config
+            - name: tmp
+              mountPath: /tmp
       volumes:
         - name: config
           configMap:
             name: ${releaseName}-route-ext-config
+        - name: tmp
+          emptyDir: {}
       restartPolicy: Never
   backoffLimit: 3
 `;

--- a/src/emit/templates/routing-service-deployment.ts
+++ b/src/emit/templates/routing-service-deployment.ts
@@ -64,12 +64,25 @@ spec:
         app.kubernetes.io/component: routing-service
         app.kubernetes.io/version: "${safeBuildId}"
     spec:
+      # The routing service never calls the Kubernetes API — don't mount a SA token.
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
       # Give a terminating pod time to keep serving in-flight callouts while the LB stops
       # routing to it (preStop below), before SIGTERM/kill.
       terminationGracePeriodSeconds: 40
       containers:
         - name: routing-service
           image: "${imageRegistry}/routing-service:${buildId}"
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
           lifecycle:
             preStop:
               # Keep serving while GCP reprograms the NEG to drain this terminating pod.
@@ -96,10 +109,22 @@ spec:
               value: "${requestTimeoutMs ?? 4000}"
             - name: CONFIG_DIR
               value: /config
+            # The per-replica TLS cert generated at container start needs the release
+            # name + namespace to build its CN/SAN (cert lands in /tmp/tls).
+            - name: RELEASE_NAME
+              value: "${releaseName}"
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
 ${internalSecretEnv}
           volumeMounts:
             - name: routing-manifest
               mountPath: /config
+            # readOnlyRootFilesystem makes / read-only; the runtime TLS cert
+            # generation writes under /tmp/tls, backed by this emptyDir.
+            - name: tmp
+              mountPath: /tmp
           # httpGet, not a socket check: a wedged event loop still accepts a TCP
           # connection but fails to *serve* /healthz, so a broken-but-listening pod
           # gets evicted from the NEG instead of silently failing callouts.
@@ -127,5 +152,7 @@ ${internalSecretEnv}
         - name: routing-manifest
           configMap:
             name: ${releaseName}-routing-manifest
+        - name: tmp
+          emptyDir: {}
 `;
 }

--- a/src/emit/templates/utils.ts
+++ b/src/emit/templates/utils.ts
@@ -16,18 +16,81 @@ export function sanitizeK8sName(name: string): string {
   return sanitized;
 }
 
-// Values below are spliced into shell scripts and K8s resource names that run under
-// privileged Workload-Identity service accounts. They are never validated elsewhere,
-// so guard against injection / invalid-name errors at generation time.
-const RELEASE_NAME_RE = /^[a-z0-9-]+$/;
+// Values below are spliced into shell scripts, `helm --set` assignments, K8s resource
+// names, and YAML that runs under privileged Workload-Identity service accounts. Guard
+// against injection / invalid-name errors at the boundary — never interpolate raw.
+//
+// releaseName is capped at 40 chars: it is prefixed into longer resource names
+// (`${releaseName}-routing-service`, GKE cluster `${releaseName}-cluster`, etc.) that
+// must each fit their own length limits (63 for K8s names, 40 for GKE clusters).
+const RELEASE_NAME_RE = /^[a-z0-9-]{1,40}$/;
 const PROJECT_ID_RE = /^[a-z][a-z0-9-]{4,28}[a-z0-9]$/;
 const REGION_RE = /^[a-z0-9-]+$/;
+// DNS-1123 hostname, optionally with a single left-most wildcard label (`*.example.com`).
+// Lowercase only, no whitespace/quotes — safe to embed in a quoted YAML scalar.
+const HOSTNAME_RE =
+  /^(\*\.)?[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)*$/;
+// OCI registry/repository prefix (no tag — the tag is the build id, applied separately).
+// Lowercase alnum with `.`/`_`/`-` separators and `/` path segments.
+const IMAGE_REGISTRY_RE = /^[a-z0-9]+([._-][a-z0-9]+)*(\/[a-z0-9]+([._-][a-z0-9]+)*)*$/;
+// Next.js build ids (default or from `generateBuildId()` — commonly a git ref in CI).
+// Excludes helm `--set` metacharacters (`,` `\`) and YAML/template breakouts (`"` `'` `{`).
+const BUILD_ID_RE = /^[A-Za-z0-9._-]{1,128}$/;
+const NAMESPACE_RE = /^[a-z0-9-]{1,63}$/;
+// GCS bucket naming rules (https://cloud.google.com/storage/docs/buckets#naming).
+const BUCKET_RE = /^[a-z0-9][a-z0-9._-]{1,61}[a-z0-9]$/;
 
 export function assertSafeReleaseName(releaseName: string): void {
   if (!RELEASE_NAME_RE.test(releaseName)) {
     throw new Error(
       `Invalid releaseName "${releaseName}": must match ${RELEASE_NAME_RE} ` +
-        `(lowercase letters, digits, and hyphens only).`,
+        `(lowercase letters, digits, and hyphens only, max 40 chars).`,
+    );
+  }
+}
+
+export function assertSafeHostname(hostname: string): void {
+  if (hostname.length > 253 || !HOSTNAME_RE.test(hostname)) {
+    throw new Error(
+      `Invalid hostname "${hostname}": must be a DNS-1123 hostname ` +
+        `(optionally wildcard-prefixed like "*.example.com").`,
+    );
+  }
+}
+
+export function assertSafeImageRegistry(registry: string): void {
+  if (registry.length > 255 || !IMAGE_REGISTRY_RE.test(registry)) {
+    throw new Error(
+      `Invalid image registry "${registry}": must be a lowercase registry/repository ` +
+        `path (e.g. "us-central1-docker.pkg.dev/my-project/nextjs"), no tag or scheme.`,
+    );
+  }
+}
+
+export function assertSafeBuildId(buildId: string): void {
+  if (!BUILD_ID_RE.test(buildId)) {
+    throw new Error(
+      `Invalid buildId "${buildId}": must match ${BUILD_ID_RE} ` +
+        `(letters, digits, ".", "_", "-" only, max 128 chars). ` +
+        `If you set generateBuildId() in next.config, restrict its output to this charset.`,
+    );
+  }
+}
+
+export function assertSafeNamespace(namespace: string): void {
+  if (!NAMESPACE_RE.test(namespace)) {
+    throw new Error(
+      `Invalid namespace "${namespace}": must match ${NAMESPACE_RE} ` +
+        `(lowercase letters, digits, and hyphens only, max 63 chars).`,
+    );
+  }
+}
+
+export function assertSafeBucketName(bucket: string): void {
+  if (!BUCKET_RE.test(bucket)) {
+    throw new Error(
+      `Invalid bucket name "${bucket}": must match ${BUCKET_RE} ` +
+        `(lowercase letters, digits, ".", "_", "-" only, 3-63 chars).`,
     );
   }
 }

--- a/src/emit/templates/utils.ts
+++ b/src/emit/templates/utils.ts
@@ -23,7 +23,9 @@ export function sanitizeK8sName(name: string): string {
 // releaseName is capped at 40 chars: it is prefixed into longer resource names
 // (`${releaseName}-routing-service`, GKE cluster `${releaseName}-cluster`, etc.) that
 // must each fit their own length limits (63 for K8s names, 40 for GKE clusters).
-const RELEASE_NAME_RE = /^[a-z0-9-]{1,40}$/;
+// Edge hyphens are rejected — the templates embed releaseName at the start of DNS-1123
+// resource names, where a leading/trailing hyphen renders an invalid name.
+const RELEASE_NAME_RE = /^[a-z0-9]([a-z0-9-]{0,38}[a-z0-9])?$/;
 const PROJECT_ID_RE = /^[a-z][a-z0-9-]{4,28}[a-z0-9]$/;
 const REGION_RE = /^[a-z0-9-]+$/;
 // DNS-1123 hostname, optionally with a single left-most wildcard label (`*.example.com`).
@@ -44,7 +46,8 @@ export function assertSafeReleaseName(releaseName: string): void {
   if (!RELEASE_NAME_RE.test(releaseName)) {
     throw new Error(
       `Invalid releaseName "${releaseName}": must match ${RELEASE_NAME_RE} ` +
-        `(lowercase letters, digits, and hyphens only, max 40 chars).`,
+        `(lowercase letters, digits, and hyphens only, max 40 chars, ` +
+        `must start and end with a letter or digit).`,
     );
   }
 }

--- a/src/emit/templates/valkey-secret.ts
+++ b/src/emit/templates/valkey-secret.ts
@@ -8,6 +8,9 @@ import { assertSafeReleaseName } from "./utils.js";
 export const VALKEY_SECRET_NAME = "valkey";
 export const VALKEY_URL_KEY = "url";
 export const VALKEY_AUTH_KEY = "auth";
+// PEM of the cache server's CA — present when the managed instance uses in-transit
+// encryption (AUTH mode). The pool pins TLS verification to this CA.
+export const VALKEY_CA_KEY = "ca";
 
 /**
  * Env-var snippet (YAML list items) injecting VALKEY_URL / VALKEY_AUTH into a pool container.
@@ -28,6 +31,12 @@ ${indent}  valueFrom:
 ${indent}    secretKeyRef:
 ${indent}      name: ${secret}
 ${indent}      key: ${VALKEY_AUTH_KEY}
+${indent}      optional: true
+${indent}- name: VALKEY_CA_CERT
+${indent}  valueFrom:
+${indent}    secretKeyRef:
+${indent}      name: ${secret}
+${indent}      key: ${VALKEY_CA_KEY}
 ${indent}      optional: true`;
 }
 
@@ -36,14 +45,17 @@ export function renderValkeySecret({
   releaseName,
   url,
   password,
+  ca,
 }: {
   releaseName: string;
   url: string;
   password?: string;
+  ca?: string;
 }): string {
   assertSafeReleaseName(releaseName);
   const entries: [string, string][] = [[VALKEY_URL_KEY, url]];
   if (password) entries.push([VALKEY_AUTH_KEY, password]);
+  if (ca) entries.push([VALKEY_CA_KEY, ca]);
   return `apiVersion: v1
 kind: Secret
 metadata:

--- a/src/emit/templates/values-yaml.ts
+++ b/src/emit/templates/values-yaml.ts
@@ -26,6 +26,12 @@ export function renderValuesYaml({
         tag: buildId,
         pullPolicy: "IfNotPresent",
       },
+      // Empty by default: the deploy CLI passes `--set global.networkPolicy.podCidrs=
+      // {..}` when it can discover the cluster's pod CIDRs; an empty list renders no
+      // NetworkPolicies (the templates are wrapped in a helm `if` guard).
+      networkPolicy: {
+        podCidrs: [] as string[],
+      },
     },
     pools: Object.fromEntries(
       [...pools.entries()].map(([name, pool]) => [

--- a/src/pool-server/dispatch.ts
+++ b/src/pool-server/dispatch.ts
@@ -2,6 +2,7 @@
 import { createServer, request as httpRequest } from "node:http";
 import { readFileSync, existsSync } from "node:fs";
 import { pipeline } from "node:stream";
+import { timingSafeEqual } from "node:crypto";
 import path from "node:path";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { HandlerLoader } from "./handler-loader.js";
@@ -49,20 +50,100 @@ function webHeadersToNodeHeaders(webHeaders: Headers): Record<string, string | s
   return headers;
 }
 
+// Client-supplied forwarding headers are only a hint. x-forwarded-host is honored solely when it
+// is a plain host[:port] token — anything else (URL syntax, whitespace, empty) falls back to the
+// Host header so a malformed value can neither throw during URL construction nor smuggle an
+// attacker-chosen origin into the relative-vs-absolute Location comparison below.
+const FORWARDED_HOST_RE = /^[a-zA-Z0-9.-]+(:[0-9]{1,5})?$/;
+
 function middlewareRedirectLocation(req: IncomingMessage, target: URL): string {
   const forwardedHost = req.headers["x-forwarded-host"];
+  const forwardedHostValue = Array.isArray(forwardedHost) ? forwardedHost[0] : forwardedHost;
   const host =
-    (Array.isArray(forwardedHost) ? forwardedHost[0] : forwardedHost) ??
+    (forwardedHostValue && FORWARDED_HOST_RE.test(forwardedHostValue)
+      ? forwardedHostValue
+      : undefined) ??
     req.headers.host ??
     "localhost";
   const forwardedProto = req.headers["x-forwarded-proto"];
+  const forwardedProtoValue = (Array.isArray(forwardedProto) ? forwardedProto[0] : forwardedProto)
+    ?.split(",")[0]
+    ?.trim();
+  // Only the two real schemes are honored — a spoofed value (e.g. `javascript:`) becomes http.
   const protocol =
-    (Array.isArray(forwardedProto) ? forwardedProto[0] : forwardedProto)?.split(",")[0]?.trim() ||
-    "http";
-  const requestOrigin = new URL(`${protocol}://${host}`).origin;
-  return target.origin === requestOrigin
-    ? `${target.pathname}${target.search}${target.hash}`
-    : target.toString();
+    forwardedProtoValue === "https" || forwardedProtoValue === "http"
+      ? forwardedProtoValue
+      : "http";
+  try {
+    const requestOrigin = new URL(`${protocol}://${host}`).origin;
+    return target.origin === requestOrigin
+      ? `${target.pathname}${target.search}${target.hash}`
+      : target.toString();
+  } catch {
+    // The port group above admits out-of-range ports (e.g. :99999), which the URL parser
+    // rejects. A bad forwarded value must never turn a middleware redirect into a 500 —
+    // the absolute target is always a valid Location.
+    return target.toString();
+  }
+}
+
+// Constant-time string compare, guarding the length side-channel (timingSafeEqual throws on
+// unequal-length buffers). Mirrors secretsMatch in server.ts.
+function timingSafeStringEqual(a: string, b: string): boolean {
+  const ab = Buffer.from(a);
+  const bb = Buffer.from(b);
+  if (ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
+}
+
+// Extract one cookie's value from a Cookie header, percent-decoded the way Next's RequestCookies
+// does it (next/dist/compiled/@edge-runtime/cookies). Returns undefined when the cookie is absent.
+function readCookieValue(cookieHeader: string, name: string): string | undefined {
+  for (const pair of cookieHeader.split(";")) {
+    const eq = pair.indexOf("=");
+    if (eq < 0) continue;
+    if (pair.slice(0, eq).trim() !== name) continue;
+    const raw = pair.slice(eq + 1).trim();
+    try {
+      return decodeURIComponent(raw);
+    } catch {
+      // Malformed percent-encoding: keep the raw value so the equality check below simply fails.
+      return raw;
+    }
+  }
+  return undefined;
+}
+
+// The strict-dynamic-route 404 (fallback:false / dynamicParams:false) may only yield to an
+// AUTHENTICATED preview/draft or on-demand-revalidate request. Both credentials are validated
+// against the build's random previewModeId, which pool-server/index.ts loads from
+// prerender-manifest.json into __NEXT_PREVIEW_MODE_ID — the same values upstream Next 16.2 checks:
+//  - `x-prerender-revalidate`: direct equality with previewModeId (checkIsOnDemandRevalidate in
+//    next/dist/server/api-utils/index.js).
+//  - `__prerender_bypass` cookie: Next sets the cookie's VALUE to the previewModeId itself
+//    (setDraftMode in next/dist/server/api-utils/node/api-resolver.js), and tryGetPreviewData
+//    (next/dist/server/api-utils/node/try-get-preview-data.js) accepts it when the decoded value
+//    equals previewModeId. NOTE: the previewModeSigningKey signs only the separate legacy Preview
+//    Mode `__next_preview_data` JWT — the bypass cookie carries no HMAC — so an exact,
+//    constant-time equality against the random build-time id IS the complete upstream scheme.
+// When the build produced no preview identity, neither credential is ever honored.
+function isVerifiedPreviewRequest(req: IncomingMessage): boolean {
+  const previewModeId = process.env.__NEXT_PREVIEW_MODE_ID;
+  if (!previewModeId) return false;
+  const revalidateHeader = req.headers["x-prerender-revalidate"];
+  const revalidateValue = Array.isArray(revalidateHeader) ? revalidateHeader[0] : revalidateHeader;
+  if (
+    typeof revalidateValue === "string" &&
+    timingSafeStringEqual(revalidateValue, previewModeId)
+  ) {
+    return true;
+  }
+  const cookieHeader = req.headers.cookie;
+  const bypassValue = readCookieValue(
+    Array.isArray(cookieHeader) ? cookieHeader.join("; ") : (cookieHeader ?? ""),
+    "__prerender_bypass",
+  );
+  return bypassValue !== undefined && timingSafeStringEqual(bypassValue, previewModeId);
 }
 
 // Swallow socket errors on a client stream. A mid-response client disconnect emits an
@@ -1479,9 +1560,15 @@ export function createDispatcher(options: DispatcherOptions) {
             );
 
             proxyReq.on("error", (err) => {
+              // The dial error stays in the server log — the client body must not leak
+              // upstream error detail (connection failures reveal internal topology/targets).
+              console.error(
+                `[pool-server] external rewrite to ${target.origin}${target.pathname} failed:`,
+                err,
+              );
               if (!res.headersSent) {
                 res.writeHead(502, { "content-type": "text/plain" });
-                res.end(`External rewrite failed: ${err.message}`);
+                res.end("Bad Gateway");
               }
               resolve();
             });
@@ -1518,8 +1605,13 @@ export function createDispatcher(options: DispatcherOptions) {
         case "route": {
           // fallback: false / dynamicParams: false — a path matching a strict
           // dynamic route but not in the prerendered set 404s (as `next start`
-          // does). Skipped for preview/revalidate requests, which legitimately
-          // render non-generated paths on demand.
+          // does). Skipped only for VERIFIED preview/revalidate requests, which
+          // legitimately render non-generated paths on demand. A bare
+          // `x-prerender-revalidate` header or a forged `__prerender_bypass`
+          // cookie must NOT skip the 404 — that would let any client force
+          // renders (which then land in the shared cache) of paths the app
+          // declared must 404. See isVerifiedPreviewRequest for the upstream
+          // credential scheme this mirrors.
           if (strictDynamicRoutes.length > 0) {
             const reqPath = (resolution.invokePath || req.url || "/").split("?")[0] ?? "/";
             const dataPrefix = `${basePath}/_next/data/${buildIdForData}/`;
@@ -1533,9 +1625,7 @@ export function createDispatcher(options: DispatcherOptions) {
               // Keep the encoded value; malformed escapes will simply fail the
               // prerender-manifest membership check below.
             }
-            const isBypass =
-              (req.headers.cookie ?? "").includes("__prerender_bypass=") ||
-              "x-prerender-revalidate" in req.headers;
+            const isBypass = isVerifiedPreviewRequest(req);
             if (
               !isBypass &&
               !prerenderedPaths.has(pagePath) &&
@@ -1921,9 +2011,15 @@ function proxyToPool(
     );
 
     proxyReq.on("error", (err) => {
+      // Pool name + dial error stay in the server log — the client body must not leak
+      // pool topology or internal hostnames.
+      console.error(
+        `[pool-server] cross-pool proxy to pool "${resolution.pool}" (${targetHost}) failed:`,
+        err,
+      );
       if (!res.headersSent) {
         res.writeHead(502, { "content-type": "text/plain" });
-        res.end(`Failed to proxy to pool "${resolution.pool}": ${err.message}`);
+        res.end("Bad Gateway");
       }
       resolve();
     });

--- a/src/pool-server/index.ts
+++ b/src/pool-server/index.ts
@@ -473,6 +473,7 @@ async function main() {
       url: valkeyUrl,
       buildId,
       ...(process.env.VALKEY_AUTH ? { password: process.env.VALKEY_AUTH } : {}),
+      ...(process.env.VALKEY_CA_CERT ? { caCert: process.env.VALKEY_CA_CERT } : {}),
     });
     console.log("[pool-server] Valkey use-cache handler registered (build " + buildId + ")");
   }

--- a/src/pool-server/server.ts
+++ b/src/pool-server/server.ts
@@ -124,11 +124,12 @@ export function createPoolServer(options: PoolServerOptions) {
     try {
       await onRequest(req, res);
     } catch (err) {
-      const errMsg = err instanceof Error ? err.message : String(err);
+      // The full error stays in the server log — the client body must not leak internal
+      // error messages (stack fragments, paths, upstream hostnames).
       console.error("Unhandled request error:", err);
       if (!res.headersSent) {
         res.writeHead(500, { "content-type": "text/plain" });
-        res.end(`Internal Server Error: ${errMsg}`);
+        res.end("Internal Server Error");
       } else if (!res.writableEnded) {
         res.end();
       }

--- a/src/pool-server/valkey-cache/cache-handler-entry.ts
+++ b/src/pool-server/valkey-cache/cache-handler-entry.ts
@@ -30,7 +30,11 @@ function getValkeyHandler(): ValkeyIncrementalCacheHandler | undefined {
   if (!url || !buildId) return undefined;
   if (!sharedHandler) {
     // Lazy: only reached in the node pool runtime when a cache is configured. Never in edge.
-    const client = createValkeyClient({ url, password: process.env.VALKEY_AUTH });
+    const client = createValkeyClient({
+      url,
+      password: process.env.VALKEY_AUTH,
+      caCert: process.env.VALKEY_CA_CERT,
+    });
     sharedHandler = new ValkeyIncrementalCacheHandler({ client, buildId });
   }
   return sharedHandler;

--- a/src/pool-server/valkey-cache/client.ts
+++ b/src/pool-server/valkey-cache/client.ts
@@ -7,6 +7,8 @@ export interface ValkeyConfig {
   url: string;
   /** AUTH string (e.g. the Memorystore auth string), optional. */
   password?: string | undefined;
+  /** PEM of the server CA for TLS verification (e.g. Memorystore in-transit encryption). */
+  caCert?: string | undefined;
 }
 
 /**
@@ -19,5 +21,5 @@ export interface ValkeyConfig {
  * degrades to a cache miss) rather than hanging a render.
  */
 export function createValkeyClient(config: ValkeyConfig): ValkeyClient {
-  return createRespClient({ url: config.url, password: config.password });
+  return createRespClient({ url: config.url, password: config.password, caCert: config.caCert });
 }

--- a/src/pool-server/valkey-cache/incremental-cache-handler.ts
+++ b/src/pool-server/valkey-cache/incremental-cache-handler.ts
@@ -14,10 +14,12 @@
 // `get` returns null when the entry's tags have been revalidated since it was stored (Next then
 // regenerates), so the per-process `tags-manifest.external` check Next also runs is irrelevant here.
 import type { ValkeyClient } from "./client.js";
+import { logErrorRateLimited, maxCacheEntryBytes, warnOnce } from "./stream-codec.js";
 import {
   areTagsExpired,
   areTagsStale,
   computeTagUpdate,
+  parseTagState,
   UPDATE_TAGS_SCRIPT,
   type TagState,
 } from "./tag-manifest.js";
@@ -28,8 +30,15 @@ const RETENTION_MARGIN_SECONDS = 60;
 // never time-revalidate). Next's semantics are "cache until a tag revalidates it", so these must NOT
 // fall to the ~61s numeric-revalidate floor (which would make them cold-miss every minute). Bounded
 // (not infinite) so a failed blue/green teardown can't leak build-namespaced keys forever; a build
-// living past this simply re-renders the entry once, then re-caches it.
-const DURABLE_TTL_SECONDS = 30 * 24 * 60 * 60; // 30 days
+// living past this simply re-renders the entry once, then re-caches it. Exported: the V2 `use cache`
+// handler caps its key TTL at the same bound (M7).
+export const DURABLE_TTL_SECONDS = 30 * 24 * 60 * 60; // 30 days
+
+// Bounds for the tag list stored with an entry (L9). Next's own `cacheTag()` enforces the
+// 256-char per-tag limit, but a route handler can set `x-next-cache-tags` manually with
+// arbitrary content — drop over-limit tags rather than storing/looking-up unbounded lists.
+const MAX_TAGS_PER_ENTRY = 128;
+const MAX_TAG_LENGTH = 256;
 
 // Minimal structural mirror of Next's classic CacheHandler contract (avoids a compile-time
 // dependency on Next internals). `value` is an `IncrementalCacheValue`; we serialize its binary
@@ -56,6 +65,29 @@ interface StoredEntry {
   lastModified: number;
   /** Retention hint (seconds) for the Valkey key TTL; not the staleness source. */
   ttlSeconds: number;
+}
+
+/**
+ * Parse and validate a stored incremental entry (L5). A corrupt entry — wrong JSON, non-finite
+ * `lastModified`/`ttlSeconds`, a non-array tag list, or a missing `value` member (`null` is a
+ * REAL cached value, but it must be present) — degrades to a miss so Next regenerates.
+ */
+function parseStoredEntry(raw: string): StoredEntry | undefined {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return undefined;
+  const e = parsed as Record<string, unknown>;
+  if (!Number.isFinite(e.lastModified)) return undefined;
+  if (!Array.isArray(e.tags) || !e.tags.every((tag) => typeof tag === "string")) return undefined;
+  if (typeof e.ttlSeconds !== "number" || !Number.isFinite(e.ttlSeconds) || e.ttlSeconds <= 0) {
+    return undefined;
+  }
+  if (!("value" in e)) return undefined;
+  return e as unknown as StoredEntry;
 }
 
 export interface ValkeyIncrementalCacheOptions {
@@ -111,20 +143,35 @@ function decodeValue(value: unknown): unknown {
 }
 
 function extractTags(value: Record<string, unknown> | null, ctx: SetCtx): string[] {
-  if (ctx.tags && ctx.tags.length) return ctx.tags;
-  const headers = value?.headers as Record<string, string | string[]> | undefined;
-  const raw = headers?.[NEXT_CACHE_TAGS_HEADER];
-  if (typeof raw === "string")
-    return raw
-      .split(",")
-      .map((t) => t.trim())
-      .filter(Boolean);
-  if (Array.isArray(raw))
-    return raw
-      .flatMap((t) => t.split(","))
-      .map((t) => t.trim())
-      .filter(Boolean);
-  return [];
+  let raw: string[];
+  if (ctx.tags && ctx.tags.length) {
+    raw = ctx.tags;
+  } else {
+    const headers = value?.headers as Record<string, string | string[]> | undefined;
+    const header = headers?.[NEXT_CACHE_TAGS_HEADER];
+    if (typeof header === "string") {
+      raw = header
+        .split(",")
+        .map((t) => t.trim())
+        .filter(Boolean);
+    } else if (Array.isArray(header)) {
+      raw = header
+        .flatMap((t) => t.split(","))
+        .map((t) => t.trim())
+        .filter(Boolean);
+    } else {
+      raw = [];
+    }
+  }
+  // Cap count and per-tag length (L9): over-limit tags are dropped, keeping the first
+  // well-formed ones in declared order.
+  const tags: string[] = [];
+  for (const tag of raw) {
+    if (typeof tag !== "string" || tag.length === 0 || tag.length > MAX_TAG_LENGTH) continue;
+    tags.push(tag);
+    if (tags.length >= MAX_TAGS_PER_ENTRY) break;
+  }
+  return tags;
 }
 
 /**
@@ -153,7 +200,8 @@ export class ValkeyIncrementalCacheHandler {
     try {
       const raw = await this.client.get(this.entryKey(cacheKey));
       if (!raw) return null;
-      const entry = JSON.parse(raw) as StoredEntry;
+      const entry = parseStoredEntry(raw);
+      if (!entry) return null; // corrupt entry → miss, Next regenerates (L5)
       const now = this.now();
 
       // Own the staleness check against the SHARED manifest (the tags-manifest.external check Next
@@ -214,7 +262,17 @@ export class ValkeyIncrementalCacheHandler {
         lastModified: this.now(),
         ttlSeconds: Math.ceil(ttlSeconds),
       };
-      await this.client.set(this.entryKey(cacheKey), JSON.stringify(entry), "EX", entry.ttlSeconds);
+      const serialized = JSON.stringify(entry);
+      // M6: skip (and log once) when the serialized entry exceeds the configured cap — an
+      // oversized page/shell must not be pushed through the socket into Valkey unboundedly.
+      if (Buffer.byteLength(serialized, "utf8") > maxCacheEntryBytes()) {
+        warnOnce(
+          "oversize-entry",
+          `[valkey-cache] an incremental cache entry exceeded ADAPTER_K8S_MAX_CACHE_ENTRY_BYTES; it was not cached (further occurrences logged once per process)`,
+        );
+        return;
+      }
+      await this.client.set(this.entryKey(cacheKey), serialized, "EX", entry.ttlSeconds);
     } catch {
       // Cache write failure must not break the response.
     }
@@ -229,8 +287,14 @@ export class ValkeyIncrementalCacheHandler {
       for (const tag of list)
         args.push(tag, JSON.stringify(computeTagUpdate(undefined, now, durations)));
       await this.client.eval(UPDATE_TAGS_SCRIPT, 1, this.tagsKey, ...args);
-    } catch {
-      // Best-effort; a missed manifest write means a revalidation is skipped, not a crash.
+    } catch (error) {
+      // Best-effort; a missed manifest write means a revalidation is skipped, not a crash — but
+      // it must be OBSERVABLE (M1). Rate-limited so a Valkey outage doesn't spam per-request logs.
+      logErrorRateLimited(
+        "revalidateTag",
+        "[valkey-cache] revalidateTag failed to write the shared tag manifest; invalidation may be lost",
+        error,
+      );
     }
   }
 
@@ -245,11 +309,9 @@ export class ValkeyIncrementalCacheHandler {
     tags.forEach((tag, i) => {
       const rawState = values[i];
       if (rawState) {
-        try {
-          manifest.set(tag, JSON.parse(rawState) as TagState);
-        } catch {
-          // ignore a corrupt field
-        }
+        // Corrupt fields degrade to "no state" (a corrupt `at` becomes 0); never throw (L5).
+        const state = parseTagState(rawState);
+        if (state) manifest.set(tag, state);
       }
     });
     return manifest;

--- a/src/pool-server/valkey-cache/resp-client.ts
+++ b/src/pool-server/valkey-cache/resp-client.ts
@@ -58,18 +58,32 @@ export interface ValkeyClient {
 }
 
 export interface RespClientOptions {
-  /** `redis://host:port` or `rediss://host:port` (TLS). */
+  /** `redis://host:port` or `rediss://host:port` (TLS). Userinfo (`redis://:pass@host`) is
+   * honored as the AUTH password when `password` isn't given explicitly. */
   url: string;
-  /** AUTH string, sent before any command. */
+  /** AUTH string, sent before any command. Takes precedence over URL userinfo. */
   password?: string | undefined;
+  /** PEM of the server CA to pin TLS verification against (e.g. a Memorystore in-transit
+   * encryption CA, which is not publicly rooted). Only meaningful with `rediss:`. */
+  caCert?: string | undefined;
   /** Reject (and drop the socket) if a command has no reply within this window. 0 disables. */
   commandTimeoutMs?: number;
   /** Reject if the TCP/TLS connection isn't established within this window (a blackholed endpoint
    * has no connect timeout of its own and would otherwise hang the first command's render). */
   connectTimeoutMs?: number;
+  /** Maximum size of a single reply frame in bytes (default 64 MiB). A server-advertised bulk
+   * length or array that would exceed this is a protocol error: the connection is destroyed and
+   * all in-flight commands fail (we never buffer an unbounded/untrustworthy advertised length). */
+  maxReplyBytes?: number;
 }
 
 const CRLF = Buffer.from("\r\n");
+
+/** Default cap for one reply frame (M6b). Entries are capped at 16 MiB, so 64 MiB is generous. */
+const DEFAULT_MAX_REPLY_BYTES = 64 * 1024 * 1024;
+/** Total buffered-but-unparsed bytes are capped at a multiple of the frame cap: pipelined replies
+ * (MULTI, concurrent commands) legitimately stack several frames behind the head one. */
+const MAX_BUFFERED_FACTOR = 4;
 
 function encodeCommand(args: Arg[]): Buffer {
   const parts: Buffer[] = [Buffer.from(`*${args.length}\r\n`)];
@@ -82,7 +96,9 @@ function encodeCommand(args: Arg[]): Buffer {
 
 // Parse one reply starting at `offset`. Returns [value, nextOffset], or null if `buf` doesn't yet
 // hold a complete reply (caller waits for more data). Bulk payloads are sliced by their length
-// prefix, so binary values containing CRLF parse correctly.
+// prefix, so binary values containing CRLF parse correctly. Callers must have validated the frame
+// with `scanFrameEnd` first (which rejects malformed lengths), so the length fields seen here are
+// already known-good.
 function parseReply(buf: Buffer, offset: number): [Reply, number] | null {
   if (offset >= buf.length) return null;
   const lineEnd = buf.indexOf(CRLF, offset);
@@ -123,30 +139,154 @@ function parseReply(buf: Buffer, offset: number): [Reply, number] | null {
   }
 }
 
+/**
+ * Measure the RESP frame starting at `offset` WITHOUT copying anything (M6b). Returns `{ end }`
+ * (absolute index one past the complete frame) or `{ need }` (rescanning is pointless until
+ * `buf.length >= need`). The `need` contract is what lets the inbound path buffer chunks of a
+ * large reply without re-scanning (and re-copying) per chunk: the bulk header reveals the full
+ * frame size up front.
+ *
+ * Throws a RespError on a protocol violation (L8): a non-integer or `< -1` length/count (RESP
+ * nulls use -1), an unknown type byte, a frame that would exceed `limit` bytes, or nesting past
+ * MAX_FRAME_DEPTH. Such a reply means the byte stream can no longer be trusted — the caller
+ * destroys the connection and fails all in-flight commands rather than risking a
+ * command-queue desync.
+ */
+// Real Valkey replies nest at most 2-3 levels (array → bulk, array → array → bulk). The
+// scanner recurses per array element, so a hostile endpoint could otherwise crash the process
+// with a stack overflow via `*1\r\n*1\r\n...` — cap the depth far above anything legitimate.
+const MAX_FRAME_DEPTH = 32;
+function scanFrameEnd(
+  buf: Buffer,
+  offset: number,
+  limit: number,
+  depth = 0,
+): { end: number } | { need: number } {
+  if (depth > MAX_FRAME_DEPTH) {
+    throw new RespError(`RESP frame nested past ${MAX_FRAME_DEPTH} levels`);
+  }
+  if (offset >= buf.length) return { need: offset + 1 };
+  const type = buf[offset]!;
+  const lineEnd = buf.indexOf(CRLF, offset);
+  if (lineEnd === -1) return { need: buf.length + 1 };
+  const after = lineEnd + 2;
+  switch (type) {
+    case 0x2b: // '+' simple string
+    case 0x2d: // '-' error
+    case 0x3a: // ':' integer
+      return { end: after };
+    case 0x24: {
+      // '$' bulk string
+      const len = Number(buf.toString("utf8", offset + 1, lineEnd));
+      if (!Number.isInteger(len) || len < -1) {
+        throw new RespError(
+          `RESP protocol error: invalid bulk length ${JSON.stringify(buf.toString("utf8", offset + 1, lineEnd))}`,
+        );
+      }
+      if (len === -1) return { end: after };
+      const end = after + len + 2;
+      if (end > limit) {
+        throw new RespError(`RESP reply frame of ${len} bytes exceeds the ${limit}-byte cap`);
+      }
+      return buf.length >= end ? { end } : { need: end };
+    }
+    case 0x2a: {
+      // '*' array
+      const count = Number(buf.toString("utf8", offset + 1, lineEnd));
+      if (!Number.isInteger(count) || count < -1) {
+        throw new RespError(
+          `RESP protocol error: invalid array count ${JSON.stringify(buf.toString("utf8", offset + 1, lineEnd))}`,
+        );
+      }
+      if (count === -1) return { end: after };
+      let cursor = after;
+      for (let i = 0; i < count; i++) {
+        const sub = scanFrameEnd(buf, cursor, limit, depth + 1);
+        if ("need" in sub) return sub;
+        cursor = sub.end;
+      }
+      if (cursor > limit) {
+        throw new RespError(`RESP reply frame exceeds the ${limit}-byte cap`);
+      }
+      return { end: cursor };
+    }
+    default:
+      throw new RespError(`RESP protocol error: unknown type byte 0x${type.toString(16)}`);
+  }
+}
+
 class RespClient implements ValkeyClient {
   private socket: Socket | TLSSocket | undefined;
   private connecting: Promise<void> | undefined;
-  private inbound: Buffer = Buffer.alloc(0);
+  /** Inbound bytes not yet attributed to a complete reply frame, as a chunk list + running total
+   * (concatenated lazily, once per emitted frame — never per received chunk). */
+  private inboundChunks: Buffer[] = [];
+  private inboundBytes = 0;
+  /** Rescan hint from `scanFrameEnd`: don't touch the chunk list until this many bytes exist. */
+  private neededBytes = 0;
   private readonly queue: Pending[] = [];
   private ended = false;
   private readonly url: string;
   private readonly password: string | undefined;
+  private readonly caCert: string | undefined;
   private readonly commandTimeoutMs: number;
   private readonly connectTimeoutMs: number;
+  private readonly maxReplyBytes: number;
+  private readonly maxBufferedBytes: number;
 
   constructor(options: RespClientOptions) {
     this.url = options.url;
     this.password = options.password;
+    this.caCert = options.caCert;
     this.commandTimeoutMs = options.commandTimeoutMs ?? 5000;
     this.connectTimeoutMs = options.connectTimeoutMs ?? 5000;
+    this.maxReplyBytes = options.maxReplyBytes ?? DEFAULT_MAX_REPLY_BYTES;
+    this.maxBufferedBytes = this.maxReplyBytes * MAX_BUFFERED_FACTOR;
   }
 
   private onData(chunk: Buffer): void {
-    this.inbound = this.inbound.length ? Buffer.concat([this.inbound, chunk]) : chunk;
-    while (this.queue.length) {
-      const parsed = parseReply(this.inbound, 0);
-      if (!parsed) break;
-      this.inbound = this.inbound.subarray(parsed[1]);
+    this.inboundChunks.push(chunk);
+    this.inboundBytes += chunk.length;
+    if (this.inboundBytes > this.maxBufferedBytes) {
+      // Unbounded buffering is a memory-exhaustion vector (M6b); bail out exactly like a socket
+      // error: destroy the connection and fail every in-flight command.
+      this.failAll(
+        new RespError(
+          `Valkey reply buffer grew past ${this.maxBufferedBytes} bytes; destroying connection`,
+        ),
+      );
+      return;
+    }
+    this.drainInbound();
+  }
+
+  // Emit every complete reply frame the inbound buffer currently holds. The expensive path — a
+  // large reply arriving in many TCP chunks — copies each byte exactly once: the header scan
+  // learns the frame size up front, intermediate chunks are only appended to the chunk list,
+  // and a single concat happens when the last chunk lands.
+  private drainInbound(): void {
+    while (this.queue.length > 0) {
+      if (this.inboundBytes < this.neededBytes) return; // head frame known-incomplete: wait cheaply
+      const buf = this.flattenInbound();
+      let scan: { end: number } | { need: number };
+      try {
+        scan = scanFrameEnd(buf, 0, this.maxReplyBytes);
+      } catch (error) {
+        this.failAll(error instanceof Error ? error : new RespError(String(error)));
+        return;
+      }
+      if ("need" in scan) {
+        this.neededBytes = scan.need;
+        return;
+      }
+      const parsed = parseReply(buf, 0);
+      if (!parsed || parsed[1] !== scan.end) {
+        // scanFrameEnd proved the frame complete, so parseReply cannot disagree — unless the two
+        // parsers drifted apart. Fail closed rather than desync the command queue.
+        this.failAll(new RespError("RESP protocol error: frame scanner/parser disagree"));
+        return;
+      }
+      this.consumeInbound(parsed[1]);
       const pending = this.queue.shift()!;
       if (pending.timer) clearTimeout(pending.timer);
       const value = parsed[0];
@@ -155,14 +295,33 @@ class RespClient implements ValkeyClient {
     }
   }
 
-  // Tear down the socket and fail every in-flight command. Called on socket error/close and on a
-  // command timeout — destroying is deliberate: a late reply after we've shifted the queue would
-  // map to the wrong caller, so we resync from a clean slate and let the next command reconnect.
+  // Join the chunk list into one contiguous buffer for scanning/parsing. No-op when a single
+  // chunk is buffered; afterwards the list collapses to that one buffer.
+  private flattenInbound(): Buffer {
+    if (this.inboundChunks.length === 1) return this.inboundChunks[0]!;
+    const flat = Buffer.concat(this.inboundChunks, this.inboundBytes);
+    this.inboundChunks = [flat];
+    return flat;
+  }
+
+  private consumeInbound(consumed: number): void {
+    const rest = this.inboundChunks[0]!.subarray(consumed);
+    this.inboundChunks = rest.length > 0 ? [rest] : [];
+    this.inboundBytes = rest.length;
+    this.neededBytes = 0; // the next head frame's size is unknown until scanned
+  }
+
+  // Tear down the socket and fail every in-flight command. Called on socket error/close, on a
+  // command timeout, and on a reply-protocol violation — destroying is deliberate: a late or
+  // mistramed reply after we've shifted the queue would map to the wrong caller, so we resync
+  // from a clean slate and let the next command reconnect.
   private failAll(error: Error): void {
     const socket = this.socket;
     this.socket = undefined;
     this.connecting = undefined;
-    this.inbound = Buffer.alloc(0);
+    this.inboundChunks = [];
+    this.inboundBytes = 0;
+    this.neededBytes = 0;
     if (socket) {
       socket.removeAllListeners();
       socket.destroy();
@@ -179,9 +338,29 @@ class RespClient implements ValkeyClient {
     const host = parsed.hostname;
     const port = parsed.port ? Number(parsed.port) : 6379;
     const useTls = parsed.protocol === "rediss:";
+    // Honor URL userinfo (`redis://:secret@host`) when no explicit password is configured (L6) —
+    // it was previously parsed and silently dropped, which surfaced as a permanent NOAUTH.
+    let userinfoPassword: string | undefined;
+    if (parsed.password) {
+      try {
+        userinfoPassword = decodeURIComponent(parsed.password);
+      } catch {
+        userinfoPassword = parsed.password; // malformed percent-encoding: use it verbatim
+      }
+    }
+    const password = this.password ?? userinfoPassword;
+    if (password && !useTls) warnPlaintextAuthOnce();
+
     // Lazy dynamic import keeps `node:net`/`node:tls` out of module eval (edge-eval-safe).
+    // With a configured CA (Memorystore in-transit encryption), pin verification to it — its
+    // CA is not publicly rooted, so the default trust store would reject the handshake.
     const socket: Socket | TLSSocket = useTls
-      ? (await import("node:tls")).connect({ host, port, servername: host })
+      ? (await import("node:tls")).connect({
+          host,
+          port,
+          servername: host,
+          ...(this.caCert ? { ca: this.caCert } : {}),
+        })
       : (await import("node:net")).connect({ host, port });
     socket.setNoDelay(true);
     socket.on("data", (chunk: Buffer) => this.onData(chunk));
@@ -229,7 +408,7 @@ class RespClient implements ValkeyClient {
 
     // AUTH before any user command. connect() stays pending (so ensureConnected keeps gating user
     // commands) until AUTH's reply lands; its own command timeout bounds it.
-    if (this.password) await this.write(["AUTH", this.password]);
+    if (password) await this.write(["AUTH", password]);
   }
 
   private ensureConnected(): Promise<void> {
@@ -318,7 +497,9 @@ class RespClient implements ValkeyClient {
     // it rather than silently dropping the trailing element.
     if (reply.length % 2 !== 0)
       throw new RespError(`HGETALL returned an odd-length reply (${reply.length})`);
-    const out: Record<string, Buffer> = {};
+    // Null-prototype object (L4): a hash field literally named `__proto__` must be stored as data,
+    // not silently mutate the result's prototype chain.
+    const out: Record<string, Buffer> = Object.create(null);
     for (let i = 0; i + 1 < reply.length; i += 2) out[reply[i]!.toString("utf8")] = reply[i + 1]!;
     return out;
   }
@@ -344,6 +525,18 @@ class RespClient implements ValkeyClient {
   _write(args: Arg[]): Promise<Reply> {
     return this.write(args);
   }
+}
+
+let warnedPlaintextAuth = false;
+
+/** One-time warning (L6): AUTH and every cached page cross the network unencrypted on redis://. */
+function warnPlaintextAuthOnce(): void {
+  if (warnedPlaintextAuth) return;
+  warnedPlaintextAuth = true;
+  console.warn(
+    "[valkey-cache] a Valkey password is configured over a plaintext redis:// connection — " +
+      "AUTH and all cache content cross the network in cleartext; use rediss:// (TLS) instead",
+  );
 }
 
 class RespMulti implements ValkeyMulti {

--- a/src/pool-server/valkey-cache/stream-codec.ts
+++ b/src/pool-server/valkey-cache/stream-codec.ts
@@ -1,5 +1,54 @@
 import type { CacheEntry } from "./types.js";
 
+// Beyond stream (de)serialization, this module hosts the small shared runtime helpers both
+// cache handlers need: the entry-size cap and the throttled logging used by the fail-open
+// paths. Kept dependency-free (no node imports) so it stays edge-eval-safe like its consumers.
+
+/** Default maximum size of a single cached entry (16 MiB), env-overridable (M6). */
+const DEFAULT_MAX_CACHE_ENTRY_BYTES = 16 * 1024 * 1024;
+
+/**
+ * The configured maximum entry size in bytes. Read from `ADAPTER_K8S_MAX_CACHE_ENTRY_BYTES` at
+ * call time (never at module eval, so importing stays edge-safe and tests can override it);
+ * absent/invalid values fall back to the 16 MiB default. An oversized entry is skipped (a
+ * miss + recompute) rather than buffered unboundedly into memory and Valkey.
+ */
+export function maxCacheEntryBytes(): number {
+  const raw = process.env.ADAPTER_K8S_MAX_CACHE_ENTRY_BYTES;
+  if (raw === undefined || raw === "") return DEFAULT_MAX_CACHE_ENTRY_BYTES;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_MAX_CACHE_ENTRY_BYTES;
+  return Math.floor(parsed);
+}
+
+const warnedKeys = new Set<string>();
+
+/**
+ * `console.warn` at most once per process per `key`. For persistent misconfigurations (e.g. a
+ * non-finite cache lifetime from a caller) where per-request logging would spam.
+ */
+export function warnOnce(key: string, message: string): void {
+  if (warnedKeys.has(key)) return;
+  warnedKeys.add(key);
+  console.warn(message);
+}
+
+const RATE_LIMIT_MS = 60_000;
+const lastErrorAt = new Map<string, number>();
+
+/**
+ * `console.error` at most once per 60s per failure class (M1). The handlers' invalidation and
+ * freshness paths fail open by design — a missed revalidation must not crash a render — but a
+ * Valkey outage there must still be OBSERVABLE without emitting one log line per request.
+ */
+export function logErrorRateLimited(failureClass: string, message: string, error: unknown): void {
+  const now = Date.now();
+  const last = lastErrorAt.get(failureClass);
+  if (last !== undefined && now - last < RATE_LIMIT_MS) return;
+  lastErrorAt.set(failureClass, now);
+  console.error(message, error);
+}
+
 /**
  * Drain a cache entry's value stream to a Buffer for storage, WITHOUT consuming the copy
  * Next still needs for the in-flight response. Mirrors Next's own handlers (`default.js`,
@@ -7,18 +56,37 @@ import type { CacheEntry } from "./types.js";
  * (so the caller's read still works) and drain the other.
  *
  * Returns `null` if the stream errors or delivers partially — a partial entry must be
- * discarded (treated as a miss), never cached.
+ * discarded (treated as a miss), never cached. Also returns `null` when the accumulated body
+ * exceeds `maxBytes` (M6): an over-cap entry degrades to a miss exactly like a partial
+ * stream, and aborting the drain early bounds memory instead of buffering an unbounded
+ * stream first and rejecting it after.
  */
-export async function drainEntryValue(entry: CacheEntry): Promise<Buffer | null> {
+export async function drainEntryValue(
+  entry: CacheEntry,
+  maxBytes: number = maxCacheEntryBytes(),
+): Promise<Buffer | null> {
   const [ours, theirs] = entry.value.tee();
   entry.value = theirs;
   try {
     const reader = ours.getReader();
     const chunks: Buffer[] = [];
+    let total = 0;
     for (;;) {
       const { done, value } = await reader.read();
       if (done) break;
-      if (value) chunks.push(Buffer.from(value));
+      if (value) {
+        total += value.byteLength;
+        if (total > maxBytes) {
+          // Stop pulling immediately so an over-cap stream can't grow memory without bound.
+          await reader.cancel().catch(() => undefined);
+          warnOnce(
+            "oversize-entry",
+            `[valkey-cache] a cache entry exceeded ADAPTER_K8S_MAX_CACHE_ENTRY_BYTES (${maxBytes} bytes); it was not cached (further occurrences logged once per process)`,
+          );
+          return null;
+        }
+        chunks.push(Buffer.from(value));
+      }
     }
     return Buffer.concat(chunks);
   } catch {

--- a/src/pool-server/valkey-cache/tag-manifest.ts
+++ b/src/pool-server/valkey-cache/tag-manifest.ts
@@ -17,24 +17,38 @@
 /**
  * Atomic last-event-wins merge for the shared tag manifest, used by both the V2 and the classic
  * incremental handlers. ARGV is `[field, json, field, json, …]`; each field is overwritten only
- * when the incoming `at` (event time) is `>=` the stored one, so a concurrent older revalidation
- * from another replica can't clobber a newer one. Runs atomically (Redis/Valkey execute a script
- * to completion without interleaving).
+ * when the incoming event is `>=` the stored one, so a concurrent older revalidation from
+ * another replica can't clobber a newer one. Runs atomically (Redis/Valkey execute a script to
+ * completion without interleaving).
+ *
+ * The merge clock is the VALKEY SERVER's (`TIME`), not the client-supplied `at`: replicas'
+ * clocks skew, and a backward-stepping replica would otherwise stamp an older `at` on a newer
+ * event and have its invalidation silently dropped by the merge. The script rewrites the
+ * incoming state's `at` to the server time before comparing/storing, so "last event" means
+ * "last to reach the server" — a single monotonic clock for ordering. The `stale`/`expired`
+ * watermarks stay client-computed: they are compared against entry timestamps, which are
+ * themselves client clocks. The client still sends its own `at` (see `computeTagUpdate`) as a
+ * fallback for any path where the script can't run its rewrite.
  */
 export const UPDATE_TAGS_SCRIPT = `
+local t = redis.call('TIME')
+local now = t[1] * 1000 + math.floor(t[2] / 1000)
 local i = 1
 while i <= #ARGV do
   local field = ARGV[i]
   local incoming = ARGV[i + 1]
   local existing = redis.call('HGET', KEYS[1], field)
   local write = true
+  local okNew, nw = pcall(cjson.decode, incoming)
+  if okNew and type(nw) == 'table' then
+    nw.at = now
+    incoming = cjson.encode(nw)
+  end
   if existing then
     local okCur, cur = pcall(cjson.decode, existing)
-    local okNew, nw = pcall(cjson.decode, incoming)
     if okCur and okNew then
       local curAt = tonumber(cur.at) or 0
-      local nwAt = tonumber(nw.at) or 0
-      if nwAt < curAt then write = false end
+      if now < curAt then write = false end
     end
   end
   if write then redis.call('HSET', KEYS[1], field, incoming) end
@@ -52,9 +66,36 @@ export interface TagState {
   /**
    * Event time of the `updateTags` call that produced this state. Used only for the
    * last-event-wins merge across replicas (so a concurrent older revalidation can't clobber a
-   * newer one) — not read by the freshness predicates.
+   * newer one) — not read by the freshness predicates. The Lua merge script rewrites this to
+   * the Valkey SERVER's clock on write; the client-stamped value is only a fallback.
    */
   at?: number;
+}
+
+/**
+ * Parse + sanitize a manifest field read back from Valkey (L5). Corrupt input degrades to
+ * `undefined` (treated as "tag never revalidated" — the same as a missing field); non-finite
+ * numeric watermarks are dropped, and a corrupt/missing `at` becomes 0 so the server-side
+ * merge treats it as older than any real event. Never throws.
+ */
+export function parseTagState(raw: string): TagState | undefined {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return undefined;
+  const s = parsed as Record<string, unknown>;
+  const finite = (x: unknown): number | undefined =>
+    typeof x === "number" && Number.isFinite(x) ? x : undefined;
+  const out: TagState = {};
+  const stale = finite(s.stale);
+  if (stale !== undefined) out.stale = stale;
+  const expired = finite(s.expired);
+  if (expired !== undefined) out.expired = expired;
+  out.at = finite(s.at) ?? 0;
+  return out;
 }
 
 export type TagManifest = ReadonlyMap<string, TagState>;

--- a/src/pool-server/valkey-cache/use-cache-handler.ts
+++ b/src/pool-server/valkey-cache/use-cache-handler.ts
@@ -1,9 +1,18 @@
 import type { ValkeyClient } from "./client.js";
-import { bufferToStream, drainEntryValue } from "./stream-codec.js";
+import { DURABLE_TTL_SECONDS } from "./incremental-cache-handler.js";
+import { RespError } from "./resp-client.js";
+import {
+  bufferToStream,
+  drainEntryValue,
+  logErrorRateLimited,
+  maxCacheEntryBytes,
+  warnOnce,
+} from "./stream-codec.js";
 import {
   computeTagUpdate,
   evaluateEntry,
   maxExpiration,
+  parseTagState,
   UPDATE_TAGS_SCRIPT,
   type TagManifest,
   type TagState,
@@ -23,6 +32,31 @@ interface StoredMeta {
 const RETENTION_MARGIN_SECONDS = 60;
 
 const EMPTY_MANIFEST: TagManifest = new Map();
+
+/**
+ * Parse and validate the stored meta field (L5). A corrupt meta — wrong JSON, non-finite
+ * lifetimes, a non-array tag list — degrades to a cache miss, never a synthesized entry.
+ */
+function parseStoredMeta(raw: string): StoredMeta | undefined {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return undefined;
+  const m = parsed as Record<string, unknown>;
+  if (
+    !Number.isFinite(m.timestamp) ||
+    !Number.isFinite(m.expire) ||
+    !Number.isFinite(m.revalidate) ||
+    !Number.isFinite(m.stale)
+  ) {
+    return undefined;
+  }
+  if (!Array.isArray(m.tags) || !m.tags.every((tag) => typeof tag === "string")) return undefined;
+  return m as unknown as StoredMeta;
+}
 
 export interface ValkeyCacheHandlerOptions {
   client: ValkeyClient;
@@ -73,7 +107,12 @@ export class ValkeyCacheHandler implements CacheHandler {
       const data = await this.client.hgetallBuffer(key);
       const metaBuf = data?.m;
       if (!metaBuf) return undefined;
-      const meta = JSON.parse(metaBuf.toString("utf8")) as StoredMeta;
+      // A meta field without its value field is a corrupt/partially-written entry — treat it as
+      // a miss (L5). The old code synthesized an EMPTY body and served it as a valid fresh entry.
+      const valueBuf = data.v;
+      if (!valueBuf) return undefined;
+      const meta = parseStoredMeta(metaBuf.toString("utf8"));
+      if (!meta) return undefined; // corrupt meta → miss, never a fabricated entry (L5)
 
       const now = this.now();
       const manifest = await this.tagStates(meta.tags);
@@ -84,7 +123,7 @@ export class ValkeyCacheHandler implements CacheHandler {
       }
       const revalidate = freshness.state === "stale" ? -1 : freshness.revalidate;
       return {
-        value: bufferToStream(data.v ?? Buffer.alloc(0)),
+        value: bufferToStream(valueBuf),
         tags: meta.tags,
         stale: meta.stale,
         timestamp: meta.timestamp,
@@ -102,10 +141,30 @@ export class ValkeyCacheHandler implements CacheHandler {
       release = resolve;
     });
     this.pendingSets.set(cacheKey, gate);
+    const key = this.entryKey(cacheKey);
+    // Tracks whether the MULTI/EXEC was dispatched: only then can a partially-applied write
+    // exist, and only then is the cleanup DEL warranted (a rejected entry promise must not
+    // delete a still-valid previously cached entry).
+    let writeAttempted = false;
     try {
       const entry = await pendingEntry;
-      const buf = await drainEntryValue(entry);
-      if (buf === null) return; // partial/errored stream → miss, don't cache
+      // H4: a non-finite or non-positive lifetime would produce a NaN/Infinity EXPIRE argument,
+      // which Valkey rejects — while the HSET in the same transaction still applies, leaving the
+      // entry cached FOREVER. Refuse to cache it: an uncacheable entry is a miss + recompute.
+      if (
+        !Number.isFinite(entry.expire) ||
+        !Number.isFinite(entry.revalidate) ||
+        entry.expire <= 0 ||
+        entry.revalidate <= 0
+      ) {
+        warnOnce(
+          "nonfinite-lifetime",
+          "[valkey-cache] refusing to cache a `use cache` entry with a non-finite or non-positive expire/revalidate; treating it as uncacheable",
+        );
+        return;
+      }
+      const buf = await drainEntryValue(entry, maxCacheEntryBytes());
+      if (buf === null) return; // partial/errored/over-cap stream → miss, don't cache
       const meta: StoredMeta = {
         tags: entry.tags,
         stale: entry.stale,
@@ -113,15 +172,30 @@ export class ValkeyCacheHandler implements CacheHandler {
         expire: entry.expire,
         revalidate: entry.revalidate,
       };
-      const ttl = Math.max(entry.expire, entry.revalidate, 1) + RETENTION_MARGIN_SECONDS;
-      const key = this.entryKey(cacheKey);
-      await this.client
+      // M7: Next hands INFINITE_CACHE-scale expires (~136 years) to this handler; cap the key
+      // TTL at the same durable bound the incremental handler uses. A cold key is just a miss +
+      // recompute — freshness logic is TTL-independent.
+      const ttl = Math.min(
+        Math.max(entry.expire, entry.revalidate, 1) + RETENTION_MARGIN_SECONDS,
+        DURABLE_TTL_SECONDS,
+      );
+      writeAttempted = true;
+      const results = await this.client
         .multi()
         .hset(key, "m", JSON.stringify(meta), "v", buf)
         .expire(key, Math.ceil(ttl))
         .exec();
+      // H4: MULTI/EXEC is NOT all-or-nothing — a rejected command leaves the others applied
+      // (e.g. HSET succeeds, EXPIRE fails → a TTL-less key cached forever). The EXEC reply
+      // carries per-command errors as elements; inspect them and treat any failure as a failed
+      // write instead of assuming success.
+      const failure = results.find((result): result is RespError => result instanceof RespError);
+      if (failure) throw failure;
     } catch {
-      // A cache write failure must not break the response.
+      // A cache write failure must not break the response. If the write may have partially
+      // applied, best-effort DEL the key so a TTL-less partial entry can't live forever (the DEL
+      // itself may fail during an outage — bounded by the build-namespaced keyspace's lifetime).
+      if (writeAttempted) this.client.del(key).catch(() => undefined);
     } finally {
       // Only clear the gate if it's still ours — an overlapping `set` may have replaced it, and
       // deleting a newer set's gate would let a concurrent `get` skip the required wait.
@@ -144,8 +218,18 @@ export class ValkeyCacheHandler implements CacheHandler {
     try {
       const manifest = await this.tagStates(tags);
       return maxExpiration(tags, manifest);
-    } catch {
-      return 0;
+    } catch (error) {
+      // L3: fail STALE, not fresh. Returning 0 ("never invalidated") would let revalidated
+      // entries keep serving during a transient manifest outage; returning the current time
+      // (`this.now()` — `Date.now` by default) makes Next treat affected entries as invalidated
+      // and regenerate, the same safe direction as `get` degrading to a miss. Logged
+      // (rate-limited) so the outage is observable without per-request log spam.
+      logErrorRateLimited(
+        "getExpiration",
+        "[valkey-cache] getExpiration failed to read the tag manifest; treating entries as stale",
+        error,
+      );
+      return this.now();
     }
   }
 
@@ -154,18 +238,25 @@ export class ValkeyCacheHandler implements CacheHandler {
     try {
       const now = this.now();
       // Apply each tag's new state atomically with LAST-EVENT-WINS semantics: the server-side
-      // script only overwrites a field when the incoming `at` (event time) is >= the stored one.
-      // This eliminates the read-modify-write race where two replicas revalidating the same tag
-      // interleave and an older/profiled update clobbers a newer hard-expire (Redis runs the
-      // whole script atomically). Passing `undefined` as the base keeps each event's state
-      // self-contained.
+      // script only overwrites a field when the incoming event (stamped with the server's clock)
+      // is >= the stored one. This eliminates the read-modify-write race where two replicas
+      // revalidating the same tag interleave and an older/profiled update clobbers a newer
+      // hard-expire (Redis runs the whole script atomically). Passing `undefined` as the base
+      // keeps each event's state self-contained.
       const args: string[] = [];
       for (const tag of tags) {
         args.push(tag, JSON.stringify(computeTagUpdate(undefined, now, durations)));
       }
       await this.client.eval(UPDATE_TAGS_SCRIPT, 1, this.tagsKey, ...args);
-    } catch {
-      // Best-effort: a failed manifest write means a revalidation is missed, not a crash.
+    } catch (error) {
+      // Best-effort: a failed manifest write means a revalidation is missed, not a crash — but
+      // it must be OBSERVABLE (M1): a Valkey outage here otherwise silently serves stale entries
+      // indefinitely. Rate-limited so the outage doesn't emit one log line per request.
+      logErrorRateLimited(
+        "updateTags",
+        "[valkey-cache] updateTags failed to write the shared tag manifest; invalidation may be lost",
+        error,
+      );
     }
   }
 
@@ -181,11 +272,9 @@ export class ValkeyCacheHandler implements CacheHandler {
     tags.forEach((tag, i) => {
       const raw = values[i];
       if (raw) {
-        try {
-          manifest.set(tag, JSON.parse(raw) as TagState);
-        } catch {
-          // ignore corrupt field
-        }
+        // Corrupt fields degrade to "no state" (a corrupt `at` becomes 0); never throw (L5).
+        const state = parseTagState(raw);
+        if (state) manifest.set(tag, state);
       }
     });
     return manifest;

--- a/src/routing-service/index.ts
+++ b/src/routing-service/index.ts
@@ -1,9 +1,58 @@
-import { readFileSync, existsSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { readFileSync, existsSync, mkdirSync } from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import type { RoutingManifest } from "../types.js";
 import { createRequestHandler } from "./handler.js";
 import { createRoutingServer, startHealthServer } from "./server.js";
+
+// The TLS identity is generated per-replica at container start, NOT baked into the image at
+// build time (where every replica would share one key and anyone with registry pull could
+// extract it). When TLS_CERT_FILE/TLS_KEY_FILE are configured but absent (the deployment points
+// them at an emptyDir such as /tmp/tls), mint a self-signed pair with openssl. Parent dirs are
+// created so a read-only /app is tolerated. Any failure — openssl missing, unwritable path —
+// falls back to the existing plaintext h2c behavior (emulate parity) instead of crashing.
+function ensureTlsIdentity(): void {
+  const certFile = process.env.TLS_CERT_FILE;
+  const keyFile = process.env.TLS_KEY_FILE;
+  if (!certFile || !keyFile) return;
+  if (existsSync(certFile) && existsSync(keyFile)) return;
+  const release = process.env.RELEASE_NAME ?? "nextjs";
+  const namespace = process.env.NAMESPACE ?? "default";
+  const serviceName = `${release}-routing-service`;
+  try {
+    mkdirSync(path.dirname(certFile), { recursive: true });
+    mkdirSync(path.dirname(keyFile), { recursive: true });
+    // execFileSync with an argv array — never a shell string — so the release/namespace
+    // values can never become command injection.
+    execFileSync(
+      "openssl",
+      [
+        "req",
+        "-x509",
+        "-newkey",
+        "rsa:2048",
+        "-nodes",
+        "-keyout",
+        keyFile,
+        "-out",
+        certFile,
+        "-days",
+        "3650",
+        "-subj",
+        `/CN=${serviceName}`,
+        "-addext",
+        `subjectAltName=DNS:${serviceName}.${namespace}.svc.cluster.local`,
+      ],
+      { stdio: ["ignore", "ignore", "pipe"] },
+    );
+    console.log(`Routing service: generated self-signed TLS identity at ${certFile}`);
+  } catch (err) {
+    console.warn(
+      `Routing service: could not generate TLS identity (${err instanceof Error ? err.message : String(err)}); falling back to plaintext h2c`,
+    );
+  }
+}
 
 async function main() {
   // Load .env files
@@ -58,8 +107,11 @@ async function main() {
   // under GCP's 5s callout timeout). Set 0 to disable.
   const timeoutMs = parseInt(process.env.ROUTING_REQUEST_TIMEOUT_MS ?? "4000", 10);
 
-  // Create handler and server
+  // Create handler and server. Mint the TLS identity first so createRoutingServer sees the
+  // cert files (or their deliberate absence, after a generation failure) when it picks its
+  // transport.
   const handler = createRequestHandler(manifest, middlewareModule);
+  ensureTlsIdentity();
   const server = createRoutingServer({ handler, port, failOpen, timeoutMs });
 
   await server.start();

--- a/src/routing-service/server.ts
+++ b/src/routing-service/server.ts
@@ -207,14 +207,17 @@ export function createRoutingServer(options: RoutingServerOptions) {
   // GCP ext_proc callouts require HTTP/2 over TLS on the data path (the gRPC health
   // check can be plaintext, which is why an h2c server looks HEALTHY but the callout
   // silently fails). Serve TLS when a cert is provided; fall back to plaintext h2c
-  // (emulate / local) otherwise.
+  // (emulate / local) otherwise. allowHTTP1 stays OFF on the TLS server: the ext_proc
+  // data path is HTTP/2-only and health checks run on the separate plaintext HTTP
+  // server, so HTTP/1.1 would be pure attack surface (it lets any Connect-protocol
+  // client speak to the service trivially).
   const certFile = process.env.TLS_CERT_FILE;
   const keyFile = process.env.TLS_KEY_FILE;
   const useTls = !!(certFile && keyFile && existsSync(certFile) && existsSync(keyFile));
   const nodeHandler = connectNodeAdapter({ routes });
   const server: Http2Server = useTls
     ? createSecureServer(
-        { cert: readFileSync(certFile!), key: readFileSync(keyFile!), allowHTTP1: true },
+        { cert: readFileSync(certFile!), key: readFileSync(keyFile!), allowHTTP1: false },
         nodeHandler,
       )
     : createServer(nodeHandler);

--- a/src/types.ts
+++ b/src/types.ts
@@ -66,7 +66,20 @@ export interface K8sAdapterConfig {
      * The instance's discovery endpoint + AUTH are injected into the pods as `VALKEY_URL` /
      * `VALKEY_AUTH`. This shape firms up alongside the provisioning step.
      */
-    memorystore?: { region?: string; sizeGb?: number; tier?: "BASIC" | "STANDARD_HA" };
+    memorystore?: {
+      region?: string;
+      sizeGb?: number;
+      tier?: "BASIC" | "STANDARD_HA";
+      /**
+       * Enable Redis AUTH + in-transit encryption (SERVER_AUTHENTICATION) on the managed
+       * instance. The pods then connect over `rediss://` with the instance AUTH string and
+       * server CA injected as `VALKEY_AUTH` / `VALKEY_CA_CERT`. Recommended — without it any
+       * workload that can reach the VPC endpoint can read/write the shared cache. NOTE: AUTH
+       * can only be set at instance creation; an existing non-AUTH instance must be recreated
+       * (`destroy` removes it) before enabling.
+       */
+      auth?: boolean;
+    };
   };
   containerStrategy?: "traced-assets" | "shared-image";
   imageOptimizer?: { enabled: boolean; mode: "sidecar" };

--- a/tests/adapter-config.test.ts
+++ b/tests/adapter-config.test.ts
@@ -33,3 +33,41 @@ describe("createK8sAdapter config normalization", () => {
     expect((adapter as any).config.provider.gke.cdn.enabled).toBe(false);
   });
 });
+
+describe("buildId validation at build time (H2)", () => {
+  // The finalized buildId flows into helm --set values, K8s names/labels, image tags and
+  // chart YAML — an unsafe one (e.g. a git branch from a custom generateBuildId) must
+  // fail the build at the source, before any artifact is emitted.
+  it.each([
+    ['feature/foo";rm', "YAML/shell breakout"],
+    ["foo,bar=baz", "helm --set metacharacters"],
+    ["foo\\bar", "helm --set escape char"],
+    ["line1\nline2", "newline"],
+  ])("rejects an unsafe buildId (%s)", async (buildId) => {
+    const adapter = createK8sAdapter(validConfig);
+    await expect(
+      adapter.onBuildComplete!({
+        buildId,
+        routing: {},
+        outputs: {},
+        projectDir: "/nonexistent",
+        config: {},
+        nextVersion: "16.2.0",
+      } as any),
+    ).rejects.toThrow(/Invalid buildId/);
+  });
+
+  it("mentions the generateBuildId contract in the error", async () => {
+    const adapter = createK8sAdapter(validConfig);
+    await expect(
+      adapter.onBuildComplete!({
+        buildId: "bad,id",
+        routing: {},
+        outputs: {},
+        projectDir: "/nonexistent",
+        config: {},
+        nextVersion: "16.2.0",
+      } as any),
+    ).rejects.toThrow(/generateBuildId/);
+  });
+});

--- a/tests/cel.test.ts
+++ b/tests/cel.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { generateCelExpression, extractStaticPrefix } from "../src/cel.js";
+import { generateCelExpression, extractStaticPrefix, escapeCelString } from "../src/cel.js";
 import {
   mockOutputs,
   mockStaticFile,
@@ -128,6 +128,17 @@ describe("generateCelExpression", () => {
     expect(cel).toContain("request.path == '/o\\'brien.txt'");
     // No unescaped quote should prematurely close the literal.
     expect(cel).not.toContain("'/o'brien.txt'");
+  });
+
+  it("rejects control characters in pathnames instead of letting them fold in YAML", () => {
+    // The CEL text is embedded in a YAML scalar in route-extension.yaml — a newline in a
+    // public filename would silently fold and corrupt the extension spec. Fail the build.
+    expect(() => escapeCelString("/evil\nfile.txt")).toThrow(/control\/non-ASCII/);
+    expect(() => escapeCelString("/evil\tfile.txt")).toThrow(/control\/non-ASCII/);
+    expect(() => escapeCelString("/café.txt")).toThrow(/control\/non-ASCII/);
+    // Printable ASCII (incl. spaces and quotes) still escapes normally.
+    expect(escapeCelString("/o'brien.txt")).toBe("/o\\'brien.txt");
+    expect(escapeCelString("/my file.txt")).toBe("/my file.txt");
   });
 
   it("returns false when nothing needs ext_proc", () => {

--- a/tests/cli/deploy.test.ts
+++ b/tests/cli/deploy.test.ts
@@ -1,6 +1,15 @@
 // tests/cli/deploy.test.ts
-import { describe, it, expect } from "vitest";
-import { buildDockerCommands, buildHelmUpgradeArgs } from "../../src/cli/deploy.js";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../../src/cli/exec.js");
+
+import * as exec from "../../src/cli/exec.js";
+import {
+  buildDockerCommands,
+  buildHelmUpgradeArgs,
+  assertSafePoolName,
+  discoverClusterPodCidr,
+} from "../../src/cli/deploy.js";
 
 describe("buildDockerCommands", () => {
   it("generates docker build and push commands per pool with auth", () => {
@@ -93,9 +102,152 @@ describe("buildHelmUpgradeArgs", () => {
       chartPath: ".k8s-adapter/output/chart",
       buildId: "new-build",
       registry: "us-central1-docker.pkg.dev/my-project/nextjs",
-      previousBuildId: "123/old",
+      previousBuildId: "123old",
     });
 
-    expect(args.join(" ")).toContain("activeBuildId=b-123-old");
+    expect(args.join(" ")).toContain("activeBuildId=b-123old");
+  });
+});
+
+describe("buildHelmUpgradeArgs — injection guards (H2)", () => {
+  const base = {
+    releaseName: "my-app",
+    chartPath: ".k8s-adapter/output/chart",
+    registry: "us-central1-docker.pkg.dev/my-project/nextjs",
+    previousBuildId: null,
+  };
+
+  it("rejects a buildId containing helm --set metacharacters (comma)", () => {
+    expect(() => buildHelmUpgradeArgs({ ...base, buildId: "abc,evil=1" })).toThrow(
+      /Invalid buildId/,
+    );
+  });
+
+  it("rejects a buildId containing quotes", () => {
+    expect(() => buildHelmUpgradeArgs({ ...base, buildId: 'abc"evil' })).toThrow(/Invalid buildId/);
+    expect(() => buildHelmUpgradeArgs({ ...base, buildId: "abc'evil" })).toThrow(/Invalid buildId/);
+  });
+
+  it("rejects a buildId containing backslashes/braces (helm --set breakouts)", () => {
+    expect(() => buildHelmUpgradeArgs({ ...base, buildId: "abc\\evil" })).toThrow(
+      /Invalid buildId/,
+    );
+    expect(() => buildHelmUpgradeArgs({ ...base, buildId: "abc{evil}" })).toThrow(
+      /Invalid buildId/,
+    );
+  });
+
+  it("rejects an unsafe previousBuildId", () => {
+    expect(() =>
+      buildHelmUpgradeArgs({ ...base, buildId: "ok123", previousBuildId: "abc,injected" }),
+    ).toThrow(/Invalid buildId/);
+    expect(() =>
+      buildHelmUpgradeArgs({ ...base, buildId: "ok123", previousBuildId: "123/old" }),
+    ).toThrow(/Invalid buildId/);
+  });
+
+  it("rejects a registry with a tag or scheme", () => {
+    expect(() =>
+      buildHelmUpgradeArgs({
+        ...base,
+        buildId: "ok123",
+        registry: "us-central1-docker.pkg.dev/my-project/nextjs:tag",
+      }),
+    ).toThrow(/Invalid image registry/);
+    expect(() =>
+      buildHelmUpgradeArgs({ ...base, buildId: "ok123", registry: "https://registry.example.com" }),
+    ).toThrow(/Invalid image registry/);
+  });
+});
+
+describe("buildHelmUpgradeArgs — NetworkPolicy pod CIDRs", () => {
+  const base = {
+    releaseName: "my-app",
+    chartPath: ".k8s-adapter/output/chart",
+    buildId: "abc123",
+    registry: "us-central1-docker.pkg.dev/my-project/nextjs",
+    previousBuildId: null,
+  };
+
+  it("appends the podCidrs helm value as a brace list when provided", () => {
+    const args = buildHelmUpgradeArgs({ ...base, podCidrs: "10.4.0.0/14" });
+    expect(args).toContain("global.networkPolicy.podCidrs={10.4.0.0/14}");
+  });
+
+  it("omits the podCidrs helm value when not discovered", () => {
+    const args = buildHelmUpgradeArgs({ ...base, podCidrs: null });
+    expect(args.join(" ")).not.toContain("networkPolicy.podCidrs");
+    const args2 = buildHelmUpgradeArgs({ ...base });
+    expect(args2.join(" ")).not.toContain("networkPolicy.podCidrs");
+  });
+});
+
+describe("assertSafePoolName (L15)", () => {
+  it("accepts normal pool names", () => {
+    expect(() => assertSafePoolName("default")).not.toThrow();
+    expect(() => assertSafePoolName("web-1")).not.toThrow();
+  });
+
+  it("rejects path-traversal and helm-metacharacter pool names", () => {
+    expect(() => assertSafePoolName("../evil")).toThrow(/Invalid pool name/);
+    expect(() => assertSafePoolName("pool/sub")).toThrow(/Invalid pool name/);
+    expect(() => assertSafePoolName("pool,evil")).toThrow(/Invalid pool name/);
+    expect(() => assertSafePoolName("Pool")).toThrow(/Invalid pool name/);
+    expect(() => assertSafePoolName("")).toThrow(/Invalid pool name/);
+  });
+});
+
+describe("discoverClusterPodCidr (fail-closed NetworkPolicy discovery)", () => {
+  beforeEach(() => {
+    vi.mocked(exec.execCapture).mockReset();
+  });
+
+  const OPTS = { clusterName: "my-app-cluster", region: "us-central1", projectId: "proj" };
+
+  it("returns the discovered CIDR", async () => {
+    vi.mocked(exec.execCapture).mockResolvedValue({
+      exitCode: 0,
+      stdout: "10.4.0.0/14\n",
+      stderr: "",
+    });
+    await expect(discoverClusterPodCidr(OPTS)).resolves.toBe("10.4.0.0/14");
+    const args = vi.mocked(exec.execCapture).mock.calls[0]?.[1];
+    expect(args).toContain("--format=value(clusterIpv4Cidr)");
+  });
+
+  it("throws when gcloud errors (no silent fail-open)", async () => {
+    vi.mocked(exec.execCapture).mockResolvedValue({
+      exitCode: 1,
+      stdout: "",
+      stderr: "forbidden",
+    });
+    await expect(discoverClusterPodCidr(OPTS)).rejects.toThrow(
+      /refusing to deploy without network isolation/,
+    );
+  });
+
+  it("throws on empty output", async () => {
+    vi.mocked(exec.execCapture).mockResolvedValue({ exitCode: 0, stdout: "\n", stderr: "" });
+    await expect(discoverClusterPodCidr(OPTS)).rejects.toThrow(/empty output/);
+  });
+
+  it("throws on malformed output (would corrupt the helm list otherwise)", async () => {
+    vi.mocked(exec.execCapture).mockResolvedValue({
+      exitCode: 0,
+      stdout: "10.4.0.0/14\nSET LEGACY\n",
+      stderr: "",
+    });
+    await expect(discoverClusterPodCidr(OPTS)).rejects.toThrow(/unexpected value/);
+  });
+
+  it("--allow-no-network-policy opts out: warns and returns null", async () => {
+    vi.mocked(exec.execCapture).mockResolvedValue({
+      exitCode: 1,
+      stdout: "",
+      stderr: "forbidden",
+    });
+    await expect(
+      discoverClusterPodCidr({ ...OPTS, allowNoNetworkPolicy: true }),
+    ).resolves.toBeNull();
   });
 });

--- a/tests/cli/destroy.test.ts
+++ b/tests/cli/destroy.test.ts
@@ -1,6 +1,28 @@
 // tests/cli/destroy.test.ts
-import { describe, it, expect } from "vitest";
-import { buildReleaseScopedGcpResources, isAlreadyGoneError } from "../../src/cli/destroy.js";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  buildReleaseScopedGcpResources,
+  isAlreadyGoneError,
+  runDestroy,
+} from "../../src/cli/destroy.js";
+import { deployExtRoleId } from "../../src/cli/init.js";
+import * as exec from "../../src/cli/exec.js";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+vi.mock("../../src/cli/exec.js");
+
+// L12: control what the interactive prompt "types" per test.
+const mockAnswer = vi.hoisted(() => ({ value: "" }));
+vi.mock("node:readline", () => ({
+  default: {
+    createInterface: () => ({
+      question: (_question: string, cb: (answer: string) => void) => cb(mockAnswer.value),
+      close: () => {},
+    }),
+  },
+}));
 
 describe("isAlreadyGoneError", () => {
   it("treats genuine not-found errors as already deleted", () => {
@@ -31,5 +53,165 @@ describe("buildReleaseScopedGcpResources", () => {
 
     expect(healthCheck?.args).toContain("my-app-routing-hc");
     expect(healthCheck?.args).not.toContain("my-app-routing-tcp");
+  });
+
+  it("M9: deletes the release-scoped custom IAM role created by init", () => {
+    const resources = buildReleaseScopedGcpResources("my-app", "my-project");
+    const role = resources.find((resource) => resource.desc.includes("custom IAM role"));
+
+    expect(role).toBeDefined();
+    expect(role!.args).toEqual([
+      "iam",
+      "roles",
+      "delete",
+      deployExtRoleId("my-app"),
+      "--project=my-project",
+      "--quiet",
+    ]);
+  });
+});
+
+describe("runDestroy — confirmation gate (L12)", () => {
+  let tmpDir: string;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  const INFRA = {
+    projectId: "deploy-project",
+    region: "us-central1",
+    gcsBucket: "deploy-project-nextjs-static",
+  };
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(path.join(os.tmpdir(), "adapter-k8s-destroy-test-"));
+    mkdirSync(path.join(tmpDir, ".k8s-adapter"), { recursive: true });
+    writeFileSync(path.join(tmpDir, ".k8s-adapter", "infrastructure.json"), JSON.stringify(INFRA));
+    vi.clearAllMocks();
+    vi.mocked(exec.execCapture).mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function printedOutput(): string {
+    return [...logSpy.mock.calls, ...warnSpy.mock.calls].map((c) => String(c[0])).join("\n");
+  }
+
+  it("refuses to destroy non-interactively without --yes", async () => {
+    // vitest runs with a non-TTY stdin
+    await expect(runDestroy({ projectDir: tmpDir, releaseName: "my-app" })).rejects.toThrow(
+      /--yes/,
+    );
+
+    // Nothing may have been deleted.
+    const calls = vi.mocked(exec.execCapture).mock.calls.map(([, args]) => args.join(" "));
+    expect(
+      calls.some((a) => a.includes("uninstall") || a.includes("delete") || a.includes("rm")),
+    ).toBe(false);
+  });
+
+  it("--yes skips the prompt and deletes", async () => {
+    await runDestroy({ projectDir: tmpDir, releaseName: "my-app", yes: true });
+
+    const calls = vi.mocked(exec.execCapture).mock.calls;
+    // helm is called via execCapture with ["uninstall", "my-app"]
+    expect(calls.some(([cmd, args]) => cmd === "helm" && args.includes("uninstall"))).toBe(true);
+    // custom role delete included
+    expect(calls.some(([, args]) => args.join(" ").includes("iam roles delete"))).toBe(true);
+  });
+
+  it("prompts for the release name on a TTY and proceeds on a match", async () => {
+    Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+    mockAnswer.value = "my-app";
+    try {
+      await runDestroy({ projectDir: tmpDir, releaseName: "my-app" });
+    } finally {
+      Object.defineProperty(process.stdin, "isTTY", { value: undefined, configurable: true });
+    }
+    expect(
+      vi
+        .mocked(exec.execCapture)
+        .mock.calls.some(([cmd, args]) => cmd === "helm" && args.includes("uninstall")),
+    ).toBe(true);
+  });
+
+  it("prompts on a TTY and aborts on a mismatch without deleting anything", async () => {
+    Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+    mockAnswer.value = "not-the-release";
+    try {
+      await expect(runDestroy({ projectDir: tmpDir, releaseName: "my-app" })).rejects.toThrow(
+        /aborted/,
+      );
+    } finally {
+      Object.defineProperty(process.stdin, "isTTY", { value: undefined, configurable: true });
+    }
+    const calls = vi.mocked(exec.execCapture).mock.calls.map(([, args]) => args.join(" "));
+    expect(
+      calls.some((a) => a.includes("uninstall") || a.includes("delete") || a.includes("rm ")),
+    ).toBe(false);
+  });
+
+  it("prints the target project prominently and warns on gcloud project mismatch", async () => {
+    vi.mocked(exec.execCapture).mockImplementation(async (_cmd, args) => {
+      if (args.includes("config") && args.includes("get-value")) {
+        return { exitCode: 0, stdout: "other-project\n", stderr: "" };
+      }
+      return { exitCode: 0, stdout: "", stderr: "" };
+    });
+
+    await runDestroy({ projectDir: tmpDir, releaseName: "my-app", yes: true });
+
+    const out = printedOutput();
+    expect(out).toContain("Target GCP project: deploy-project");
+    expect(out).toContain("WARNING");
+    expect(out).toContain("other-project");
+  });
+
+  it("tolerates gcloud config failure (no warning, destroy proceeds)", async () => {
+    vi.mocked(exec.execCapture).mockImplementation(async (_cmd, args) => {
+      if (args.includes("config") && args.includes("get-value")) {
+        return { exitCode: 1, stdout: "", stderr: "gcloud broken" };
+      }
+      return { exitCode: 0, stdout: "", stderr: "" };
+    });
+
+    await runDestroy({ projectDir: tmpDir, releaseName: "my-app", yes: true });
+    expect(printedOutput()).not.toContain("WARNING");
+    expect(
+      vi
+        .mocked(exec.execCapture)
+        .mock.calls.some(([cmd, args]) => cmd === "helm" && args.includes("uninstall")),
+    ).toBe(true);
+  });
+
+  it("dry-run enumerates every planned deletion and executes nothing", async () => {
+    await runDestroy({ projectDir: tmpDir, releaseName: "my-app", dryRun: true });
+
+    // Absolutely nothing executed — not even the gcloud config check.
+    expect(vi.mocked(exec.execCapture)).not.toHaveBeenCalled();
+
+    const out = printedOutput();
+    expect(out).toContain("[dry-run] helm uninstall my-app");
+    expect(out).toContain(
+      "[dry-run] gcloud storage rm -r gs://deploy-project-nextjs-static --quiet",
+    );
+    expect(out).toContain("[dry-run] gcloud iam service-accounts delete");
+    expect(out).toContain("[dry-run] gcloud service-extensions lb-traffic-extensions delete");
+    expect(out).toContain("[dry-run] gcloud compute backend-services delete");
+    expect(out).toContain("[dry-run] gcloud compute health-checks delete");
+    expect(out).toContain("[dry-run] gcloud compute addresses delete");
+    expect(out).toContain(`[dry-run] gcloud iam roles delete ${deployExtRoleId("my-app")}`);
+  });
+
+  it("dry-run skips the confirmation gate entirely", async () => {
+    // No --yes, non-TTY — must still succeed because dry-run deletes nothing.
+    await expect(
+      runDestroy({ projectDir: tmpDir, releaseName: "my-app", dryRun: true }),
+    ).resolves.toBeUndefined();
   });
 });

--- a/tests/cli/exec.test.ts
+++ b/tests/cli/exec.test.ts
@@ -1,6 +1,9 @@
 // tests/cli/exec.test.ts
-import { describe, it, expect } from "vitest";
-import { exec, execCapture } from "../../src/cli/exec.js";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { exec, execCapture, resolveWindowsCommand } from "../../src/cli/exec.js";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import path from "node:path";
+import os from "node:os";
 
 describe("exec", () => {
   it("runs a command and returns exit code 0 on success", async () => {
@@ -25,5 +28,83 @@ describe("execCapture", () => {
     const result = await execCapture("node", ["-e", 'console.error("oops"); process.exit(1)']);
     expect(result.stderr.trim()).toBe("oops");
     expect(result.exitCode).toBe(1);
+  });
+
+  it("does not route args through a shell (metacharacters are literal)", async () => {
+    // With shell:true this would spawn `q` / print env vars; with shell:false echo
+    // receives the string verbatim.
+    const result = await execCapture("echo", ["a;b&c|d>e$F `g` $(h)"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBe("a;b&c|d>e$F `g` $(h)");
+  });
+});
+
+// M2: on Windows the executable is resolved on PATH (.cmd/.exe/.bat shims) and spawned
+// with shell:false instead of routing every arg through cmd.exe.
+describe("resolveWindowsCommand", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(path.join(os.tmpdir(), "adapter-k8s-exec-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function touch(rel: string): void {
+    const full = path.join(tmpDir, rel);
+    mkdirSync(path.dirname(full), { recursive: true });
+    writeFileSync(full, "@echo off\r\n");
+  }
+
+  it("resolves a .cmd shim on PATH", () => {
+    touch("bin/gcloud.cmd");
+    const resolved = resolveWindowsCommand("gcloud", path.join(tmpDir, "bin"));
+    expect(resolved).toBe(path.join(tmpDir, "bin", "gcloud.cmd"));
+  });
+
+  it("prefers .cmd over .exe over .bat over the bare name", () => {
+    touch("bin/tool.cmd");
+    touch("bin/tool.exe");
+    touch("bin/tool.bat");
+    touch("bin/tool");
+    expect(resolveWindowsCommand("tool", path.join(tmpDir, "bin"))).toBe(
+      path.join(tmpDir, "bin", "tool.cmd"),
+    );
+
+    rmSync(path.join(tmpDir, "bin", "tool.cmd"));
+    expect(resolveWindowsCommand("tool", path.join(tmpDir, "bin"))).toBe(
+      path.join(tmpDir, "bin", "tool.exe"),
+    );
+
+    rmSync(path.join(tmpDir, "bin", "tool.exe"));
+    expect(resolveWindowsCommand("tool", path.join(tmpDir, "bin"))).toBe(
+      path.join(tmpDir, "bin", "tool.bat"),
+    );
+
+    rmSync(path.join(tmpDir, "bin", "tool.bat"));
+    expect(resolveWindowsCommand("tool", path.join(tmpDir, "bin"))).toBe(
+      path.join(tmpDir, "bin", "tool"),
+    );
+  });
+
+  it("searches PATH entries in order (semicolon-separated)", () => {
+    touch("first/tool.exe");
+    touch("second/tool.cmd");
+    const pathEnv = `${path.join(tmpDir, "first")};${path.join(tmpDir, "second")}`;
+    expect(resolveWindowsCommand("tool", pathEnv)).toBe(path.join(tmpDir, "first", "tool.exe"));
+  });
+
+  it("skips empty PATH entries", () => {
+    touch("bin/tool.cmd");
+    const resolved = resolveWindowsCommand("tool", `;;${path.join(tmpDir, "bin")};`);
+    expect(resolved).toBe(path.join(tmpDir, "bin", "tool.cmd"));
+  });
+
+  it("returns the bare command when not found on PATH", () => {
+    expect(resolveWindowsCommand("definitely-missing-tool", tmpDir)).toBe(
+      "definitely-missing-tool",
+    );
   });
 });

--- a/tests/cli/init.test.ts
+++ b/tests/cli/init.test.ts
@@ -1,14 +1,28 @@
 // tests/cli/init.test.ts
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { buildInitGcloudCommands, runInit } from "../../src/cli/init.js";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  buildInitGcloudCommands,
+  runInit,
+  deployExtRoleId,
+  DEPLOY_EXT_ROLE_PERMISSIONS,
+} from "../../src/cli/init.js";
 import * as exec from "../../src/cli/exec.js";
 import * as scaffold from "../../src/cli/scaffold.js";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import os from "node:os";
 
 vi.mock("../../src/cli/exec.js");
 vi.mock("../../src/cli/scaffold.js");
+
+const VALID = {
+  projectId: "my-project",
+  region: "us-central1",
+  hosts: ["app.example.com"],
+  bucket: "my-project-nextjs-static",
+  registry: "us-central1-docker.pkg.dev/my-project/nextjs",
+  releaseName: "my-app",
+};
 
 describe("buildInitGcloudCommands", () => {
   it("generates correct gcloud commands for infrastructure", () => {
@@ -72,6 +86,87 @@ describe("buildInitGcloudCommands", () => {
     const routeExtCmd = commands.find((c) => c.description.includes("LbRouteExtension"));
     expect(routeExtCmd).toBeUndefined();
   });
+
+  it("M9: grants Artifact Registry writer at REPOSITORY scope, not project scope", () => {
+    const commands = buildInitGcloudCommands({
+      projectId: "my-project",
+      region: "us-central1",
+      bucket: "my-project-nextjs-static",
+      releaseName: "my-app",
+    });
+
+    const writerGrants = commands.filter((c) => c.args.includes("roles/artifactregistry.writer"));
+    expect(writerGrants).toHaveLength(1);
+    // Repository-scoped binding (mirrors the repoAdmin pattern), not `projects add-iam-policy-binding`.
+    expect(writerGrants[0]!.args).toContain("repositories");
+    expect(writerGrants[0]!.args).toContain("add-iam-policy-binding");
+    expect(writerGrants[0]!.args).toContain("nextjs");
+    expect(writerGrants[0]!.args).not.toContain("projects");
+  });
+
+  it("M9: binds the release-scoped custom role instead of the broad admin roles", () => {
+    const commands = buildInitGcloudCommands({
+      projectId: "my-project",
+      region: "us-central1",
+      bucket: "my-project-nextjs-static",
+      releaseName: "my-app",
+    });
+    const flat = commands.map((c) => c.args.join(" ")).join("\n");
+
+    expect(flat).not.toContain("roles/networkservices.admin");
+    expect(flat).not.toContain("roles/compute.loadBalancerAdmin");
+
+    const customBinding = commands.find((c) =>
+      c.args.some((a) => a.includes(`projects/my-project/roles/${deployExtRoleId("my-app")}`)),
+    );
+    expect(customBinding).toBeDefined();
+    expect(customBinding!.args).toContain("add-iam-policy-binding");
+  });
+
+  it("NetworkPolicy: Autopilot clusters never get --enable-network-policy (it is rejected)", () => {
+    const commands = buildInitGcloudCommands({
+      projectId: "my-project",
+      region: "us-central1",
+      bucket: "my-project-nextjs-static",
+      releaseName: "my-app",
+    });
+    const clusterCmd = commands.find((c) => c.args.includes("clusters"));
+    expect(clusterCmd!.args).toContain("create-auto");
+    expect(clusterCmd!.args).not.toContain("--enable-network-policy");
+  });
+
+  it("NetworkPolicy: Standard clusters are created with --enable-network-policy", () => {
+    const commands = buildInitGcloudCommands({
+      projectId: "my-project",
+      region: "us-central1",
+      bucket: "my-project-nextjs-static",
+      releaseName: "my-app",
+      autopilot: false,
+    });
+    const clusterCmd = commands.find((c) => c.args.includes("clusters"));
+    expect(clusterCmd!.args).toContain("create");
+    expect(clusterCmd!.args).not.toContain("create-auto");
+    expect(clusterCmd!.args).toContain("--enable-network-policy");
+  });
+});
+
+describe("deployExtRoleId", () => {
+  it("derives a hyphen-free role id from the release name", () => {
+    expect(deployExtRoleId("my-app")).toBe("nextjs_deploy_ext_my_app");
+  });
+
+  it("matches the GCP custom-role id charset and length limits", () => {
+    for (const name of ["a", "my-app", "x".repeat(40)]) {
+      expect(deployExtRoleId(name)).toMatch(/^[a-zA-Z0-9_]{3,64}$/);
+    }
+  });
+
+  it("covers exactly the permissions the traffic-extension Job needs", () => {
+    expect(DEPLOY_EXT_ROLE_PERMISSIONS).toContain("networkservices.lbTrafficExtensions.create");
+    expect(DEPLOY_EXT_ROLE_PERMISSIONS).toContain("networkservices.lbTrafficExtensions.update");
+    expect(DEPLOY_EXT_ROLE_PERMISSIONS).toContain("compute.backendServices.update");
+    expect(DEPLOY_EXT_ROLE_PERMISSIONS).toContain("compute.forwardingRules.list");
+  });
 });
 
 describe("runInit", () => {
@@ -80,48 +175,165 @@ describe("runInit", () => {
   beforeEach(() => {
     tmpDir = mkdtempSync(path.join(os.tmpdir(), "adapter-k8s-init-test-"));
     vi.clearAllMocks();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
   });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function mockScaffold(): void {
+    vi.spyOn(scaffold, "generateAdapterConfig").mockReturnValue("config");
+    vi.spyOn(scaffold, "generateInfrastructureJson").mockReturnValue("infra");
+  }
 
   it("retries on IAM binding failure and handles already exists", async () => {
     const execCapture = vi.spyOn(exec, "execCapture");
-    const generateAdapterConfig = vi
-      .spyOn(scaffold, "generateAdapterConfig")
-      .mockReturnValue("config");
-    const generateInfrastructureJson = vi
-      .spyOn(scaffold, "generateInfrastructureJson")
-      .mockReturnValue("infra");
+    mockScaffold();
 
-    // Mock: all gcloud commands succeed, except IAM binding (retry) and registry (already exists)
-    // Default to success for all calls
-    execCapture.mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
-
-    // Override specific calls: IAM binding fails first, then succeeds on retry
-    let callCount = 0;
-    execCapture.mockImplementation(async () => {
-      callCount++;
-      // Call 7 = IAM binding (Grant storage admin) — fail first time
-      if (callCount === 7) return { exitCode: 1, stdout: "", stderr: "denied" };
-      // Call 8 = IAM binding retry — succeed
-      // Call 9 = Registry writer — already exists
-      if (callCount === 9) return { exitCode: 1, stdout: "", stderr: "ALREADY_EXISTS" };
+    // Fail the storage-admin binding once (retry then succeeds), and report
+    // ALREADY_EXISTS for the Artifact Registry writer grant.
+    let storageGrantFailed = false;
+    execCapture.mockImplementation(async (_cmd, args) => {
+      if (args.includes("roles/storage.objectAdmin") && !storageGrantFailed) {
+        storageGrantFailed = true;
+        return { exitCode: 1, stdout: "", stderr: "denied" };
+      }
+      if (args.includes("roles/artifactregistry.writer")) {
+        return { exitCode: 1, stdout: "", stderr: "ALREADY_EXISTS" };
+      }
       return { exitCode: 0, stdout: "", stderr: "" };
     });
 
     await runInit({
-      projectId: "p",
-      region: "r",
-      hosts: ["h"],
-      bucket: "b",
-      registry: "reg",
-      releaseName: "rel",
+      ...VALID,
       projectDir: tmpDir,
       iamRetryDelayMs: 0,
     });
 
     // Should have called execCapture for all gcloud commands + DNS auth describe
     expect(execCapture).toHaveBeenCalled();
-    expect(generateAdapterConfig).toHaveBeenCalled();
-    expect(generateInfrastructureJson).toHaveBeenCalled();
-    rmSync(tmpDir, { recursive: true, force: true });
+    expect(scaffold.generateAdapterConfig).toHaveBeenCalled();
+    expect(scaffold.generateInfrastructureJson).toHaveBeenCalled();
+  });
+
+  it("creates the custom traffic-extension role and binds it (never the admin roles)", async () => {
+    const execCapture = vi.spyOn(exec, "execCapture");
+    mockScaffold();
+    execCapture.mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+
+    await runInit({ ...VALID, projectDir: tmpDir, iamRetryDelayMs: 0 });
+
+    const calls = execCapture.mock.calls.map(([, args]) => args);
+    const roleCreate = calls.find((a) => a.includes("roles") && a.includes("create"));
+    expect(roleCreate).toBeDefined();
+    expect(roleCreate!).toContain(deployExtRoleId(VALID.releaseName));
+    for (const perm of DEPLOY_EXT_ROLE_PERMISSIONS) {
+      expect(roleCreate!.join(" ")).toContain(perm);
+    }
+    const flat = calls.map((a) => a.join(" ")).join("\n");
+    expect(flat).not.toContain("roles/networkservices.admin");
+    expect(flat).not.toContain("roles/compute.loadBalancerAdmin");
+  });
+
+  it("updates the custom role when it already exists (idempotent)", async () => {
+    const execCapture = vi.spyOn(exec, "execCapture");
+    mockScaffold();
+    execCapture.mockImplementation(async (_cmd, args) => {
+      if (args.includes("roles") && args.includes("create")) {
+        return { exitCode: 1, stdout: "", stderr: "ALREADY_EXISTS" };
+      }
+      return { exitCode: 0, stdout: "", stderr: "" };
+    });
+
+    await runInit({ ...VALID, projectDir: tmpDir, iamRetryDelayMs: 0 });
+
+    const calls = execCapture.mock.calls.map(([, args]) => args);
+    const roleUpdate = calls.find((a) => a.includes("roles") && a.includes("update"));
+    expect(roleUpdate).toBeDefined();
+    expect(roleUpdate!).toContain(deployExtRoleId(VALID.releaseName));
+    for (const perm of DEPLOY_EXT_ROLE_PERMISSIONS) {
+      expect(roleUpdate!.join(" ")).toContain(perm);
+    }
+  });
+
+  it("fails loudly when the custom role cannot be created (no admin-role fallback)", async () => {
+    const execCapture = vi.spyOn(exec, "execCapture");
+    mockScaffold();
+    execCapture.mockResolvedValue({ exitCode: 1, stdout: "", stderr: "PERMISSION_DENIED" });
+
+    await expect(runInit({ ...VALID, projectDir: tmpDir, iamRetryDelayMs: 0 })).rejects.toThrow(
+      /custom IAM role/,
+    );
+  });
+
+  it("validates operator inputs before running anything (injection guards)", async () => {
+    const execCapture = vi.spyOn(exec, "execCapture");
+    mockScaffold();
+    execCapture.mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+
+    await expect(
+      runInit({ ...VALID, hosts: ["evil'example.com"], projectDir: tmpDir }),
+    ).rejects.toThrow(/Invalid hostname/);
+    await expect(runInit({ ...VALID, bucket: "bad bucket'", projectDir: tmpDir })).rejects.toThrow(
+      /Invalid bucket name/,
+    );
+    await expect(
+      runInit({ ...VALID, registry: "registry.example.com/x:tag", projectDir: tmpDir }),
+    ).rejects.toThrow(/Invalid image registry/);
+    await expect(runInit({ ...VALID, projectId: "BAD", projectDir: tmpDir })).rejects.toThrow(
+      /Invalid projectId/,
+    );
+    await expect(runInit({ ...VALID, region: "us central1", projectDir: tmpDir })).rejects.toThrow(
+      /Invalid region/,
+    );
+
+    // Nothing should have been executed for any of the invalid inputs.
+    expect(execCapture).not.toHaveBeenCalled();
+  });
+
+  it("M4b: scaffolds .gitignore with .k8s-adapter/ and never duplicates it", async () => {
+    const execCapture = vi.spyOn(exec, "execCapture");
+    mockScaffold();
+    execCapture.mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+
+    await runInit({ ...VALID, projectDir: tmpDir, iamRetryDelayMs: 0 });
+    const gitignorePath = path.join(tmpDir, ".gitignore");
+    expect(existsSync(gitignorePath)).toBe(true);
+    expect(readFileSync(gitignorePath, "utf-8")).toContain(".k8s-adapter/");
+
+    // Second run: line must not be duplicated.
+    await runInit({ ...VALID, projectDir: tmpDir, iamRetryDelayMs: 0 });
+    const content = readFileSync(gitignorePath, "utf-8");
+    const occurrences = content.split("\n").filter((l) => l.trim() === ".k8s-adapter/").length;
+    expect(occurrences).toBe(1);
+  });
+
+  it("M4b: appends to an existing .gitignore (adding a trailing newline if needed)", async () => {
+    const execCapture = vi.spyOn(exec, "execCapture");
+    mockScaffold();
+    execCapture.mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+
+    writeFileSync(path.join(tmpDir, ".gitignore"), "node_modules"); // no trailing newline
+    await runInit({ ...VALID, projectDir: tmpDir, iamRetryDelayMs: 0 });
+    const content = readFileSync(path.join(tmpDir, ".gitignore"), "utf-8");
+    expect(content).toBe("node_modules\n.k8s-adapter/\n");
+  });
+
+  it("dry-run prints the role commands without executing them", async () => {
+    const execCapture = vi.spyOn(exec, "execCapture");
+    mockScaffold();
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await runInit({ ...VALID, projectDir: tmpDir, dryRun: true, iamRetryDelayMs: 0 });
+
+    expect(execCapture).not.toHaveBeenCalled();
+    const printed = logSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(printed).toContain("[dry-run] gcloud iam roles create");
+    expect(printed).toContain(deployExtRoleId(VALID.releaseName));
+    // dry-run must not scaffold .gitignore
+    expect(existsSync(path.join(tmpDir, ".gitignore"))).toBe(false);
   });
 });

--- a/tests/cli/provision-cache.test.ts
+++ b/tests/cli/provision-cache.test.ts
@@ -1,6 +1,35 @@
-import { describe, expect, it } from "vitest";
-import { buildDeleteMemorystoreCommand, cacheInstanceName } from "../../src/cli/provision-cache.js";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("../../src/cli/exec.js");
+
+import * as exec from "../../src/cli/exec.js";
+import {
+  buildDeleteMemorystoreCommand,
+  cacheInstanceName,
+  provisionMemorystore,
+} from "../../src/cli/provision-cache.js";
 import { buildReleaseScopedGcpResources } from "../../src/cli/destroy.js";
+
+const OPTS = {
+  projectId: "proj",
+  region: "us-central1",
+  releaseName: "test-app",
+  log: () => {},
+};
+
+// Sequence the gcloud responses a provisioning run makes. The key is matched
+// against the joined args so order doesn't matter.
+function mockGcloud(responses: [match: string, result: exec.ExecCaptureResult][]) {
+  vi.mocked(exec.execCapture).mockImplementation(async (_cmd, args) => {
+    const joined = args.join(" ");
+    for (const [match, result] of responses) {
+      if (joined.includes(match)) return result;
+    }
+    return { exitCode: 1, stdout: "", stderr: `unmocked gcloud call: ${joined}` };
+  });
+}
+
+const ok = (stdout = ""): exec.ExecCaptureResult => ({ exitCode: 0, stdout, stderr: "" });
 
 describe("cacheInstanceName", () => {
   it("derives a deterministic per-release instance name", () => {
@@ -38,5 +67,96 @@ describe("buildReleaseScopedGcpResources (cache teardown)", () => {
     expect(cache).toBeDefined();
     expect(cache?.args).toContain("my-app-cache");
     expect(cache?.args).toContain("--region=us-central1");
+  });
+});
+
+describe("provisionMemorystore with AUTH + in-transit encryption", () => {
+  beforeEach(() => {
+    vi.mocked(exec.execCapture).mockReset();
+  });
+
+  it("creates the instance with AUTH + SERVER_AUTHENTICATION and returns authString + CA", async () => {
+    // describeInstance is called twice with the same args: not-found first (create
+    // path), then READY (waitForReady). Track calls to sequence the two answers.
+    let describes = 0;
+    vi.mocked(exec.execCapture).mockImplementation(async (_cmd, args) => {
+      const joined = args.join(" ");
+      if (joined.includes("--format=value(state,host,port)")) {
+        describes += 1;
+        return describes === 1
+          ? { exitCode: 1, stdout: "", stderr: "not found" }
+          : ok("READY 10.0.0.1 6379");
+      }
+      if (joined.includes("get-auth-string")) return ok("s3cr3t-auth\n");
+      if (joined.includes("--format=json(serverCaCerts)")) {
+        return ok(
+          JSON.stringify({ serverCaCerts: [{ cert: "-----BEGIN CERTIFICATE-----\nCA\n" }] }),
+        );
+      }
+      return ok();
+    });
+    const endpoint = await provisionMemorystore({ ...OPTS, auth: true });
+    expect(endpoint).toEqual({
+      host: "10.0.0.1",
+      port: 6379,
+      authString: "s3cr3t-auth",
+      caCert: "-----BEGIN CERTIFICATE-----\nCA\n",
+    });
+    const createCall = vi
+      .mocked(exec.execCapture)
+      .mock.calls.find(([, args]) => args.includes("create"));
+    expect(createCall?.[1]).toContain("--auth-enabled");
+    expect(createCall?.[1]).toContain("--transit-encryption-mode");
+    expect(createCall?.[1]).toContain("SERVER_AUTHENTICATION");
+  });
+
+  it("omits AUTH flags when auth is not requested", async () => {
+    let describes = 0;
+    vi.mocked(exec.execCapture).mockImplementation(async (_cmd, args) => {
+      const joined = args.join(" ");
+      if (joined.includes("--format=value(state,host,port)")) {
+        describes += 1;
+        return describes === 1
+          ? { exitCode: 1, stdout: "", stderr: "not found" }
+          : ok("READY 10.0.0.1 6379");
+      }
+      return ok();
+    });
+    const endpoint = await provisionMemorystore(OPTS);
+    expect(endpoint).toEqual({ host: "10.0.0.1", port: 6379 });
+    const createCall = vi
+      .mocked(exec.execCapture)
+      .mock.calls.find(([, args]) => args.includes("create"));
+    expect(createCall?.[1]).not.toContain("--auth-enabled");
+  });
+
+  it("refuses to reuse an existing non-AUTH instance when auth is requested", async () => {
+    mockGcloud([
+      ["services enable", ok()],
+      ["--format=value(state,host,port)", ok("READY 10.0.0.1 6379")],
+      [
+        "--format=json(authEnabled,transitEncryptionMode)",
+        ok(JSON.stringify({ authEnabled: false, transitEncryptionMode: "DISABLED" })),
+      ],
+    ]);
+    await expect(provisionMemorystore({ ...OPTS, auth: true })).rejects.toThrow(
+      /already exists WITHOUT AUTH/,
+    );
+  });
+
+  it("reuses an existing AUTH-enabled instance and returns its credentials", async () => {
+    mockGcloud([
+      ["services enable", ok()],
+      ["--format=value(state,host,port)", ok("READY 10.0.0.1 6379")],
+      [
+        "--format=json(authEnabled,transitEncryptionMode)",
+        ok(JSON.stringify({ authEnabled: true, transitEncryptionMode: "SERVER_AUTHENTICATION" })),
+      ],
+      ["get-auth-string", ok("s3cr3t-auth\n")],
+      ["--format=json(serverCaCerts)", ok(JSON.stringify({ serverCaCerts: [{ cert: "CA-PEM" }] }))],
+    ]);
+    const endpoint = await provisionMemorystore({ ...OPTS, auth: true });
+    expect(endpoint.authString).toBe("s3cr3t-auth");
+    expect(endpoint.caCert).toBe("CA-PEM");
   });
 });

--- a/tests/cli/rollback.test.ts
+++ b/tests/cli/rollback.test.ts
@@ -17,7 +17,14 @@ const PROJECT = "/proj";
 const RELEASE = "rel";
 const infraPath = path.join(PROJECT, ".k8s-adapter", "infrastructure.json");
 const metaPath = path.join(PROJECT, ".k8s-adapter", "output", "build-metadata.json");
-const cdnFilter = path.join(PROJECT, ".k8s-adapter", "output", "chart", "templates", "cdn-http-filter.yaml");
+const cdnFilter = path.join(
+  PROJECT,
+  ".k8s-adapter",
+  "output",
+  "chart",
+  "templates",
+  "cdn-http-filter.yaml",
+);
 
 /** execCapture stub: success everywhere except optionally the service selector patch. */
 function capture(patchFails: boolean) {
@@ -34,7 +41,10 @@ function capture(patchFails: boolean) {
 describe("runRollback — CDN invalidation", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(readState).mockResolvedValue({ buildId: "buildn", previousBuildId: "buildm" } as never);
+    vi.mocked(readState).mockResolvedValue({
+      buildId: "buildn",
+      previousBuildId: "buildm",
+    } as never);
     vi.mocked(writeState).mockResolvedValue(undefined as never);
     vi.mocked(execOrThrow).mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" } as never);
     vi.mocked(invalidateCdnBuildTag).mockResolvedValue(undefined);
@@ -74,5 +84,29 @@ describe("runRollback — CDN invalidation", () => {
       /process\.exit:1/,
     );
     expect(invalidateCdnBuildTag).not.toHaveBeenCalled();
+  });
+
+  it("L13: dry-run prints the plan without touching the cluster or the kubeconfig", async () => {
+    vi.mocked(execCapture).mockImplementation(capture(false) as never);
+
+    await runRollback({ projectDir: PROJECT, releaseName: RELEASE, dryRun: true });
+
+    const calls = vi.mocked(execCapture).mock.calls.map(([, args]) => args);
+    // get-credentials mutates the operator's kubeconfig — forbidden in dry-run.
+    expect(calls.some((args) => args.includes("get-credentials"))).toBe(false);
+    // No mutations of any kind.
+    expect(vi.mocked(execOrThrow)).not.toHaveBeenCalled();
+    expect(vi.mocked(writeState)).not.toHaveBeenCalled();
+    expect(invalidateCdnBuildTag).not.toHaveBeenCalled();
+    // The plan was printed.
+    const printed = vi
+      .mocked(console.log)
+      .mock.calls.map((c) => String(c[0]))
+      .join("\n");
+    expect(printed).toContain("[dry-run] Rollback plan: buildn → buildm");
+    expect(printed).toContain("[dry-run] Would scale up previous build: rel-ssr-buildm");
+    expect(printed).toContain("[dry-run] Would scale down current build: rel-ssr-buildn");
+    expect(printed).toContain("[dry-run] Would patch active Service selectors");
+    expect(printed).toContain("[dry-run] Would swap state: buildId=buildm, previousBuildId=buildn");
   });
 });

--- a/tests/cli/terminal.test.ts
+++ b/tests/cli/terminal.test.ts
@@ -1,0 +1,32 @@
+// tests/cli/terminal.test.ts
+import { describe, it, expect } from "vitest";
+import { sanitizeForTerminal } from "../../src/cli/terminal.js";
+
+describe("sanitizeForTerminal (L14)", () => {
+  it("strips ESC and CSI sequences", () => {
+    expect(sanitizeForTerminal("ok\x1b[31mred\x1b[0m")).toBe("ok[31mred[0m");
+    expect(sanitizeForTerminal("\x1b[2Jcleared")).toBe("[2Jcleared");
+    expect(sanitizeForTerminal("a\x1bb")).toBe("ab");
+  });
+
+  it("strips C0 control characters", () => {
+    expect(sanitizeForTerminal("a\x00b\x07c\x1fd")).toBe("abcd");
+    expect(sanitizeForTerminal("\r\n")).toBe("\n"); // CR stripped, LF kept
+  });
+
+  it("strips C1 control characters and DEL", () => {
+    expect(sanitizeForTerminal("a\x7Fb")).toBe("ab");
+    expect(sanitizeForTerminal("a\u009B[0mb")).toBe("a[0mb"); // U+009B is CSI itself
+    expect(sanitizeForTerminal("a\u0080\u009Fb")).toBe("ab");
+  });
+
+  it("keeps newlines and tabs", () => {
+    expect(sanitizeForTerminal("line1\nline2\tindented")).toBe("line1\nline2\tindented");
+  });
+
+  it("leaves normal text untouched", () => {
+    expect(sanitizeForTerminal("Error: something failed (exit 1)")).toBe(
+      "Error: something failed (exit 1)",
+    );
+  });
+});

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -43,6 +43,34 @@ describe("validateConfig", () => {
     expect(() => validateConfig(config)).toThrow(/provider.gke.gateway.hosts is required/);
   });
 
+  it("rejects a hostname that would break out of the quoted YAML scalar", () => {
+    // The hostname is interpolated into gateway.ts as "- "<hostname>"" — a quote+newline
+    // injects arbitrary chart YAML. validateConfig must reject it at the boundary.
+    const makeConfig = (hostname: string): K8sAdapterConfig =>
+      ({
+        pools: { ssr: { routes: ["appPages"] } },
+        provider: {
+          gke: {
+            gateway: {
+              type: "gateway-api",
+              className: "gke",
+              hosts: [{ hostname, tls: { enabled: true } }],
+            },
+          },
+        },
+      }) as K8sAdapterConfig;
+
+    expect(() => validateConfig(makeConfig('app.example.com"\nmalicious: true'))).toThrow(
+      /Invalid hostname/,
+    );
+    expect(() => validateConfig(makeConfig("app.example.com;rm -rf /"))).toThrow(
+      /Invalid hostname/,
+    );
+    expect(() => validateConfig(makeConfig("UPPER.example.com"))).toThrow(/Invalid hostname/);
+    expect(() => validateConfig(makeConfig("app.example.com"))).not.toThrow();
+    expect(() => validateConfig(makeConfig("localhost"))).not.toThrow();
+  });
+
   it("allows wildcard hostnames (Certificate Manager supports them)", () => {
     const config: K8sAdapterConfig = {
       pools: { ssr: { routes: ["appPages"] } },

--- a/tests/emit/dockerfiles.test.ts
+++ b/tests/emit/dockerfiles.test.ts
@@ -15,9 +15,21 @@ describe("generateDockerfile", () => {
     });
     expect(result).toContain("FROM node:22-slim");
     expect(result).toContain("WORKDIR /app");
-    expect(result).toContain("COPY . .");
+    expect(result).toContain("COPY --chown=node:node . .");
     expect(result).toContain("NEXT_BUILD_ID=abc123");
     expect(result).toContain('CMD ["node", "pool-server.cjs"]');
+  });
+
+  it("runs as the non-root node user with node-owned app files", () => {
+    const result = generateDockerfile({
+      containerStrategy: "shared-image",
+      nodeVersion: "22",
+      buildId: "abc123",
+    });
+    expect(result).toContain("USER node");
+    // USER must come after COPY (which chowns to node) and before CMD.
+    expect(result.indexOf("USER node")).toBeGreaterThan(result.indexOf("COPY --chown=node:node"));
+    expect(result.indexOf("USER node")).toBeLessThan(result.indexOf("CMD"));
   });
 });
 
@@ -30,9 +42,10 @@ describe("generatePoolDockerfile", () => {
     });
     expect(result).toContain("FROM node:22-slim");
     expect(result).toContain("WORKDIR /app");
-    expect(result).toContain("COPY context/ .");
+    expect(result).toContain("COPY --chown=node:node context/ .");
     expect(result).toContain("POOL_NAME=ssr");
     expect(result).toContain("NEXT_BUILD_ID=abc123");
+    expect(result).toContain("USER node");
     expect(result).toContain('CMD ["node", "pool-server.cjs"]');
   });
 });
@@ -40,14 +53,25 @@ describe("generatePoolDockerfile", () => {
 describe("generateRoutingServiceDockerfile", () => {
   it("generates a Dockerfile for the routing service", () => {
     const result = generateRoutingServiceDockerfile({ nodeVersion: "22", buildId: "abc123" });
-    // GCP ext_proc callouts require HTTP/2 over TLS; the image bakes a self-signed cert.
-    expect(result).toContain("openssl req -x509");
-    expect(result).toContain("TLS_CERT_FILE=/app/tls-cert.pem");
-    expect(result).toContain("TLS_KEY_FILE=/app/tls-key.pem");
     expect(result).toContain("FROM node:22-slim");
     expect(result).toContain("routing-service.cjs");
     expect(result).toContain("EXPOSE 8443");
     expect(result).toContain("ENV NEXT_BUILD_ID=abc123");
+    expect(result).toContain("COPY --chown=node:node context/ .");
+    expect(result).toContain("USER node");
     expect(result).not.toContain("POOL_NAME");
+  });
+
+  it("does not bake a TLS cert into the image — the runtime generates one under /tmp/tls", () => {
+    const result = generateRoutingServiceDockerfile({ nodeVersion: "22", buildId: "abc123" });
+    // The per-replica cert is generated at container start (another workstream owns that
+    // runtime code); nothing cert-shaped may be baked into an image layer.
+    expect(result).not.toContain("openssl req");
+    expect(result).not.toContain("tls-cert.pem -out");
+    // openssl stays installed for the runtime generation.
+    expect(result).toContain("apt-get install -y --no-install-recommends openssl");
+    // Cert paths point at the pod's /tmp emptyDir (root FS is read-only).
+    expect(result).toContain("TLS_CERT_FILE=/tmp/tls/tls-cert.pem");
+    expect(result).toContain("TLS_KEY_FILE=/tmp/tls/tls-key.pem");
   });
 });

--- a/tests/emit/dockerignore.test.ts
+++ b/tests/emit/dockerignore.test.ts
@@ -9,11 +9,12 @@ describe("generateDockerignore", () => {
     expect(result).toContain("**/.env.*");
   });
 
-  it("re-includes .env.example so non-secret sample files survive", () => {
+  it("does NOT re-include .env.example — no env file variant belongs in an image", () => {
     const result = generateDockerignore();
-    expect(result).toContain("!**/.env.example");
-    // The negation must come after the broad .env.* exclusion to take effect.
-    const lines = result.split("\n");
-    expect(lines.indexOf("!**/.env.example")).toBeGreaterThan(lines.indexOf("**/.env.*"));
+    // The broad `**/.env.*` exclusion must stand with no negation punching a hole in it:
+    // example files can drift into real-looking credentials and would be baked into
+    // pushed image layers.
+    expect(result).not.toContain("!**/.env.example");
+    expect(result).not.toMatch(/^!/m);
   });
 });

--- a/tests/emit/helm.test.ts
+++ b/tests/emit/helm.test.ts
@@ -1,6 +1,6 @@
 // tests/emit/helm.test.ts
 import { describe, it, expect } from "vitest";
-import { generateHelmChart } from "../../src/emit/helm.js";
+import { generateHelmChart, SECRET_CHART_FILES } from "../../src/emit/helm.js";
 import { sanitizeK8sName } from "../../src/emit/templates/utils.js";
 import type { PoolDefinition, K8sAdapterConfig, RoutingManifest } from "../../src/types.js";
 
@@ -367,6 +367,42 @@ describe("generateHelmChart", () => {
     });
     expect(result["templates/cdn-http-filter.yaml"]).toBeUndefined();
     expect(result["templates/http-route.yaml"]).toBeUndefined();
+  });
+
+  it("always emits the NetworkPolicy template (helm-gated) with an empty podCidrs default", () => {
+    const pools = new Map<string, PoolDefinition>([
+      ["ssr", { name: "ssr", outputs: [], config: { routes: ["appPages"] } }],
+    ]);
+    const result = generateHelmChart({
+      pools,
+      buildId: "abc123",
+      nextVersion: "16.2.0",
+      config: {
+        pools: { ssr: { routes: ["appPages"] } },
+        provider: { gke: {} },
+      } as K8sAdapterConfig,
+      imageRegistry: "gcr.io/my-project",
+      routingManifest: mockManifest,
+    });
+
+    // The template is always in the chart; the helm `if` guard renders nothing until the
+    // deploy CLI sets global.networkPolicy.podCidrs.
+    const netpol = result["templates/network-policy.yaml"];
+    expect(netpol).toBeDefined();
+    expect(netpol).toContain("{{- if .Values.global.networkPolicy.podCidrs }}");
+    expect(netpol).toContain("kind: NetworkPolicy");
+
+    // values.yaml carries the empty default the CLI overrides with --set.
+    const values = JSON.parse(result["values.yaml"].slice(result["values.yaml"].indexOf("{")));
+    expect(values.global.networkPolicy).toEqual({ podCidrs: [] });
+  });
+
+  it("marks the secret-bearing templates for mode-0600 writes (M4)", () => {
+    // adapter.ts writes chart files and MUST create these with mode 0600 — the set is
+    // the single source of truth, kept next to the files' generation.
+    expect(SECRET_CHART_FILES.has("templates/internal-secret.yaml")).toBe(true);
+    expect(SECRET_CHART_FILES.has("templates/valkey-secret.yaml")).toBe(true);
+    expect(SECRET_CHART_FILES.size).toBe(2);
   });
 
   it("throws a helpful error when the routing manifest exceeds the ConfigMap size limit", () => {

--- a/tests/emit/templates/deployment.test.ts
+++ b/tests/emit/templates/deployment.test.ts
@@ -31,4 +31,32 @@ describe("renderDeployment", () => {
     // optional so a missing secret never blocks pod startup
     expect(yaml).toContain("optional: true");
   });
+
+  it("ships the hardened pod/container security posture", () => {
+    const yaml = renderDeployment({ poolName: "ssr", buildId: "b1", releaseName: "my-app" });
+    // Pod level: non-root uid 1000 (the node user), seccomp, no SA token (the pool
+    // never calls the Kubernetes API).
+    expect(yaml).toContain("automountServiceAccountToken: false");
+    expect(yaml).toContain("runAsNonRoot: true");
+    expect(yaml).toContain("runAsUser: 1000");
+    expect(yaml).toContain("fsGroup: 1000");
+    expect(yaml).toContain("seccompProfile:");
+    expect(yaml).toContain("type: RuntimeDefault");
+    // Container level: no privilege escalation, read-only root FS, all caps dropped.
+    expect(yaml).toContain("allowPrivilegeEscalation: false");
+    expect(yaml).toContain("readOnlyRootFilesystem: true");
+    expect(yaml).toContain('drop: ["ALL"]');
+    // A writable /tmp (emptyDir) backs the read-only root filesystem.
+    expect(yaml).toMatch(/volumeMounts:[\s\S]*?name: tmp\n\s+mountPath: \/tmp/);
+    expect(yaml).toMatch(/volumes:[\s\S]*?name: tmp\n\s+emptyDir: \{\}/);
+    // .next/cache stays writable for Next's filesystem-cache fallback when no shared
+    // Valkey handler is wired (otherwise renders fail with EROFS).
+    expect(yaml).toMatch(/name: next-cache\n\s+mountPath: \/app\/\.next\/cache/);
+    expect(yaml).toMatch(/name: next-cache\n\s+emptyDir: \{\}/);
+  });
+
+  it("does NOT set TRUST_INTERNAL_HEADERS — the legacy bypass must not ship in the chart", () => {
+    const yaml = renderDeployment({ poolName: "ssr", buildId: "b1", releaseName: "my-app" });
+    expect(yaml).not.toContain("TRUST_INTERNAL_HEADERS");
+  });
 });

--- a/tests/emit/templates/gateway.test.ts
+++ b/tests/emit/templates/gateway.test.ts
@@ -130,6 +130,56 @@ describe("renderHTTPRoute CDN filter injection", () => {
   });
 });
 
+describe("renderHTTPRoute HTTP->HTTPS redirect (M8)", () => {
+  const tlsHosts: HostConfig[] = [{ hostname: "app.example.com", tls: { enabled: true } }];
+
+  it("pins the app route to the https listener and adds a RequestRedirect route when TLS is on", () => {
+    const yaml = renderHTTPRoute({
+      releaseName: "nextjs",
+      hosts: tlsHosts,
+      pools: makePools(2),
+      buildId: "abc123",
+      routingManifest: makeManifest({ "/dashboard/page": "pool1" }),
+    });
+
+    // Two HTTPRoute documents: the app route and the redirect route.
+    const routeDocs = yaml.match(/kind: HTTPRoute/g) ?? [];
+    expect(routeDocs).toHaveLength(2);
+
+    // The app route attaches ONLY to the https listener (no plaintext service).
+    expect(yaml).toMatch(
+      /name: nextjs-routes\nspec:\n  parentRefs:\n    - name: nextjs-gateway\n      sectionName: https/,
+    );
+
+    // The redirect route attaches to the http listener and 302-upgrades to https:443.
+    expect(yaml).toContain("name: nextjs-http-redirect");
+    expect(yaml).toMatch(
+      /name: nextjs-http-redirect\nspec:\n  parentRefs:\n    - name: nextjs-gateway\n      sectionName: http/,
+    );
+    expect(yaml).toContain("type: RequestRedirect");
+    expect(yaml).toMatch(/requestRedirect:\n\s+scheme: https\n\s+port: 443\n\s+statusCode: 302/);
+    // Same hostnames on the redirect route.
+    const redirectDoc = yaml.slice(yaml.indexOf("name: nextjs-http-redirect"));
+    expect(redirectDoc).toContain('"app.example.com"');
+  });
+
+  it("emits no redirect route and no sectionName when TLS is off", () => {
+    const yaml = renderHTTPRoute({
+      releaseName: "nextjs",
+      hosts, // tls disabled
+      pools: makePools(2),
+      buildId: "abc123",
+      routingManifest: makeManifest({ "/dashboard/page": "pool1" }),
+    });
+
+    const routeDocs = yaml.match(/kind: HTTPRoute/g) ?? [];
+    expect(routeDocs).toHaveLength(1);
+    expect(yaml).not.toContain("RequestRedirect");
+    expect(yaml).not.toContain("sectionName");
+    expect(yaml).not.toContain("http-redirect");
+  });
+});
+
 describe("releaseName validation in gateway templates", () => {
   it("renderGateway rejects an unsafe releaseName", () => {
     expect(() => renderGateway({ releaseName: 'foo";rm -rf /;"', hosts })).toThrow(

--- a/tests/emit/templates/network-policy.test.ts
+++ b/tests/emit/templates/network-policy.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import { renderNetworkPolicies } from "../../../src/emit/templates/network-policy.js";
+
+// Minimal evaluator for this template's two helm constructs: a top-level
+// `{{- if .Values.global.networkPolicy.podCidrs }}` guard wrapping the whole file, and
+// `{{- range .Values.global.networkPolicy.podCidrs }}` loops expanding CIDR list items.
+// (`{{-`/`{{- end }}` trim the adjacent newline, mirrored here.)
+function helmRender(template: string, podCidrs: string[]): string {
+  if (podCidrs.length === 0) return ""; // the `if` guard renders nothing
+  let out = template.replace(/^\{\{- if \.Values\.global\.networkPolicy\.podCidrs \}\}/, "");
+  out = out.replace(
+    /\n\{\{- range \.Values\.global\.networkPolicy\.podCidrs \}\}\n([\s\S]*?)\n\{\{- end \}\}/g,
+    (_m, body: string) =>
+      podCidrs.map((c) => `\n${body.replace("{{ . | quote }}", JSON.stringify(c))}`).join(""),
+  );
+  out = out.replace(/\n\{\{- end \}\}\n?$/, "\n");
+  return out;
+}
+
+describe("renderNetworkPolicies", () => {
+  it("wraps the whole file in a podCidrs guard so an empty list renders no document", () => {
+    const template = renderNetworkPolicies({ releaseName: "my-app", poolNames: ["ssr"] });
+    expect(template).toMatch(/^\{\{- if \.Values\.global\.networkPolicy\.podCidrs \}\}/);
+    expect(template).toMatch(/\{\{- end \}\}\n?$/);
+    expect(helmRender(template, [])).toBe("");
+  });
+
+  it("renders a routing-service policy allowing only non-pod (LB/health-check) ingress", () => {
+    const template = renderNetworkPolicies({ releaseName: "my-app", poolNames: ["ssr"] });
+    const yaml = helmRender(template, ["10.8.0.0/14", "10.12.0.0/14"]);
+
+    const routingDoc = yaml.slice(0, yaml.indexOf("---"));
+    expect(routingDoc).toContain("kind: NetworkPolicy");
+    expect(routingDoc).toContain("name: my-app-routing-service");
+    // Selects the routing-service pods by their deployment labels.
+    expect(routingDoc).toMatch(
+      /podSelector:\n    matchLabels:\n      app\.kubernetes\.io\/name: my-app\n      app\.kubernetes\.io\/component: routing-service/,
+    );
+    // Ingress from anywhere EXCEPT the pod CIDRs (LB + Google health checks arrive with
+    // non-pod source IPs; in-cluster pods are blocked).
+    expect(routingDoc).toContain("cidr: 0.0.0.0/0");
+    expect(routingDoc).toContain("except:");
+    expect(routingDoc).toContain('- "10.8.0.0/14"');
+    expect(routingDoc).toContain('- "10.12.0.0/14"');
+    // Only the ports the routing service serves: gRPC 8443 + health 8081.
+    expect(routingDoc).toContain("port: 8443");
+    expect(routingDoc).toContain("port: 8081");
+    expect(routingDoc).not.toContain("port: 3000");
+    // No pod-to-pod allowance for the ext_proc tier.
+    expect(routingDoc).not.toContain("podSelector:\n        ");
+  });
+
+  it("renders one policy per pool with the LB rule UNION a sibling-podSelector rule", () => {
+    const template = renderNetworkPolicies({ releaseName: "my-app", poolNames: ["ssr", "api"] });
+    const yaml = helmRender(template, ["10.8.0.0/14"]);
+
+    const docs = yaml.split("\n---\n").filter((d) => d.includes("kind: NetworkPolicy"));
+    // routing-service + one per pool
+    expect(docs).toHaveLength(3);
+
+    const poolDoc = docs.find((d) => d.includes("name: my-app-ssr"))!;
+    expect(poolDoc).toBeDefined();
+    expect(poolDoc).toContain("app.kubernetes.io/component: ssr");
+    // Rule (a): LB traffic — same ipBlock-except-CIDRs as the routing tier.
+    expect(poolDoc).toContain("- ipBlock:");
+    expect(poolDoc).toContain("cidr: 0.0.0.0/0");
+    expect(poolDoc).toContain('- "10.8.0.0/14"');
+    // Rule (b): cross-pool proxy traffic comes from SIBLING POOL pods (proxyToPool) —
+    // one podSelector per pool component of this release. Both `from` entries form a union.
+    expect(poolDoc).toMatch(
+      /- podSelector:\n            matchLabels:\n              app\.kubernetes\.io\/name: my-app\n              app\.kubernetes\.io\/component: ssr/,
+    );
+    expect(poolDoc).toMatch(
+      /- podSelector:\n            matchLabels:\n              app\.kubernetes\.io\/name: my-app\n              app\.kubernetes\.io\/component: api/,
+    );
+    // The routing service never originates pool traffic: its component must NOT be
+    // allowed into pools (a compromised ext_proc pod can't reach the dataplane directly).
+    const podSelectorBlocks =
+      poolDoc.match(/- podSelector:[\s\S]*?(?=\n        - |\n      ports:)/g) ?? [];
+    expect(podSelectorBlocks.some((b) => b.includes("component: routing-service"))).toBe(false);
+    // Pools serve only 3000.
+    expect(poolDoc).toContain("port: 3000");
+    expect(poolDoc).not.toContain("port: 8443");
+
+    expect(docs.some((d) => d.includes("name: my-app-api"))).toBe(true);
+  });
+
+  it("rejects an unsafe releaseName", () => {
+    expect(() =>
+      renderNetworkPolicies({ releaseName: 'foo";rm -rf /;"', poolNames: ["ssr"] }),
+    ).toThrow(/Invalid releaseName/);
+  });
+});

--- a/tests/emit/templates/route-ext-job.test.ts
+++ b/tests/emit/templates/route-ext-job.test.ts
@@ -36,18 +36,24 @@ describe("renderRouteExtUpdateJob", () => {
     // The rendered Job name MUST equal routeExtJobName's output — deploy.ts skips the
     // current job by exact name, and any drift deletes the running job mid-registration.
     expect(yaml).toContain(`name: ${name}`);
-    // The name keeps the FULL build id (DNS-sanitized, ≤63 chars) — Jobs are immutable,
-    // so per-build uniqueness is the requirement; a short slice risks collisions.
-    expect(name).toBe("my-app-route-ext-jpy1gcvqshohb9piqlgyf");
+    // A fixed digest of the complete build id keeps immutable Job names collision-resistant
+    // without risking truncation beyond Kubernetes' 63-character name limit.
+    expect(name).toBe("my-app-route-ext-ca7026fd6961");
     expect(name.length).toBeLessThanOrEqual(63);
+    // The digested name no longer reveals the build — the annotation records the full id
+    // so operators can map a Job back to its build.
+    expect(yaml).toContain(`adapter-k8s.dev/build-id: "${buildId}"`);
   });
 
   it("produces collision-resistant, DNS-safe job names for awkward build ids", () => {
-    // Two build ids sharing a 10-char prefix must not collide (the old slice scheme did).
-    const a = routeExtJobName("my-app", "aaaaaaaaaabbbb");
-    const b = routeExtJobName("my-app", "aaaaaaaaaacccc");
+    // A maximum-length release leaves only 12 build-id characters in the old truncated
+    // name. The digest must still distinguish full build ids that share that prefix.
+    const releaseName = "a".repeat(40);
+    const a = routeExtJobName(releaseName, "aaaaaaaaaaaabbbb");
+    const b = routeExtJobName(releaseName, "aaaaaaaaaaaacccc");
     expect(a).not.toBe(b);
-    // Non-DNS chars are sanitized away and the result fits the 63-char limit.
+    expect(a).toHaveLength(63);
+    // The digest result is DNS-safe and fits the Kubernetes name limit.
     const c = routeExtJobName("my-app", "Feature/Branch_X.Y");
     expect(c).toMatch(/^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/);
   });
@@ -118,6 +124,30 @@ describe("renderRouteExtUpdateJob", () => {
         buildId: "abc123",
       }),
     ).toThrow(/Invalid releaseName/);
+  });
+
+  it("rejects a releaseName with a leading or trailing hyphen (invalid DNS-1123 prefix)", () => {
+    for (const releaseName of ["-my-app", "my-app-"]) {
+      expect(() =>
+        renderRouteExtUpdateJob({
+          releaseName,
+          projectId: "my-project",
+          region: "us-central1",
+          buildId: "abc123",
+        }),
+      ).toThrow(/Invalid releaseName/);
+    }
+  });
+
+  it("rejects a buildId outside the safe charset (interpolated into the annotation)", () => {
+    expect(() =>
+      renderRouteExtUpdateJob({
+        releaseName: "my-app",
+        projectId: "my-project",
+        region: "us-central1",
+        buildId: 'abc"123',
+      }),
+    ).toThrow(/Invalid buildId/);
   });
 
   it("rejects a projectId containing an injection payload", () => {

--- a/tests/emit/templates/route-ext-job.test.ts
+++ b/tests/emit/templates/route-ext-job.test.ts
@@ -36,9 +36,58 @@ describe("renderRouteExtUpdateJob", () => {
     // The rendered Job name MUST equal routeExtJobName's output — deploy.ts skips the
     // current job by exact name, and any drift deletes the running job mid-registration.
     expect(yaml).toContain(`name: ${name}`);
-    // Regression: the name uses a 10-char build-id slice; deploy's old 12-char substring
-    // match failed to skip it and deleted it.
-    expect(name).toBe("my-app-route-ext-jpy1gcvqsh");
+    // The name keeps the FULL build id (DNS-sanitized, ≤63 chars) — Jobs are immutable,
+    // so per-build uniqueness is the requirement; a short slice risks collisions.
+    expect(name).toBe("my-app-route-ext-jpy1gcvqshohb9piqlgyf");
+    expect(name.length).toBeLessThanOrEqual(63);
+  });
+
+  it("produces collision-resistant, DNS-safe job names for awkward build ids", () => {
+    // Two build ids sharing a 10-char prefix must not collide (the old slice scheme did).
+    const a = routeExtJobName("my-app", "aaaaaaaaaabbbb");
+    const b = routeExtJobName("my-app", "aaaaaaaaaacccc");
+    expect(a).not.toBe(b);
+    // Non-DNS chars are sanitized away and the result fits the 63-char limit.
+    const c = routeExtJobName("my-app", "Feature/Branch_X.Y");
+    expect(c).toMatch(/^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/);
+  });
+
+  it("ships the hardened job/pod posture (ttl, non-root, read-only FS, gcloud config home)", () => {
+    const yaml = renderRouteExtUpdateJob({
+      releaseName: "my-app",
+      projectId: "my-project",
+      region: "us-central1",
+      buildId: "abc123",
+    });
+    // Finished Jobs are swept after an hour.
+    expect(yaml).toContain("ttlSecondsAfterFinished: 3600");
+    // Pod runs as nobody (65534) with seccomp.
+    expect(yaml).toContain("runAsNonRoot: true");
+    expect(yaml).toContain("runAsUser: 65534");
+    expect(yaml).toContain("fsGroup: 65534");
+    expect(yaml).toContain("seccompProfile:");
+    expect(yaml).toContain("type: RuntimeDefault");
+    // Container: no privilege escalation, read-only root FS, all caps dropped.
+    expect(yaml).toContain("allowPrivilegeEscalation: false");
+    expect(yaml).toContain("readOnlyRootFilesystem: true");
+    expect(yaml).toContain('drop: ["ALL"]');
+    // gcloud needs a writable config home as non-root; /tmp is an emptyDir.
+    expect(yaml).toMatch(/- name: CLOUDSDK_CONFIG\n\s+value: \/tmp\/\.config\/gcloud/);
+    expect(yaml).toMatch(/volumeMounts:[\s\S]*?name: tmp\n\s+mountPath: \/tmp/);
+    expect(yaml).toMatch(/volumes:[\s\S]*?name: tmp\n\s+emptyDir: \{\}/);
+  });
+
+  it("keeps the Workload Identity SA automounted (no automountServiceAccountToken: false)", () => {
+    const yaml = renderRouteExtUpdateJob({
+      releaseName: "my-app",
+      projectId: "my-project",
+      region: "us-central1",
+      buildId: "abc123",
+    });
+    // The Job needs its SA token to call gcloud via Workload Identity — unlike the app
+    // workloads, automountServiceAccountToken must NOT be disabled here.
+    expect(yaml).toContain("serviceAccountName: my-app-deploy-sa");
+    expect(yaml).not.toContain("automountServiceAccountToken: false");
   });
 
   it("attaches to ALL forwarding rules and fails loudly (no http:// bypass, no false success)", () => {
@@ -126,5 +175,46 @@ describe("renderRouteExtConfigMap", () => {
     expect(yaml).toContain("loadBalancingScheme: EXTERNAL_MANAGED");
     expect(yaml).toContain("my-app-traffic-ext");
     expect(yaml).toContain("nextjs-routing");
+  });
+
+  it("embeds the CEL expression as a YAML single-quoted scalar that round-trips", () => {
+    // A public file with an apostrophe (o'brien.txt) makes the CEL text contain \'.
+    // In a YAML DOUBLE-quoted scalar \' is an invalid escape — the produced
+    // route-extension.yaml would be unparseable and the extension would never register.
+    // Single-quoted YAML escapes ' by doubling, operating on the already-CEL-escaped
+    // text, so the YAML parser reads the CEL text back exactly.
+    const celExpression = "!(request.path == '/o\\'brien.txt')"; // CEL: /o\'brien.txt
+    const chainJson = JSON.stringify([
+      {
+        name: "nextjs-routing",
+        matchCondition: { celExpression },
+        extensions: [
+          {
+            name: "routing-service",
+            authority: "my-app-routing-service.default.svc.cluster.local",
+            service:
+              "projects/my-project/locations/us-central1/backendServices/my-app-routing-service",
+            timeout: "5s",
+            supportedEvents: ["REQUEST_HEADERS"],
+            failOpen: true,
+          },
+        ],
+      },
+    ]);
+
+    const yaml = renderRouteExtConfigMap({
+      releaseName: "my-app",
+      extensionChainJson: chainJson,
+      projectId: "my-project",
+      region: "us-central1",
+    });
+
+    // The scalar must be single-quoted with only '' quote pairs inside (valid YAML).
+    const match = yaml.match(/^ +celExpression: '((?:[^']|'')*)'$/m);
+    expect(match).not.toBeNull();
+    // Un-doubling the YAML escape must yield the exact CEL text (round-trip).
+    expect(match![1].replace(/''/g, "'")).toBe(celExpression);
+    // And the raw CEL quote sequence must not appear un-doubled.
+    expect(yaml).not.toContain(`celExpression: "${celExpression}"`);
   });
 });

--- a/tests/emit/templates/routing-service.test.ts
+++ b/tests/emit/templates/routing-service.test.ts
@@ -38,6 +38,42 @@ describe("renderRoutingServiceDeployment", () => {
     expect(yaml).toMatch(/ROUTING_FAIL_OPEN[\s\S]*?value: "false"/);
     expect(yaml).toContain('value: "3000"');
   });
+
+  it("ships the hardened pod/container security posture", () => {
+    const yaml = renderRoutingServiceDeployment({
+      releaseName: "my-app",
+      buildId: "abc123",
+      imageRegistry: "reg",
+    });
+    // Pod level: non-root uid 1000 (the node user), seccomp, no SA token (the routing
+    // service never calls the Kubernetes API).
+    expect(yaml).toContain("automountServiceAccountToken: false");
+    expect(yaml).toContain("runAsNonRoot: true");
+    expect(yaml).toContain("runAsUser: 1000");
+    expect(yaml).toContain("fsGroup: 1000");
+    expect(yaml).toContain("seccompProfile:");
+    expect(yaml).toContain("type: RuntimeDefault");
+    // Container level: no privilege escalation, read-only root FS, all caps dropped.
+    expect(yaml).toContain("allowPrivilegeEscalation: false");
+    expect(yaml).toContain("readOnlyRootFilesystem: true");
+    expect(yaml).toContain('drop: ["ALL"]');
+    // A writable /tmp (emptyDir) backs the read-only root filesystem — the runtime TLS
+    // cert generation writes under /tmp/tls.
+    expect(yaml).toMatch(/volumeMounts:[\s\S]*?name: tmp\n\s+mountPath: \/tmp/);
+    expect(yaml).toMatch(/volumes:[\s\S]*?name: tmp\n\s+emptyDir: \{\}/);
+  });
+
+  it("injects RELEASE_NAME and NAMESPACE so the runtime can build the cert CN/SAN", () => {
+    const yaml = renderRoutingServiceDeployment({
+      releaseName: "my-app",
+      buildId: "abc123",
+      imageRegistry: "reg",
+    });
+    expect(yaml).toMatch(/- name: RELEASE_NAME\n\s+value: "my-app"/);
+    expect(yaml).toMatch(
+      /- name: NAMESPACE\n\s+valueFrom:\n\s+fieldRef:\n\s+fieldPath: metadata\.namespace/,
+    );
+  });
 });
 
 describe("renderRoutingServiceService", () => {

--- a/tests/emit/templates/valkey-secret.test.ts
+++ b/tests/emit/templates/valkey-secret.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import {
+  renderValkeyEnv,
+  renderValkeySecret,
+  VALKEY_AUTH_KEY,
+  VALKEY_CA_KEY,
+  VALKEY_URL_KEY,
+} from "../../../src/emit/templates/valkey-secret.js";
+
+describe("renderValkeySecret", () => {
+  it("renders url only by default", () => {
+    const yaml = renderValkeySecret({ releaseName: "my-app", url: "redis://10.0.0.1:6379" });
+    expect(yaml).toContain(`${VALKEY_URL_KEY}: "redis://10.0.0.1:6379"`);
+    expect(yaml).not.toContain(VALKEY_AUTH_KEY);
+    expect(yaml).not.toContain(VALKEY_CA_KEY);
+  });
+
+  it("includes the AUTH string when provided", () => {
+    const yaml = renderValkeySecret({
+      releaseName: "my-app",
+      url: "rediss://10.0.0.1:6379",
+      password: "s3cr3t",
+    });
+    expect(yaml).toContain(`${VALKEY_AUTH_KEY}: "s3cr3t"`);
+  });
+
+  it("includes the server CA when provided (managed AUTH + in-transit encryption)", () => {
+    const yaml = renderValkeySecret({
+      releaseName: "my-app",
+      url: "rediss://10.0.0.1:6379",
+      password: "s3cr3t",
+      ca: "-----BEGIN CERTIFICATE-----\nABC\n-----END CERTIFICATE-----\n",
+    });
+    // JSON-quoted so the multi-line PEM survives as a single YAML scalar.
+    expect(yaml).toContain(
+      `${VALKEY_CA_KEY}: "-----BEGIN CERTIFICATE-----\\nABC\\n-----END CERTIFICATE-----\\n"`,
+    );
+  });
+});
+
+describe("renderValkeyEnv", () => {
+  it("injects VALKEY_URL / VALKEY_AUTH / VALKEY_CA_CERT as optional secret refs", () => {
+    const env = renderValkeyEnv("my-app", "  ");
+    for (const name of ["VALKEY_URL", "VALKEY_AUTH", "VALKEY_CA_CERT"]) {
+      expect(env).toContain(`- name: ${name}`);
+    }
+    expect(env).toContain(`name: my-app-valkey`);
+    expect(env).toContain(`key: ${VALKEY_CA_KEY}`);
+    // Every ref is optional so a cache-less deploy never blocks pod startup.
+    expect(env.match(/optional: true/g)).toHaveLength(3);
+  });
+});

--- a/tests/pool-server/dispatch.test.ts
+++ b/tests/pool-server/dispatch.test.ts
@@ -492,9 +492,10 @@ describe("createDispatcher", () => {
     // External rewrites are proxied — the actual HTTP request will fail in tests
     // but the dispatch should attempt the proxy (not return 502 immediately)
     await dispatcher.dispatch(req, res as unknown as ServerResponse, resolution);
-    // Proxy will fail with connection error in test env → 502 with error message
+    // Proxy will fail with connection error in test env → 502, but the body is generic:
+    // the upstream error detail must not leak to clients (L1).
     expect(res._status).toBe(502);
-    expect(res._body).toContain("External rewrite failed");
+    expect(res._body).toBe("Bad Gateway");
   });
 
   it("returns 404 for not-found", async () => {
@@ -1797,35 +1798,113 @@ describe("createDispatcher", () => {
       expect(res._body).toContain("Internal Server Error");
     });
 
-    it("lets a preview (__prerender_bypass) request through a fallback:false route", async () => {
-      const localHandlerInvoker = vi.fn().mockResolvedValue(undefined);
-      const dispatcher = createDispatcher({
-        handlerLoader: {
-          load: vi.fn().mockResolvedValue(vi.fn()),
-          has: vi.fn((p: string) => p === "/blog/[slug]"),
-          get: vi.fn().mockReturnValue({ runtime: "nodejs" }),
-        } as any,
-        poolName: "ssr",
-        buildId: "test123",
-        staticAssets: [],
-        localHandlerInvoker,
-        strictDynamicRoutes: [{ pageRegex: /^\/blog\/([^/]+?)(?:\/)?$/ }],
-        prerenderedPaths: new Set(["/blog/first"]),
-        buildIdForData: "test123",
+    // M10: the strict-dynamic-route 404 bypass requires a VERIFIED preview credential —
+    // upstream Next validates x-prerender-revalidate and the __prerender_bypass cookie
+    // against the build's random previewModeId (loaded as __NEXT_PREVIEW_MODE_ID).
+    describe("strict-route preview bypass credentials (M10)", () => {
+      const PREVIEW_ID = "build-preview-id";
+      let previousPreviewId: string | undefined;
+
+      function makeStrictDispatcher(localHandlerInvoker: ReturnType<typeof vi.fn>) {
+        return createDispatcher({
+          handlerLoader: {
+            load: vi.fn().mockResolvedValue(vi.fn()),
+            has: vi.fn((p: string) => p === "/blog/[slug]"),
+            get: vi.fn().mockReturnValue({ runtime: "nodejs" }),
+          } as any,
+          poolName: "ssr",
+          buildId: "test123",
+          staticAssets: [],
+          localHandlerInvoker,
+          strictDynamicRoutes: [{ pageRegex: /^\/blog\/([^/]+?)(?:\/)?$/ }],
+          prerenderedPaths: new Set(["/blog/first"]),
+          buildIdForData: "test123",
+        });
+      }
+
+      const strictResolution: ResolveResult = {
+        kind: "route",
+        pool: "ssr",
+        matchedPathname: "/blog/[slug]",
+        routeMatches: { slug: "nope" },
+        resolvedHeaders: undefined,
+      };
+
+      beforeEach(() => {
+        previousPreviewId = process.env.__NEXT_PREVIEW_MODE_ID;
       });
-      const res = mockRes();
-      await dispatcher.dispatch(
-        mockReq("/blog/nope", { cookie: "__prerender_bypass=xyz" }),
-        res as unknown as ServerResponse,
-        {
-          kind: "route",
-          pool: "ssr",
-          matchedPathname: "/blog/[slug]",
-          routeMatches: { slug: "nope" },
-          resolvedHeaders: undefined,
-        },
-      );
-      expect(localHandlerInvoker).toHaveBeenCalledOnce();
+
+      afterEach(() => {
+        if (previousPreviewId === undefined) delete process.env.__NEXT_PREVIEW_MODE_ID;
+        else process.env.__NEXT_PREVIEW_MODE_ID = previousPreviewId;
+      });
+
+      it("lets a VERIFIED preview/revalidate request through a fallback:false route", async () => {
+        process.env.__NEXT_PREVIEW_MODE_ID = PREVIEW_ID;
+        const localHandlerInvoker = vi.fn().mockResolvedValue(undefined);
+        const dispatcher = makeStrictDispatcher(localHandlerInvoker);
+
+        // On-demand revalidation: header value equals the build's previewModeId.
+        const resRevalidate = mockRes();
+        await dispatcher.dispatch(
+          mockReq("/blog/nope", { "x-prerender-revalidate": PREVIEW_ID }),
+          resRevalidate as unknown as ServerResponse,
+          strictResolution,
+        );
+        expect(localHandlerInvoker).toHaveBeenCalledOnce();
+
+        // Draft mode: the bypass cookie's value equals the previewModeId — exactly
+        // what Next's setDraftMode writes into the cookie.
+        const resDraft = mockRes();
+        await dispatcher.dispatch(
+          mockReq("/blog/nope", { cookie: `__prerender_bypass=${PREVIEW_ID}` }),
+          resDraft as unknown as ServerResponse,
+          strictResolution,
+        );
+        expect(localHandlerInvoker).toHaveBeenCalledTimes(2);
+      });
+
+      it("RED TEAM: forged preview credentials do NOT bypass a fallback:false 404", async () => {
+        process.env.__NEXT_PREVIEW_MODE_ID = PREVIEW_ID;
+        const localHandlerInvoker = vi.fn().mockResolvedValue(undefined);
+        const dispatcher = makeStrictDispatcher(localHandlerInvoker);
+
+        // Presence alone proves nothing — every forged credential must still 404.
+        for (const headers of [
+          { "x-prerender-revalidate": "1" },
+          { "x-prerender-revalidate": `${PREVIEW_ID}-typo` },
+          { cookie: "__prerender_bypass=forged" },
+          // A lookalike cookie name must not satisfy the check either.
+          { cookie: `x__prerender_bypass=${PREVIEW_ID}` },
+        ]) {
+          const res = mockRes();
+          await dispatcher.dispatch(
+            mockReq("/blog/nope", headers),
+            res as unknown as ServerResponse,
+            strictResolution,
+          );
+          expect(res._status).toBe(404);
+        }
+        expect(localHandlerInvoker).not.toHaveBeenCalled();
+      });
+
+      it("never honors a preview bypass when the build has no preview identity", async () => {
+        delete process.env.__NEXT_PREVIEW_MODE_ID;
+        const localHandlerInvoker = vi.fn().mockResolvedValue(undefined);
+        const dispatcher = makeStrictDispatcher(localHandlerInvoker);
+
+        const res = mockRes();
+        await dispatcher.dispatch(
+          mockReq("/blog/nope", {
+            "x-prerender-revalidate": PREVIEW_ID,
+            cookie: `__prerender_bypass=${PREVIEW_ID}`,
+          }),
+          res as unknown as ServerResponse,
+          strictResolution,
+        );
+        expect(res._status).toBe(404);
+        expect(localHandlerInvoker).not.toHaveBeenCalled();
+      });
     });
 
     it("routes a prerender through the handler when one exists (ISR/draft/revalidate semantics)", async () => {
@@ -2807,6 +2886,73 @@ describe("createDispatcher", () => {
       expect(res._status).toBe(200);
       expect(res._headers["location"]).toBeUndefined();
       expect(res._headers["x-nextjs-redirect"]).toBe("/target");
+    });
+
+    // L2: middlewareRedirectLocation consumes client-supplied x-forwarded-host/-proto.
+    // Only well-formed values may influence the relative-vs-absolute Location decision.
+    describe("middleware redirect Location with forwarded headers (L2)", () => {
+      function makeRedirectDispatcher() {
+        return createDispatcher({
+          handlerLoader: { load: vi.fn(), has: vi.fn(), get: vi.fn() } as any,
+          poolName: "ssr",
+          buildId: "test123",
+          staticAssets: [],
+        });
+      }
+
+      async function dispatchRedirect(headers: Record<string, string>, target: string) {
+        const res = mockRes();
+        await makeRedirectDispatcher().dispatch(
+          mockReq("/old", headers),
+          res as unknown as ServerResponse,
+          {
+            kind: "redirect",
+            url: new URL(target),
+            status: 307,
+            resolvedHeaders: new Headers({ location: "/target" }),
+          },
+        );
+        return res;
+      }
+
+      it("honors a well-formed x-forwarded-host and x-forwarded-proto", async () => {
+        const res = await dispatchRedirect(
+          { "x-forwarded-host": "app.example.com:8443", "x-forwarded-proto": "https" },
+          "https://app.example.com:8443/target",
+        );
+        expect(res._status).toBe(307);
+        // Same origin as the forwarded host → relative Location.
+        expect(res._headers["location"]).toBe("/target");
+      });
+
+      it("RED TEAM: ignores a malformed x-forwarded-host and falls back to Host", async () => {
+        const res = await dispatchRedirect(
+          { "x-forwarded-host": "http://evil.example/" },
+          "http://localhost/target",
+        );
+        expect(res._status).toBe(307);
+        // The malformed value must not win — Host (localhost) decides → relative.
+        expect(res._headers["location"]).toBe("/target");
+      });
+
+      it("RED TEAM: a spoofed non-http(s) x-forwarded-proto falls back to http", async () => {
+        const res = await dispatchRedirect(
+          { "x-forwarded-proto": "javascript:alert(1)" },
+          "http://localhost/target",
+        );
+        expect(res._status).toBe(307);
+        expect(res._headers["location"]).toBe("/target");
+      });
+
+      it("RED TEAM: an out-of-range forwarded port never throws into a 500", async () => {
+        const res = await dispatchRedirect(
+          { "x-forwarded-host": "localhost:99999" },
+          "http://localhost/target",
+        );
+        expect(res._status).toBe(307);
+        // URL construction fails defensively → absolute target, still a valid Location.
+        expect(res._headers["location"]).toBe("http://localhost/target");
+      });
     });
 
     it("returns 400 for the error resolution kind (malformed percent-encoding)", async () => {

--- a/tests/pool-server/server.test.ts
+++ b/tests/pool-server/server.test.ts
@@ -46,6 +46,20 @@ describe("createPoolServer", () => {
     await server.close();
     server = null; // already closed
   });
+
+  it("returns a generic body when onRequest throws (L1: no internals to the client)", async () => {
+    const onRequest = vi.fn(() => {
+      throw new Error("sensitive internals: /secret/db password");
+    });
+    server = createPoolServer({ onRequest, port: 0 });
+    const address = await server.start();
+
+    const res = await fetch(`http://127.0.0.1:${address.port}/boom`);
+    expect(res.status).toBe(500);
+    const body = await res.text();
+    expect(body).toBe("Internal Server Error");
+    expect(body).not.toContain("sensitive");
+  });
 });
 
 describe("internal header security", () => {

--- a/tests/pool-server/valkey-cache/incremental-cache-handler.test.ts
+++ b/tests/pool-server/valkey-cache/incremental-cache-handler.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type {
+  ValkeyClient,
+  ValkeyMulti,
+} from "../../../src/pool-server/valkey-cache/resp-client.js";
+import { ValkeyIncrementalCacheHandler } from "../../../src/pool-server/valkey-cache/incremental-cache-handler.js";
+
+// Unit tests for the classic incremental handler's tag caps (L9), size cap (M6), malformed-entry
+// handling (L5) and observable invalidation failures (M1) — no Docker needed.
+
+type Arg = string | number | Buffer;
+
+class FakeValkeyClient implements ValkeyClient {
+  readonly strings = new Map<string, string>();
+  readonly tagFields = new Map<string, string>();
+  readonly setArgs: { key: string; value: string; args: Arg[] }[] = [];
+  evalError: Error | null = null;
+
+  async get(key: string): Promise<string | null> {
+    return this.strings.get(key) ?? null;
+  }
+  async set(key: string, value: string | Buffer, ...args: Arg[]): Promise<string | null> {
+    this.strings.set(key, String(value));
+    this.setArgs.push({ key, value: String(value), args });
+    return "OK";
+  }
+  async del(...keys: string[]): Promise<number> {
+    let n = 0;
+    for (const key of keys) if (this.strings.delete(key)) n++;
+    return n;
+  }
+  async expire(): Promise<number> {
+    return 1;
+  }
+  async ttl(): Promise<number> {
+    return -1;
+  }
+  async eval(...args: Arg[]): Promise<unknown> {
+    if (this.evalError) throw this.evalError;
+    for (let i = 3; i + 1 < args.length; i += 2) {
+      this.tagFields.set(String(args[i]), String(args[i + 1]));
+    }
+    return 1;
+  }
+  async hmget(_key: string, ...fields: string[]): Promise<(string | null)[]> {
+    return fields.map((field) => this.tagFields.get(field) ?? null);
+  }
+  async hset(): Promise<number> {
+    return 1;
+  }
+  async hgetallBuffer(): Promise<Record<string, Buffer>> {
+    return Object.create(null);
+  }
+  multi(): ValkeyMulti {
+    throw new Error("not used by the incremental handler");
+  }
+  async quit(): Promise<void> {}
+}
+
+function appPageEntry(html: string, tagHeader?: string): Record<string, unknown> {
+  return {
+    kind: "APP_PAGE",
+    html,
+    headers: tagHeader === undefined ? {} : { "x-next-cache-tags": tagHeader },
+  } as Record<string, unknown>;
+}
+
+const storedTags = (client: FakeValkeyClient, key: string): string[] => {
+  const raw = client.strings.get(key);
+  if (!raw) throw new Error(`no stored entry for ${key}`);
+  return (JSON.parse(raw) as { tags: string[] }).tags;
+};
+
+afterEach(() => {
+  delete process.env.ADAPTER_K8S_MAX_CACHE_ENTRY_BYTES;
+  vi.restoreAllMocks();
+});
+
+describe("L9: extractTags caps", () => {
+  it("caps the tag list at 128 entries", async () => {
+    const client = new FakeValkeyClient();
+    const h = new ValkeyIncrementalCacheHandler({ client, buildId: "l9", now: () => 1000 });
+    const tags = Array.from({ length: 200 }, (_, i) => `tag-${i}`);
+    await h.set("/p", appPageEntry("P"), { tags });
+    const stored = storedTags(client, "k8s:l9:inc:/p");
+    expect(stored).toHaveLength(128);
+    expect(stored[0]).toBe("tag-0"); // keeps the first tags in declared order
+    expect(stored[127]).toBe("tag-127");
+  });
+
+  it("drops tags longer than 256 chars (manually-set x-next-cache-tags)", async () => {
+    const client = new FakeValkeyClient();
+    const h = new ValkeyIncrementalCacheHandler({ client, buildId: "l9b", now: () => 1000 });
+    const long = "x".repeat(257);
+    const ok = "y".repeat(256);
+    await h.set("/p", appPageEntry("P", `${long},keep,${ok}`), {});
+    expect(storedTags(client, "k8s:l9b:inc:/p")).toEqual(["keep", ok]);
+  });
+
+  it("drops empty segments from a messy header", async () => {
+    const client = new FakeValkeyClient();
+    const h = new ValkeyIncrementalCacheHandler({ client, buildId: "l9c", now: () => 1000 });
+    await h.set("/p", appPageEntry("P", " , a,, b ,"), {});
+    expect(storedTags(client, "k8s:l9c:inc:/p")).toEqual(["a", "b"]);
+  });
+});
+
+describe("M6: entry size cap", () => {
+  it("skips the write when the serialized entry exceeds the cap, logging once", async () => {
+    // Cap sits between a small entry's serialized size (~200 bytes of JSON overhead) and the
+    // oversized ones (4 KiB of HTML each).
+    process.env.ADAPTER_K8S_MAX_CACHE_ENTRY_BYTES = "1024";
+    const client = new FakeValkeyClient();
+    const h = new ValkeyIncrementalCacheHandler({ client, buildId: "m6", now: () => 1000 });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    await h.set("/big", appPageEntry("x".repeat(4096), "t"), {});
+    await h.set("/big2", appPageEntry("y".repeat(4096), "t"), {});
+    expect(client.setArgs).toEqual([]); // nothing reached Valkey
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0]?.[0]).toMatch(/ADAPTER_K8S_MAX_CACHE_ENTRY_BYTES/);
+
+    // An under-cap entry still caches.
+    await h.set("/small", appPageEntry("ok"), {});
+    expect(client.setArgs).toHaveLength(1);
+  });
+});
+
+describe("L5: malformed stored entries degrade to a miss", () => {
+  it.each([
+    ["unparseable JSON", "{corrupt"],
+    [
+      "non-numeric lastModified",
+      JSON.stringify({ value: null, tags: [], lastModified: "1000", ttlSeconds: 61 }),
+    ],
+    [
+      "tags not an array",
+      JSON.stringify({ value: null, tags: "t", lastModified: 1000, ttlSeconds: 61 }),
+    ],
+    [
+      "non-positive ttlSeconds",
+      JSON.stringify({ value: null, tags: [], lastModified: 1000, ttlSeconds: 0 }),
+    ],
+    ["missing value member", JSON.stringify({ tags: [], lastModified: 1000, ttlSeconds: 61 })],
+    ["a JSON array", JSON.stringify([1, 2, 3])],
+  ])("get returns null for %s", async (_label, raw) => {
+    const client = new FakeValkeyClient();
+    client.strings.set("k8s:l5i:inc:/p", raw);
+    const h = new ValkeyIncrementalCacheHandler({ client, buildId: "l5i", now: () => 1000 });
+    expect(await h.get("/p", {})).toBeNull();
+  });
+
+  it("round-trips a real entry through the fake (sanity)", async () => {
+    const client = new FakeValkeyClient();
+    const h = new ValkeyIncrementalCacheHandler({ client, buildId: "ok", now: () => 1000 });
+    await h.set("/p", appPageEntry("PAGE", "prod"), {});
+    const got = await h.get("/p", {});
+    expect(got).not.toBeNull();
+    expect((got!.value as Record<string, unknown>).html).toBe("PAGE");
+    expect(got!.lastModified).toBe(1000);
+  });
+});
+
+describe("M1: revalidateTag failures are observable (fail-open, rate-limited)", () => {
+  it("logs once per 60s class window and never throws", async () => {
+    const client = new FakeValkeyClient();
+    client.evalError = new Error("valkey down");
+    const h = new ValkeyIncrementalCacheHandler({ client, buildId: "m1i", now: () => 1000 });
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    await expect(h.revalidateTag("t")).resolves.toBeUndefined();
+    await expect(h.revalidateTag(["t", "u"])).resolves.toBeUndefined();
+    expect(error).toHaveBeenCalledTimes(1);
+    expect(String(error.mock.calls[0]?.[0])).toMatch(/revalidateTag failed/);
+  });
+});

--- a/tests/pool-server/valkey-cache/resp-client.test.ts
+++ b/tests/pool-server/valkey-cache/resp-client.test.ts
@@ -1,0 +1,333 @@
+import * as net from "node:net";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createRespClient, RespError } from "../../../src/pool-server/valkey-cache/resp-client.js";
+
+// Unit tests for the RESP2 client against an in-process fake server (no Docker needed): raw
+// scripted bytes give exact control over reply framing, so these exercise the inbound
+// reassembly path (M6b), the reply-size caps, protocol validation (L8), URL userinfo AUTH and
+// the plaintext warning (L6), and prototype-pollution safety in hgetallBuffer (L4).
+
+/** Parse one RESP2 command (array of bulk strings) from the head of `buf`. */
+function parseCommand(buf: Buffer): { args: string[]; consumed: number } | null {
+  if (buf.length === 0 || buf[0] !== 0x2a) return null;
+  const lineEnd = buf.indexOf("\r\n");
+  if (lineEnd === -1) return null;
+  const count = Number(buf.toString("utf8", 1, lineEnd));
+  if (!Number.isInteger(count) || count < 1) return null;
+  let cursor = lineEnd + 2;
+  const args: string[] = [];
+  for (let i = 0; i < count; i++) {
+    if (cursor >= buf.length || buf[cursor] !== 0x24) return null;
+    const le = buf.indexOf("\r\n", cursor);
+    if (le === -1) return null;
+    const len = Number(buf.toString("utf8", cursor + 1, le));
+    const start = le + 2;
+    if (!Number.isInteger(len) || len < 0 || start + len + 2 > buf.length) return null;
+    args.push(buf.toString("utf8", start, start + len));
+    cursor = start + len + 2;
+  }
+  return { args, consumed: cursor };
+}
+
+interface FakeServer {
+  url: string;
+  port: number;
+  /** Every command the server has parsed, in arrival order (decoded as strings). */
+  commands: string[][];
+  close: () => Promise<void>;
+}
+
+/**
+ * Start a fake Valkey server. `respond` maps a decoded command to raw reply bytes (an array of
+ * chunks to simulate fragmentation — chunks are written on separate event-loop ticks so they
+ * arrive as separate TCP segments) or null (no reply at all).
+ */
+function startFakeValkey(respond: (cmd: string[]) => Buffer[] | null): Promise<FakeServer> {
+  const commands: string[][] = [];
+  const sockets = new Set<net.Socket>();
+  const server = net.createServer((socket) => {
+    sockets.add(socket);
+    socket.on("error", () => undefined);
+    socket.on("close", () => sockets.delete(socket));
+    let buf = Buffer.alloc(0);
+    socket.on("data", (chunk) => {
+      buf = buf.length ? Buffer.concat([buf, chunk]) : chunk;
+      for (;;) {
+        const parsed = parseCommand(buf);
+        if (!parsed) break;
+        commands.push(parsed.args);
+        buf = buf.subarray(parsed.consumed);
+        const reply = respond(parsed.args);
+        if (reply) {
+          // Trickle chunks on separate ticks so large replies actually arrive fragmented.
+          let i = 0;
+          const tick = () => {
+            if (socket.destroyed || i >= reply.length) return;
+            socket.write(reply[i++]!, tick);
+          };
+          tick();
+        }
+      }
+    });
+  });
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      const { port } = server.address() as net.AddressInfo;
+      resolve({
+        url: `redis://127.0.0.1:${port}`,
+        port,
+        commands,
+        close: () =>
+          new Promise<void>((r) => {
+            for (const s of sockets) s.destroy();
+            server.close(() => r());
+          }),
+      });
+    });
+  });
+}
+
+const ok = () => [Buffer.from("+OK\r\n")];
+const bulk = (value: string | null) => [
+  Buffer.from(value === null ? "$-1\r\n" : `$${Buffer.byteLength(value)}\r\n${value}\r\n`),
+];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("inbound reassembly (M6b)", () => {
+  it("reassembles a large bulk string arriving in many small chunks", async () => {
+    // Patterned (not uniform) payload so an ordering/offset bug changes the bytes.
+    const body = Buffer.alloc(400_000);
+    for (let i = 0; i < body.length; i++) body[i] = 65 + (i % 26);
+    const frame = Buffer.concat([Buffer.from(`$${body.length}\r\n`), body, Buffer.from("\r\n")]);
+    const chunks: Buffer[] = [];
+    for (let i = 0; i < frame.length; i += 8_192) chunks.push(frame.subarray(i, i + 8_192));
+    const server = await startFakeValkey(() => chunks);
+    const client = createRespClient({ url: server.url });
+    try {
+      const got = await client.get("big");
+      expect(got).toBe(body.toString("utf8"));
+    } finally {
+      await client.quit();
+      await server.close();
+    }
+  });
+
+  it("emits multiple pipelined replies from a single TCP chunk", async () => {
+    const server = await startFakeValkey((cmd) => {
+      if (cmd[0] === "GET") return bulk(`v-${cmd[1]}`);
+      return ok();
+    });
+    const client = createRespClient({ url: server.url });
+    try {
+      const [a, b, c] = await Promise.all([client.get("a"), client.get("b"), client.get("c")]);
+      expect([a, b, c]).toEqual(["v-a", "v-b", "v-c"]);
+    } finally {
+      await client.quit();
+      await server.close();
+    }
+  });
+
+  it("parses every reply type: simple string, integer, null bulk, null array", async () => {
+    const server = await startFakeValkey((cmd) => {
+      switch (cmd[0]) {
+        case "SET":
+          return ok();
+        case "GET":
+          return bulk(null);
+        case "TTL":
+          return [Buffer.from(":42\r\n")];
+        case "EVAL":
+          return [Buffer.from("*-1\r\n")];
+        default:
+          return ok();
+      }
+    });
+    const client = createRespClient({ url: server.url });
+    try {
+      expect(await client.set("k", "v")).toBe("OK");
+      expect(await client.get("k")).toBeNull();
+      expect(await client.ttl("k")).toBe(42);
+      expect(await client.eval("return nil", 0)).toBeNull();
+    } finally {
+      await client.quit();
+      await server.close();
+    }
+  });
+});
+
+describe("reply size caps (M6b) and protocol validation (L8)", () => {
+  it("fails all commands when a bulk advertises more than the 64 MiB frame cap", async () => {
+    const server = await startFakeValkey(() => [Buffer.from("$70000000\r\n")]); // header only
+    const client = createRespClient({ url: server.url });
+    try {
+      await expect(client.get("k")).rejects.toThrow(/exceeds the .* cap/);
+    } finally {
+      await client.quit();
+      await server.close();
+    }
+  });
+
+  it("honors a custom maxReplyBytes", async () => {
+    const server = await startFakeValkey(() => [Buffer.from("$2048\r\n")]);
+    const client = createRespClient({ url: server.url, maxReplyBytes: 1024 });
+    try {
+      await expect(client.get("k")).rejects.toThrow(/exceeds the 1024-byte cap/);
+    } finally {
+      await client.quit();
+      await server.close();
+    }
+  });
+
+  it("fails all commands on a NaN bulk length (never desyncs the queue)", async () => {
+    const server = await startFakeValkey(() => [Buffer.from("$notanumber\r\n")]);
+    const client = createRespClient({ url: server.url });
+    try {
+      await expect(client.get("k")).rejects.toThrow(/invalid bulk length/);
+      // The connection was destroyed; a fresh command reconnects rather than reading garbage.
+      expect(server.commands).toEqual([["GET", "k"]]);
+    } finally {
+      await client.quit();
+      await server.close();
+    }
+  });
+
+  it("fails all commands on a NaN array count", async () => {
+    const server = await startFakeValkey(() => [Buffer.from("*x\r\n")]);
+    const client = createRespClient({ url: server.url });
+    try {
+      await expect(client.get("k")).rejects.toThrow(/invalid array count/);
+    } finally {
+      await client.quit();
+      await server.close();
+    }
+  });
+
+  it("fails all commands on an out-of-range negative length (< -1)", async () => {
+    const server = await startFakeValkey(() => [Buffer.from("$-5\r\n")]);
+    const client = createRespClient({ url: server.url });
+    try {
+      await expect(client.get("k")).rejects.toThrow(/invalid bulk length/);
+    } finally {
+      await client.quit();
+      await server.close();
+    }
+  });
+
+  it("fails all commands on pathologically deep array nesting (no stack overflow)", async () => {
+    // Real Valkey replies nest ≤3 levels; `*1\r\n` × 100 is a hostile endpoint probing
+    // the recursive frame scanner. The depth cap must turn it into a protocol error.
+    const server = await startFakeValkey(() => [Buffer.from("*1\r\n".repeat(100))]);
+    const client = createRespClient({ url: server.url });
+    try {
+      await expect(client.get("k")).rejects.toThrow(/nested past 32 levels/);
+    } finally {
+      await client.quit();
+      await server.close();
+    }
+  });
+
+  it("fails all commands on an unknown type byte", async () => {
+    const server = await startFakeValkey(() => [Buffer.from("!bogus\r\n")]);
+    const client = createRespClient({ url: server.url });
+    try {
+      await expect(client.get("k")).rejects.toThrow(/unknown type byte/);
+    } finally {
+      await client.quit();
+      await server.close();
+    }
+  });
+
+  it("a RespError reply rejects that command but keeps the connection usable", async () => {
+    const server = await startFakeValkey((cmd) =>
+      cmd[1] === "bad" ? [Buffer.from("-WRONGTYPE nope\r\n")] : bulk("fine"),
+    );
+    const client = createRespClient({ url: server.url });
+    try {
+      await expect(client.get("bad")).rejects.toBeInstanceOf(RespError);
+      expect(await client.get("good")).toBe("fine");
+    } finally {
+      await client.quit();
+      await server.close();
+    }
+  });
+});
+
+describe("AUTH via URL userinfo + plaintext warning (L6)", () => {
+  it("honors `redis://:pass@host` userinfo when no explicit password is given, warning once", async () => {
+    const server = await startFakeValkey((cmd) => (cmd[0] === "AUTH" ? ok() : bulk("v")));
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const client = createRespClient({ url: `redis://:s3cret@127.0.0.1:${server.port}` });
+    try {
+      expect(await client.get("k")).toBe("v");
+      expect(server.commands[0]).toEqual(["AUTH", "s3cret"]);
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(String(warn.mock.calls[0]?.[0])).toMatch(/cleartext/);
+
+      // An explicit password wins over userinfo, and the plaintext warning stays once-per-process.
+      const explicit = createRespClient({
+        url: `redis://:wrong@127.0.0.1:${server.port}`,
+        password: "right",
+      });
+      try {
+        expect(await explicit.get("k")).toBe("v");
+        const auths = server.commands.filter((c) => c[0] === "AUTH");
+        expect(auths).toEqual([
+          ["AUTH", "s3cret"],
+          ["AUTH", "right"],
+        ]);
+        expect(warn).toHaveBeenCalledTimes(1);
+      } finally {
+        await explicit.quit();
+      }
+
+      // Percent-encoded userinfo is decoded.
+      const encoded = createRespClient({ url: `redis://:p%40ss@127.0.0.1:${server.port}` });
+      try {
+        await encoded.get("k");
+        expect(server.commands.filter((c) => c[0] === "AUTH").at(-1)).toEqual(["AUTH", "p@ss"]);
+      } finally {
+        await encoded.quit();
+      }
+    } finally {
+      await client.quit();
+      await server.close();
+    }
+  });
+
+  it("sends no AUTH and warns nothing when no password is configured anywhere", async () => {
+    const server = await startFakeValkey(() => bulk("v"));
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const client = createRespClient({ url: server.url });
+    try {
+      expect(await client.get("k")).toBe("v");
+      expect(server.commands).toEqual([["GET", "k"]]);
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      await client.quit();
+      await server.close();
+    }
+  });
+});
+
+describe("hgetallBuffer (L4: prototype pollution)", () => {
+  it("stores a `__proto__` FIELD as data on a null-prototype result", async () => {
+    const server = await startFakeValkey(() => [
+      Buffer.from("*2\r\n$9\r\n__proto__\r\n$5\r\nvalue\r\n"),
+    ]);
+    const client = createRespClient({ url: server.url });
+    try {
+      const result = await client.hgetallBuffer("h");
+      expect(Object.getPrototypeOf(result)).toBeNull();
+      expect(Object.prototype.hasOwnProperty.call(result, "__proto__")).toBe(true);
+      expect(result["__proto__"]?.toString("utf8")).toBe("value");
+      // The global object prototype was not polluted.
+      expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    } finally {
+      await client.quit();
+      await server.close();
+    }
+  });
+});

--- a/tests/pool-server/valkey-cache/stream-codec.test.ts
+++ b/tests/pool-server/valkey-cache/stream-codec.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  bufferToStream,
+  drainEntryValue,
+  maxCacheEntryBytes,
+} from "../../../src/pool-server/valkey-cache/stream-codec.js";
+import type { CacheEntry } from "../../../src/pool-server/valkey-cache/types.js";
+
+// Unit tests for the value-stream drain, including the M6 size cap (an over-cap entry degrades
+// to a miss, matching the partial-stream policy) and the env-configurable cap.
+
+function entryOf(text: string): CacheEntry {
+  return {
+    value: bufferToStream(Buffer.from(text, "utf8")),
+    tags: [],
+    stale: 300,
+    timestamp: 1000,
+    expire: 300,
+    revalidate: 60,
+  };
+}
+
+/** A multi-chunk stream entry, so the cap is exercised across chunk boundaries. */
+function chunkedEntry(chunks: string[]): CacheEntry {
+  const entry = entryOf("");
+  entry.value = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(Buffer.from(chunk, "utf8"));
+      controller.close();
+    },
+  });
+  return entry;
+}
+
+afterEach(() => {
+  delete process.env.ADAPTER_K8S_MAX_CACHE_ENTRY_BYTES;
+  vi.restoreAllMocks();
+});
+
+describe("drainEntryValue", () => {
+  it("drains an under-cap stream to a Buffer and leaves the entry's stream readable", async () => {
+    const entry = entryOf("hello world");
+    const buf = await drainEntryValue(entry, 1024);
+    expect(buf?.toString("utf8")).toBe("hello world");
+    // The tee'd branch handed back to the entry still delivers the full body.
+    const reread = await drainEntryValue(entry, 1024);
+    expect(reread?.toString("utf8")).toBe("hello world");
+  });
+
+  it("accepts a body of exactly maxBytes", async () => {
+    const body = "x".repeat(64);
+    const buf = await drainEntryValue(entryOf(body), 64);
+    expect(buf?.toString("utf8")).toBe(body);
+  });
+
+  it("returns null when the accumulated body exceeds maxBytes (M6)", async () => {
+    const buf = await drainEntryValue(chunkedEntry(["a".repeat(40), "b".repeat(40)]), 64);
+    expect(buf).toBeNull();
+  });
+
+  it("returns null when a single chunk exceeds maxBytes", async () => {
+    const buf = await drainEntryValue(entryOf("x".repeat(65)), 64);
+    expect(buf).toBeNull();
+  });
+
+  it("returns null for an errored stream (existing partial-stream policy)", async () => {
+    const entry = entryOf("");
+    entry.value = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(Buffer.from("partial"));
+        controller.error(new Error("boom"));
+      },
+    });
+    expect(await drainEntryValue(entry, 1024)).toBeNull();
+  });
+
+  it("defaults to the ADAPTER_K8S_MAX_CACHE_ENTRY_BYTES env cap", async () => {
+    process.env.ADAPTER_K8S_MAX_CACHE_ENTRY_BYTES = "16";
+    expect(await drainEntryValue(entryOf("x".repeat(17)))).toBeNull();
+    expect((await drainEntryValue(entryOf("x".repeat(16))))?.length).toBe(16);
+  });
+
+  it("logs the oversize skip at most once per process", async () => {
+    // Fresh module state so the once-per-process flag starts unset regardless of test order.
+    vi.resetModules();
+    const codec = await import("../../../src/pool-server/valkey-cache/stream-codec.js");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    expect(await codec.drainEntryValue(entryOf("x".repeat(100)), 8)).toBeNull();
+    expect(await codec.drainEntryValue(entryOf("y".repeat(100)), 8)).toBeNull();
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0]?.[0]).toMatch(/ADAPTER_K8S_MAX_CACHE_ENTRY_BYTES/);
+  });
+});
+
+describe("maxCacheEntryBytes", () => {
+  it("defaults to 16 MiB", () => {
+    expect(maxCacheEntryBytes()).toBe(16 * 1024 * 1024);
+  });
+
+  it("honors a valid env override", () => {
+    process.env.ADAPTER_K8S_MAX_CACHE_ENTRY_BYTES = "1024";
+    expect(maxCacheEntryBytes()).toBe(1024);
+  });
+
+  it("falls back to the default on invalid env values", () => {
+    for (const bad of ["abc", "-5", "0", "NaN", "Infinity"]) {
+      process.env.ADAPTER_K8S_MAX_CACHE_ENTRY_BYTES = bad;
+      expect(maxCacheEntryBytes()).toBe(16 * 1024 * 1024);
+    }
+  });
+});

--- a/tests/pool-server/valkey-cache/tag-manifest.test.ts
+++ b/tests/pool-server/valkey-cache/tag-manifest.test.ts
@@ -5,6 +5,8 @@ import {
   computeTagUpdate,
   evaluateEntry,
   maxExpiration,
+  parseTagState,
+  UPDATE_TAGS_SCRIPT,
   type TagManifest,
   type TagState,
 } from "../../../src/pool-server/valkey-cache/tag-manifest.js";
@@ -73,6 +75,52 @@ describe("maxExpiration (mirrors default.js getExpiration)", () => {
     const m = manifest({ a: { expired: 100 }, b: { expired: 900 }, c: {} });
     expect(maxExpiration(["a", "b", "c"], m)).toBe(900);
     expect(maxExpiration(["c", "missing"], m)).toBe(0);
+  });
+});
+
+describe("UPDATE_TAGS_SCRIPT (L7: merge ordered on the server clock)", () => {
+  it("takes the merge timestamp from the server's TIME, not an ARGV-supplied `at`", () => {
+    expect(UPDATE_TAGS_SCRIPT).toContain("redis.call('TIME')");
+    // The incoming state's `at` is rewritten to the server time before comparing/storing.
+    expect(UPDATE_TAGS_SCRIPT).toContain("nw.at = now");
+    // The merge comparison is against the server clock, never a client-parsed `nw.at`.
+    expect(UPDATE_TAGS_SCRIPT).not.toContain("nwAt");
+  });
+});
+
+describe("parseTagState (L5: corrupt manifest fields degrade safely)", () => {
+  it("parses a well-formed state", () => {
+    expect(parseTagState(JSON.stringify({ stale: 1, expired: 2, at: 3 }))).toEqual({
+      stale: 1,
+      expired: 2,
+      at: 3,
+    });
+  });
+
+  it("returns undefined for invalid JSON", () => {
+    expect(parseTagState("{not json")).toBeUndefined();
+  });
+
+  it("returns undefined for non-object JSON", () => {
+    expect(parseTagState("42")).toBeUndefined();
+    expect(parseTagState('"str"')).toBeUndefined();
+    expect(parseTagState("null")).toBeUndefined();
+    expect(parseTagState("[1,2]")).toBeUndefined();
+  });
+
+  it("treats a corrupt `at` as 0 (older than any real event in the merge)", () => {
+    expect(parseTagState(JSON.stringify({ expired: 5, at: "soon" }))).toEqual({
+      expired: 5,
+      at: 0,
+    });
+    expect(parseTagState(JSON.stringify({ expired: 5 }))).toEqual({ expired: 5, at: 0 });
+  });
+
+  it("drops non-finite watermarks instead of poisoning freshness predicates", () => {
+    // JSON can't represent Infinity/NaN, but a hand-corrupted field can carry strings/null.
+    expect(parseTagState(JSON.stringify({ stale: "x", expired: null, at: 7 }))).toEqual({
+      at: 7,
+    });
   });
 });
 

--- a/tests/pool-server/valkey-cache/use-cache-handler.integration.test.ts
+++ b/tests/pool-server/valkey-cache/use-cache-handler.integration.test.ts
@@ -203,13 +203,26 @@ describe.skipIf(!dockerAvailable)("ValkeyCacheHandler (integration)", () => {
     expect(await b.getExpiration(["live"])).toBeGreaterThan(0);
   });
 
-  it("updateTags is last-event-wins: an older event cannot clobber a newer one", async () => {
-    // Reproduces the concurrent-revalidation race: a later profiled revalidation (future expiry)
-    // must not be overwritten by an older hard-expire that arrives afterward.
-    const early = new ValkeyCacheHandler({ client: newClient(), buildId: "lew", now: () => 5000 });
-    const late = new ValkeyCacheHandler({ client: newClient(), buildId: "lew", now: () => 9000 });
-    await late.updateTags(["t"], { expire: 300 }); // event at 9000 → expired = 9000 + 300_000
-    await early.updateTags(["t"]); // older event at 5000 → must be ignored by the atomic merge
-    expect(await early.getExpiration(["t"])).toBe(9000 + 300_000);
+  it("updateTags merge is last-event-wins on the SERVER clock (client clocks don't order events)", async () => {
+    // The Lua merge stamps each event with the Valkey server's TIME, so ARRIVAL ORDER — not the
+    // (possibly skewed) client clock — decides which event wins. Here the second event carries
+    // the OLDER client clock yet still wins, because it reached the server later. (Pre-L7 this
+    // merge compared client-stamped `at`s, so a backward-stepping replica's invalidation was
+    // silently dropped.)
+    const ahead = new ValkeyCacheHandler({ client: newClient(), buildId: "lew", now: () => 9000 });
+    const behind = new ValkeyCacheHandler({ client: newClient(), buildId: "lew", now: () => 5000 });
+    await ahead.updateTags(["t"], { expire: 300 }); // expired = 9000 + 300_000, arrives first
+    await behind.updateTags(["t"]); // hard-expire (expired = 5000), arrives LATER → wins
+    expect(await ahead.getExpiration(["t"])).toBe(5000);
+  });
+
+  it("updateTags merge: a later-arriving profiled revalidation wins over an earlier hard-expire", async () => {
+    // Same server-clock ordering, opposite direction: the hard-expire arrives first, the
+    // profiled revalidation (future expiry) arrives later and must not be shadowed by it.
+    const early = new ValkeyCacheHandler({ client: newClient(), buildId: "lew2", now: () => 5000 });
+    const late = new ValkeyCacheHandler({ client: newClient(), buildId: "lew2", now: () => 9000 });
+    await early.updateTags(["u"]); // hard-expire, arrives first
+    await late.updateTags(["u"], { expire: 300 }); // arrives LATER → wins
+    expect(await early.getExpiration(["u"])).toBe(9000 + 300_000);
   });
 });

--- a/tests/pool-server/valkey-cache/use-cache-handler.test.ts
+++ b/tests/pool-server/valkey-cache/use-cache-handler.test.ts
@@ -1,0 +1,320 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DURABLE_TTL_SECONDS } from "../../../src/pool-server/valkey-cache/incremental-cache-handler.js";
+import { RespError, type ValkeyMulti } from "../../../src/pool-server/valkey-cache/resp-client.js";
+import type { ValkeyClient } from "../../../src/pool-server/valkey-cache/client.js";
+import { bufferToStream } from "../../../src/pool-server/valkey-cache/stream-codec.js";
+import type { CacheEntry } from "../../../src/pool-server/valkey-cache/types.js";
+import { ValkeyCacheHandler } from "../../../src/pool-server/valkey-cache/use-cache-handler.js";
+
+// Unit tests for the V2 `use cache` handler's defensive write/read paths (no Docker needed):
+// an in-memory fake ValkeyClient records writes and can be scripted to fail.
+
+type Arg = string | number | Buffer;
+
+class FakeValkeyClient implements ValkeyClient {
+  readonly hashes = new Map<string, Record<string, Buffer>>();
+  readonly strings = new Map<string, string>();
+  readonly tagFields = new Map<string, string>();
+  readonly delCalls: string[][] = [];
+  readonly multiExpireArgs: number[] = [];
+  multiCount = 0;
+  /** When set, `multi().exec()` reports it as a per-command failure inside the EXEC reply. */
+  execFailure: RespError | null = null;
+  evalError: Error | null = null;
+  hmgetError: Error | null = null;
+
+  async get(key: string): Promise<string | null> {
+    return this.strings.get(key) ?? null;
+  }
+  async set(key: string, value: string | Buffer): Promise<string | null> {
+    this.strings.set(key, String(value));
+    return "OK";
+  }
+  async del(...keys: string[]): Promise<number> {
+    this.delCalls.push(keys);
+    let n = 0;
+    for (const key of keys) {
+      if (this.hashes.delete(key)) n++;
+      if (this.strings.delete(key)) n++;
+    }
+    return n;
+  }
+  async expire(): Promise<number> {
+    return 1;
+  }
+  async ttl(): Promise<number> {
+    return -1;
+  }
+  async eval(...args: Arg[]): Promise<unknown> {
+    if (this.evalError) throw this.evalError;
+    // args: [script, numkeys, key, field, json, field, json, ...] — naive store, no merge.
+    for (let i = 3; i + 1 < args.length; i += 2) {
+      this.tagFields.set(String(args[i]), String(args[i + 1]));
+    }
+    return 1;
+  }
+  async hmget(_key: string, ...fields: string[]): Promise<(string | null)[]> {
+    if (this.hmgetError) throw this.hmgetError;
+    return fields.map((field) => this.tagFields.get(field) ?? null);
+  }
+  async hset(key: string, ...args: Arg[]): Promise<number> {
+    const hash = this.hashes.get(key) ?? Object.create(null);
+    for (let i = 0; i + 1 < args.length; i += 2) {
+      const value = args[i + 1]!;
+      hash[String(args[i])] = Buffer.isBuffer(value) ? value : Buffer.from(String(value));
+    }
+    this.hashes.set(key, hash);
+    return 1;
+  }
+  async hgetallBuffer(key: string): Promise<Record<string, Buffer>> {
+    return this.hashes.get(key) ?? Object.create(null);
+  }
+  multi(): ValkeyMulti {
+    this.multiCount++;
+    const pendingHsets: [string, Arg[]][] = [];
+    const expireArgs = this.multiExpireArgs;
+    const applyHset = (key: string, args: Arg[]) => this.hset(key, ...args);
+    const getFailure = () => this.execFailure;
+    return {
+      hset(key: string, ...args: Arg[]) {
+        pendingHsets.push([key, args]);
+        return this;
+      },
+      expire(_key: string, seconds: number) {
+        expireArgs.push(seconds);
+        return this;
+      },
+      async exec(): Promise<unknown[]> {
+        const failure = getFailure();
+        if (failure) {
+          // Simulate MULTI's non-atomicity: the HSET applied, the EXPIRE was rejected.
+          for (const [key, args] of pendingHsets) await applyHset(key, args);
+          return [pendingHsets.length, failure];
+        }
+        const results: unknown[] = [];
+        for (const [key, args] of pendingHsets) results.push(await applyHset(key, args));
+        results.push(1);
+        return results;
+      },
+    };
+  }
+  async quit(): Promise<void> {}
+}
+
+function makeEntry(
+  text: string,
+  opts: {
+    tags?: string[];
+    stale?: number;
+    timestamp?: number;
+    expire?: number;
+    revalidate?: number;
+  } = {},
+): CacheEntry {
+  return {
+    value: bufferToStream(Buffer.from(text, "utf8")),
+    tags: opts.tags ?? [],
+    stale: opts.stale ?? 300,
+    timestamp: opts.timestamp ?? 1000,
+    expire: opts.expire ?? 300,
+    revalidate: opts.revalidate ?? 60,
+  };
+}
+
+async function readStream(s: ReadableStream<Uint8Array>): Promise<string> {
+  const reader = s.getReader();
+  const chunks: Buffer[] = [];
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (value) chunks.push(Buffer.from(value));
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+const validMeta = (overrides: Record<string, unknown> = {}) =>
+  JSON.stringify({
+    tags: [],
+    stale: 300,
+    timestamp: 1000,
+    expire: 300,
+    revalidate: 60,
+    ...overrides,
+  });
+
+afterEach(() => {
+  delete process.env.ADAPTER_K8S_MAX_CACHE_ENTRY_BYTES;
+  vi.restoreAllMocks();
+});
+
+describe("set/get round-trip (fake client)", () => {
+  it("caches and serves a fresh entry", async () => {
+    const h = new ValkeyCacheHandler({
+      client: new FakeValkeyClient(),
+      buildId: "u1",
+      now: () => 1000,
+    });
+    await h.set("k", Promise.resolve(makeEntry("hello", { tags: ["t"] })));
+    const got = await h.get("k", []);
+    expect(got).toBeDefined();
+    expect(await readStream(got!.value)).toBe("hello");
+  });
+});
+
+describe("H4: non-finite lifetimes are refused, EXEC failures are detected", () => {
+  it("does NOT cache an entry with a NaN expire (and warns once per process)", async () => {
+    const client = new FakeValkeyClient();
+    const h = new ValkeyCacheHandler({ client, buildId: "h4", now: () => 1000 });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    await h.set("k", Promise.resolve(makeEntry("v", { expire: NaN })));
+    await h.set("k2", Promise.resolve(makeEntry("v", { revalidate: Infinity })));
+
+    // No write was ever dispatched, and reads see nothing.
+    expect(client.multiCount).toBe(0);
+    expect(client.hashes.size).toBe(0);
+    expect(await h.get("k", [])).toBeUndefined();
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0]?.[0]).toMatch(/non-finite or non-positive/);
+  });
+
+  it("does NOT cache an entry with a non-positive lifetime", async () => {
+    const client = new FakeValkeyClient();
+    const h = new ValkeyCacheHandler({ client, buildId: "h4b", now: () => 1000 });
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    await h.set("k", Promise.resolve(makeEntry("v", { expire: 0 })));
+    expect(client.multiCount).toBe(0);
+    expect(await h.get("k", [])).toBeUndefined();
+  });
+
+  it("treats a per-command EXEC failure as a failed write and DELs the partial entry", async () => {
+    const client = new FakeValkeyClient();
+    client.execFailure = new RespError("ERR invalid expire time in 'expire' command");
+    const h = new ValkeyCacheHandler({ client, buildId: "h4c", now: () => 1000 });
+
+    // set() must not reject (a cache write failure never breaks the response)...
+    await expect(h.set("k", Promise.resolve(makeEntry("v")))).resolves.toBeUndefined();
+    // ...but the partially-applied HSET (no TTL) must be cleaned up.
+    expect(client.delCalls).toEqual([["k8s:h4c:entry:k"]]);
+    expect(client.hashes.size).toBe(0);
+    expect(await h.get("k", [])).toBeUndefined();
+  });
+
+  it("does NOT DEL a previously cached entry when the entry promise itself rejects", async () => {
+    const client = new FakeValkeyClient();
+    const h = new ValkeyCacheHandler({ client, buildId: "h4d", now: () => 1000 });
+    await h.set("k", Promise.resolve(makeEntry("good")));
+    expect(client.hashes.size).toBe(1);
+    await h.set("k", Promise.reject(new Error("render failed")));
+    // The write was never dispatched, so no cleanup DEL may remove the old entry.
+    expect(client.delCalls).toEqual([]);
+    expect(await h.get("k", [])).toBeDefined();
+  });
+});
+
+describe("M7: V2 key TTL is capped at DURABLE_TTL_SECONDS", () => {
+  it("caps the EXPIRE argument for an INFINITE_CACHE-scale expire (~136 years)", async () => {
+    const client = new FakeValkeyClient();
+    const h = new ValkeyCacheHandler({ client, buildId: "m7", now: () => 1000 });
+    await h.set(
+      "k",
+      Promise.resolve(makeEntry("v", { expire: 2 ** 32 - 1, revalidate: 2 ** 32 - 1 })),
+    );
+    expect(client.multiExpireArgs).toEqual([DURABLE_TTL_SECONDS]);
+    expect(DURABLE_TTL_SECONDS).toBe(30 * 24 * 60 * 60);
+  });
+
+  it("does not shorten a normal TTL (expire + retention margin)", async () => {
+    const client = new FakeValkeyClient();
+    const h = new ValkeyCacheHandler({ client, buildId: "m7b", now: () => 1000 });
+    await h.set("k", Promise.resolve(makeEntry("v", { expire: 300, revalidate: 60 })));
+    expect(client.multiExpireArgs).toEqual([360]); // 300 + 60s retention margin
+  });
+});
+
+describe("M6: entry size cap", () => {
+  it("skips caching when the value exceeds ADAPTER_K8S_MAX_CACHE_ENTRY_BYTES", async () => {
+    process.env.ADAPTER_K8S_MAX_CACHE_ENTRY_BYTES = "16";
+    const client = new FakeValkeyClient();
+    const h = new ValkeyCacheHandler({ client, buildId: "m6", now: () => 1000 });
+    await h.set("k", Promise.resolve(makeEntry("x".repeat(64))));
+    expect(client.multiCount).toBe(0);
+    expect(await h.get("k", [])).toBeUndefined();
+  });
+});
+
+describe("L5: malformed stored entries degrade to a miss", () => {
+  const preload = (client: FakeValkeyClient, key: string, fields: Record<string, string>) => {
+    const hash: Record<string, Buffer> = Object.create(null);
+    for (const [f, v] of Object.entries(fields)) hash[f] = Buffer.from(v, "utf8");
+    client.hashes.set(`k8s:l5:entry:${key}`, hash);
+  };
+
+  it("meta present but value field missing → miss (not an empty fresh entry)", async () => {
+    const client = new FakeValkeyClient();
+    preload(client, "k", { m: validMeta() }); // no "v"
+    const h = new ValkeyCacheHandler({ client, buildId: "l5", now: () => 1000 });
+    expect(await h.get("k", [])).toBeUndefined();
+  });
+
+  it("unparseable meta JSON → miss", async () => {
+    const client = new FakeValkeyClient();
+    preload(client, "k", { m: "{corrupt", v: "value" });
+    const h = new ValkeyCacheHandler({ client, buildId: "l5", now: () => 1000 });
+    expect(await h.get("k", [])).toBeUndefined();
+  });
+
+  it.each([
+    ["non-numeric expire", { expire: "300" }],
+    ["NaN revalidate", { revalidate: null }],
+    ["missing timestamp", { timestamp: undefined }],
+    ["tags not an array", { tags: "t1,t2" }],
+    ["tags with non-string members", { tags: [1, 2] }],
+    ["meta is a JSON array", null],
+  ])("invalid meta shape (%s) → miss", async (_label, patch) => {
+    const client = new FakeValkeyClient();
+    const raw = patch === null ? "[1,2,3]" : validMeta(patch as Record<string, unknown>);
+    preload(client, "k", { m: raw, v: "value" });
+    const h = new ValkeyCacheHandler({ client, buildId: "l5", now: () => 1000 });
+    expect(await h.get("k", [])).toBeUndefined();
+  });
+});
+
+describe("L3: getExpiration fails STALE (not fresh) on error", () => {
+  it("returns now and logs rate-limited when the manifest read fails", async () => {
+    const client = new FakeValkeyClient();
+    client.hmgetError = new Error("valkey down");
+    const h = new ValkeyCacheHandler({ client, buildId: "l3", now: () => 777_000 });
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    expect(await h.getExpiration(["a"])).toBe(777_000);
+    expect(await h.getExpiration(["a"])).toBe(777_000);
+    expect(error).toHaveBeenCalledTimes(1); // rate-limited, not per-call
+  });
+});
+
+describe("M1: updateTags failures are observable (fail-open, rate-limited)", () => {
+  it("logs once per 60s class window and never throws", async () => {
+    const client = new FakeValkeyClient();
+    client.evalError = new Error("valkey down");
+    const h = new ValkeyCacheHandler({ client, buildId: "m1", now: () => 1000 });
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    await expect(h.updateTags(["t"])).resolves.toBeUndefined();
+    await expect(h.updateTags(["t"])).resolves.toBeUndefined();
+    expect(error).toHaveBeenCalledTimes(1);
+    expect(String(error.mock.calls[0]?.[0])).toMatch(/updateTags failed/);
+  });
+});
+
+describe("tag state reads", () => {
+  it("corrupt manifest fields are treated as 'never revalidated'", async () => {
+    const client = new FakeValkeyClient();
+    client.tagFields.set("t", "{corrupt json");
+    const h = new ValkeyCacheHandler({ client, buildId: "ts", now: () => 1000 });
+    // A corrupt field must not throw or invalidate; entry stays fresh.
+    expect(await h.getExpiration(["t"])).toBe(0);
+    await h.set("k", Promise.resolve(makeEntry("v", { tags: ["t"] })));
+    expect(await h.get("k", [])).toBeDefined();
+  });
+});

--- a/tests/routing-service/server.test.ts
+++ b/tests/routing-service/server.test.ts
@@ -1,4 +1,10 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import http2 from "node:http2";
+import https from "node:https";
 import { create, toBinary, fromBinary } from "@bufbuild/protobuf";
 import {
   createRoutingServer,
@@ -39,24 +45,118 @@ async function collect(gen: AsyncGenerator<ProcessingResponse>): Promise<Process
 
 describe("createRoutingServer", () => {
   let server: ReturnType<typeof createRoutingServer> | null = null;
+  let tmpDir: string | null = null;
+  const savedTlsEnv: Record<string, string | undefined> = {};
 
   afterEach(async () => {
     if (server) {
       await server.stop();
       server = null;
     }
+    for (const key of ["TLS_CERT_FILE", "TLS_KEY_FILE"]) {
+      if (savedTlsEnv[key] === undefined) delete process.env[key];
+      else process.env[key] = savedTlsEnv[key];
+      delete savedTlsEnv[key];
+    }
+    if (tmpDir) {
+      rmSync(tmpDir, { recursive: true, force: true });
+      tmpDir = null;
+    }
   });
 
-  it("creates an HTTP/2 ext_proc server that can start and stop", async () => {
-    const handler = vi.fn().mockResolvedValue({
+  function continueHandler() {
+    return vi.fn().mockResolvedValue({
       requestHeaders: { response: { headerMutation: { setHeaders: [] }, status: "CONTINUE" } },
     } as PlainProcessingResponse);
+  }
 
-    server = createRoutingServer({ handler, port: 0 });
+  it("creates an HTTP/2 ext_proc server that can start and stop", async () => {
+    server = createRoutingServer({ handler: continueHandler(), port: 0 });
     const address = await server.start();
     expect(address.port).toBeGreaterThan(0);
     await server.stop();
     server = null;
+  });
+
+  it("keeps the plaintext h2c path working for emulate (no TLS env)", async () => {
+    server = createRoutingServer({ handler: continueHandler(), port: 0 });
+    const { port } = await server.start();
+
+    // An h2 client connects to the plaintext server — the local/emulate path is unchanged.
+    const session = http2.connect(`http://127.0.0.1:${port}`);
+    await new Promise<void>((resolve, reject) => {
+      session.once("connect", () => resolve());
+      session.once("error", reject);
+    });
+    session.close();
+  });
+
+  // H1b: the TLS ext_proc data path is HTTP/2-only (allowHTTP1: false). Health checks run
+  // on the separate plaintext HTTP server, so HTTP/1.1 must never reach the Connect handler.
+  it("serves HTTP/2 over TLS and rejects HTTP/1.1 clients", async () => {
+    // Mint a throwaway self-signed pair — the same openssl invocation the container-start
+    // path in index.ts uses (L11).
+    tmpDir = mkdtempSync(path.join(os.tmpdir(), "routing-tls-test-"));
+    const certFile = path.join(tmpDir, "tls-cert.pem");
+    const keyFile = path.join(tmpDir, "tls-key.pem");
+    execFileSync(
+      "openssl",
+      [
+        "req",
+        "-x509",
+        "-newkey",
+        "rsa:2048",
+        "-nodes",
+        "-keyout",
+        keyFile,
+        "-out",
+        certFile,
+        "-days",
+        "1",
+        "-subj",
+        "/CN=test-routing-service",
+      ],
+      { stdio: ["ignore", "ignore", "pipe"] },
+    );
+    savedTlsEnv.TLS_CERT_FILE = process.env.TLS_CERT_FILE;
+    savedTlsEnv.TLS_KEY_FILE = process.env.TLS_KEY_FILE;
+    process.env.TLS_CERT_FILE = certFile;
+    process.env.TLS_KEY_FILE = keyFile;
+
+    server = createRoutingServer({ handler: continueHandler(), port: 0 });
+    // Track TLS sockets so the test can force-close the ALPN-rejected HTTP/1.1 connection:
+    // Node answers it with a terminal 403 but deliberately keeps the socket open, which
+    // would otherwise stall server.stop() waiting for it.
+    const sockets = new Set<import("node:net").Socket>();
+    server.server.on("secureConnection", (socket: import("node:net").Socket) => {
+      sockets.add(socket);
+      socket.once("close", () => sockets.delete(socket));
+    });
+    const { port } = await server.start();
+
+    // HTTP/2 over TLS works — this is the GCP ext_proc data path.
+    const session = http2.connect(`https://127.0.0.1:${port}`, { rejectUnauthorized: false });
+    await new Promise<void>((resolve, reject) => {
+      session.once("connect", () => resolve());
+      session.once("error", reject);
+    });
+    session.destroy();
+
+    // An HTTP/1.1 client is rejected at the ALPN layer (allowHTTP1: false) and never
+    // reaches the Connect handler.
+    const http1Status = await new Promise<number>((resolve, reject) => {
+      const req = https.request(
+        { host: "127.0.0.1", port, path: "/", rejectUnauthorized: false, agent: false },
+        (res) => {
+          res.resume();
+          res.once("end", () => resolve(res.statusCode ?? 0));
+        },
+      );
+      req.once("error", reject);
+      req.end();
+    });
+    expect(http1Status).toBe(403);
+    for (const socket of sockets) socket.destroy();
   });
 });
 


### PR DESCRIPTION
Remediates every finding from the full-codebase security review (see `docs/security-review-2026-07-20.md` for findings, remediation status, and accepted trade-offs): 5 High, 10 Medium, and 16 Low, plus follow-up hardening from a second review pass. **606 tests passing (55 files), +~60 new security regression tests.**

## High

- **H1 — In-cluster isolation:** New NetworkPolicy templates. The routing service accepts only non-pod (LB/health-check) ingress on 8443/8081, closing the in-cluster dispatch-secret extraction path; pools accept LB + sibling-pool traffic only (the routing-service component is explicitly excluded). Deploy discovers the cluster pod CIDR and **fails closed** — a failed/malformed lookup aborts the deploy unless `--allow-no-network-policy` is passed explicitly. Standard clusters are created with `--enable-network-policy`; the TLS server sets `allowHTTP1: false`.
- **H2 — Input validation at the boundary:** `buildId`, `releaseName`, hostname, registry, namespace, project, region, bucket, and pool names are validated against strict charsets at every boundary (build, deploy, template render) before reaching `helm --set`, YAML, or spawned commands. All spawns are `shell: false` with array args.
- **H3 — Container hardening:** `USER node` in all images; `runAsNonRoot`, `readOnlyRootFilesystem`, `allowPrivilegeEscalation: false`, `capabilities: drop ALL`, `seccompProfile: RuntimeDefault`, `automountServiceAccountToken: false` on app workloads (the route-ext Job keeps its token for Workload Identity — pinned by test); writable `emptyDir`s at `/tmp` and `/app/.next/cache`.
- **H4 — Cache-poisoning via non-finite lifetimes:** finite-lifetime guard skips the write entirely; MULTI/EXEC replies are inspected per-command with best-effort `DEL` on partial failure. Regression tests simulate EXEC non-atomicity.
- **H5 — Memorystore AUTH + TLS:** `cache.memorystore.auth: true` provisions with AUTH + in-transit encryption; CA pinned in the RESP client (`rejectUnauthorized` never disabled); credentials delivered Secret-only via `VALKEY_AUTH`/`VALKEY_CA_CERT`; existing non-AUTH instances rejected with remediation guidance; one-tenant-per-instance documented in README § Distributed Cache.

## Medium (all 10)

Rate-limited logging for silent `revalidateTag`/cache failures; Windows `shell: true` removed (PATH-resolved spawn); `releaseName` validated and length-capped; secret files written `0600` + `.gitignore` scaffolded; hostname/registry/CEL-YAML escaping; cache entry size caps + RESP reassembly rewrite (chunk-array with concat-once, 64 MiB frame cap, nesting depth cap); V2 TTL capped at 30d; HTTP→HTTPS redirect route; least-privilege custom IAM role (8 permissions) replacing project-wide admin roles; preview/revalidate bypass now requires constant-time comparison against `previewModeId`.

## Low (all 16)

Generic client error bodies; `x-forwarded-*` gating; fail-toward-stale `getExpiration`; `Object.create(null)` hash replies; malformed-entry → miss; URL userinfo honored as AUTH + cleartext-AUTH warning; server-clock tag merges; tag caps (128×256); `TRUST_INTERNAL_HEADERS` out of the chart; per-replica TLS certs minted at container start; `destroy` typed-confirmation gate + `--yes`; inert dry-runs; terminal control-char stripping; `.env.example` out of images; pool-name assertion; collision-resistant Job naming.

## Job-name digest (second commit)

The route-ext Job name now uses a 12-hex-char SHA-256 digest of the full build id (`<release>-route-ext-<digest>`), so max-length (40-char) release names still produce unique, 63-char-safe names — the old truncation retained only a 12-char build-id prefix and could collide across builds of immutable Jobs. The full build id is recorded in an `adapter-k8s.dev/build-id` annotation for operator traceability, and `RELEASE_NAME_RE` now rejects leading/trailing hyphens (invalid as a DNS-1123 name prefix).

## Accepted trade-offs (documented in the review doc §6)

- The ext_proc protocol still echoes the dispatch secret — exposure bounded by NetworkPolicy + ALPN rather than eliminated (a future mTLS design could remove it).
- `readOnlyRootFilesystem` may surface app-level write paths unit tests can't see — readiness gating fails safe (no cutover); run `test:e2e:live` before publishing.
- `cloud-sdk:slim` remains a floating tag; the Job is otherwise hardened and TTL-swept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
