### PR TITLE
Resolve `next` app-first when staging the pool context

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,9 @@ name: ci
 on:
   push:
     branches: [main, jamesdaniels_wip]
+  # No base-branch filter: the filter matches the PR's BASE, which silently skipped
+  # CI for stacked PRs (PRs targeting a feature branch instead of main).
   pull_request:
-    branches: [main, jamesdaniels_wip]
 
 jobs:
   build-and-test:

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -20,16 +20,24 @@ const _dirname =
       ? __dirname
       : process.cwd();
 
-// Resolve a dependency's directory, preferring the ADAPTER package (where the dep is
-// declared, e.g. @next/routing) over the app root. Strict package managers (pnpm) do not
-// expose the adapter's transitive deps from the app root, so app-first resolution turns a
-// valid install into "cannot find module". App-root is kept as a fallback for hoisted
-// layouts (npm) and for a symlinked adapter checkout.
-function resolveDepDir(dep: string, projectDir: string): string | undefined {
-  const fromFiles = [
-    path.join(_dirname, "index.js"), // adapter package (dist/)
-    path.join(projectDir, "package.json"), // app root
-  ];
+// Resolve a dependency's directory. The preferred resolution root depends on who OWNS the
+// dep:
+//   - "adapter" (default): deps the adapter declares (e.g. @next/routing). Strict package
+//     managers (pnpm) do not expose the adapter's transitive deps from the app root, so
+//     app-first resolution turns a valid install into "cannot find module". App-root is
+//     kept as a fallback for hoisted layouts (npm) and for a symlinked adapter checkout.
+//   - "app": deps the APP declares (e.g. next). The app's copy is the version its build
+//     output requires at runtime; with a symlinked adapter checkout, adapter-first would
+//     silently stage the ADAPTER repo's copy — a version skew between build and image.
+//     Adapter-root is kept as a fallback for layouts where the app root cannot resolve it.
+function resolveDepDir(
+  dep: string,
+  projectDir: string,
+  owner: "adapter" | "app" = "adapter",
+): string | undefined {
+  const adapterRoot = path.join(_dirname, "index.js"); // adapter package (dist/)
+  const appRoot = path.join(projectDir, "package.json"); // app root
+  const fromFiles = owner === "app" ? [appRoot, adapterRoot] : [adapterRoot, appRoot];
   for (const fromFile of fromFiles) {
     try {
       return path.dirname(createRequire(fromFile).resolve(`${dep}/package.json`));
@@ -1802,8 +1810,9 @@ export function createK8sAdapter(userConfig?: K8sAdapterConfig): NextAdapter {
           // N50 (review, Low): `<projectDir>/node_modules/next` under an existsSync guard
           // silently staged NOTHING in a hoisted workspace (npm/yarn put `next` at the
           // workspace root), which is a "Cannot find module 'next/...'" crash in the pool.
-          // Resolve it the same way @next/routing is resolved, and fail loudly.
-          const nextPkgDir = resolveDepDir("next", projectDir);
+          // Resolve via createRequire like @next/routing — but app-first: `next` is the
+          // app's dependency and the app's version is the one its build output needs.
+          const nextPkgDir = resolveDepDir("next", projectDir, "app");
           if (!nextPkgDir || !existsSync(nextPkgDir)) {
             throw new Error(
               `[adapter-k8s] Could not resolve the "next" package from ${projectDir}. The pool ` +

--- a/tests/adapter-build-context.test.ts
+++ b/tests/adapter-build-context.test.ts
@@ -195,6 +195,22 @@ describe("pool build context staging", () => {
     });
   });
 
+  // `next` is the APP's dependency: the staged copy must be the version the app builds
+  // against, not whatever the adapter package happens to resolve. With a symlinked adapter
+  // checkout (or these tests), adapter-first resolution shipped the ADAPTER repo's `next`
+  // into the pool image — a silent version skew between build and runtime.
+  it("stages the app's own next package, not the adapter's (app-first resolution)", async () => {
+    seedProject();
+    writeFile(
+      "node_modules/next/package.json",
+      JSON.stringify({ name: "next", version: "0.0.0-app-local" }),
+    );
+    await build();
+
+    const staged = JSON.parse(readFileSync(poolContext("node_modules/next/package.json"), "utf-8"));
+    expect(staged.version).toBe("0.0.0-app-local");
+  });
+
   // N50 (review #32, reproduced): the pool context dirs were never wiped and `stageFile`
   // copies with `cp(..., { recursive: true })`, which MERGES — so a chunk (or a route
   // handler, or a public file) deleted from the source kept shipping inside every subsequent


### PR DESCRIPTION
Stacked on #<!-- -->`jamesdaniels_addressingReviewFeedback`.

## What

`resolveDepDir` gains an `owner: "adapter" | "app"` parameter. `@next/routing` (and the sharp resolver) stay adapter-first per the N50 pnpm rationale; the `next` staging call site (src/adapter.ts:1815) becomes app-first, with adapter-root kept as fallback.

## Why

Two consequences of adapter-first resolution for `next`:

1. **Version skew (prod):** with a symlinked adapter checkout, the pool image silently shipped the *adapter repo's* `next`, not the version the app's build output requires. The app always declares `next` directly, so app-first resolution is safe under pnpm-strict layouts — the pnpm argument only applies to the adapter's own transitive deps.

2. **CI timeouts (the red `ci` runs since 4bfa6ad):** the `adapter-build-context` tests seed a 2-file fake `next` in a tmpdir project, but every `build()` resolved and staged this repo's real ~8k-file Next install — ~80k `stat` / ~24k `copyFile` / ~26k `chmod` per 3 builds (measured via fs interception). The four tests that run `build()` twice took ~740ms locally and blew vitest's 5s default timeout on shared `ubuntu-latest` runners, deterministically. With the fix the file drops from ~7s to ~0.5s locally and the tests are hermetic as the file header claims.

## Test

New regression test: seeds `node_modules/next` in the app project with version `0.0.0-app-local` and asserts the staged `node_modules/next/package.json` is the app's copy. Watched it fail red (staged copy was this repo's `16.2.10`) before the fix.

- `tests/adapter-build-context.test.ts`: 19/19 pass, 6.73s → 283ms
- Full suite: 1928 passed; 1 failure is pre-existing and unrelated (see below)
- `tsc --emitDeclarationOnly` clean; no new lint/format issues

## Note: pre-existing env-sensitive test (not addressed here)

`adapter-config.test.ts > "fails when release+pool truncation collapses distinct build ids"` fails in any checkout whose directory name exceeds ~12 chars (verified on the base commit): `modifyConfig({}, {})` has no projectDir, so `deriveReleaseName` falls back to `process.cwd()`'s basename, and a long dir name trips the 59-char budget in `validateConfig` before the guard under test runs. Passes in CI (`adapter-k8s`) and the main checkout; worth a hermeticity fix in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)