### PR TITLE
Strip Next resume control headers at ingress

### DIFF
--- a/src/pool-server/server.ts
+++ b/src/pool-server/server.ts
@@ -4,6 +4,7 @@ import {
   INTERNAL_DISPATCH_HEADERS,
   INTERNAL_SECRET_HEADER,
   requestTargetPathname,
+  UNTRUSTED_NEXT_REQUEST_HEADERS,
 } from "../routing-common.js";
 import { guardStreamErrors, timingSafeStringEqual } from "./dispatch.js";
 
@@ -61,6 +62,14 @@ export function applyRequestTrustBoundary(
     ? typeof presentedSecret === "string" && timingSafeStringEqual(presentedSecret, internalSecret)
     : trustInternalHeaders;
   delete req.headers[INTERNAL_SECRET_HEADER];
+
+  // These are private Next.js control headers, not trusted adapter dispatch headers. Never
+  // preserve a network-supplied value, even when this request carries a valid dispatch secret:
+  // the upstream routing tier may otherwise turn public resume controls into trusted postponed
+  // state. Legitimate resume controls are synthesized later on private local invocations.
+  for (const h of UNTRUSTED_NEXT_REQUEST_HEADERS) {
+    delete req.headers[h];
+  }
 
   // Strip internal routing headers from untrusted sources. A client must not be able to
   // spoof the dispatch protocol (e.g. x-output-id → dispatch straight to a handler, skipping

--- a/src/routing-common.ts
+++ b/src/routing-common.ts
@@ -58,6 +58,17 @@ export const INTERNAL_DISPATCH_HEADERS = [
   "x-mw-request-headers",
 ] as const;
 
+// Next.js treats these as private request-control headers. `next-resume: 1` tells the App Router
+// to deserialize the request body as trusted postponed state; `x-next-resume-state-length` frames
+// postponed state prepended to a Server Action body. They are NOT part of the adapter's
+// secret-gated dispatch protocol: no network hop is allowed to preserve client-supplied values.
+// The pool creates either header only after this boundary, so stripping them at both public
+// ingress tiers does not interfere with legitimate resume handling.
+export const UNTRUSTED_NEXT_REQUEST_HEADERS = [
+  "next-resume",
+  "x-next-resume-state-length",
+] as const;
+
 // Recognized `x-mw-evaluated` verdicts that authorize the pool to skip its own middleware.
 // `ran` = matched + executed; `skip-nomatch` = middleware exists but matcher didn't match;
 // `none` = the app has no middleware. Anything else (incl. `error` / absent) ⇒ do NOT skip.

--- a/src/routing-service/handler.ts
+++ b/src/routing-service/handler.ts
@@ -29,6 +29,7 @@ import {
   serializeHeaderMap,
   INTERNAL_DISPATCH_HEADERS,
   INTERNAL_SECRET_HEADER,
+  UNTRUSTED_NEXT_REQUEST_HEADERS,
 } from "../routing-common.js";
 
 type LoadedModule = Record<string, unknown>;
@@ -205,6 +206,7 @@ export function createRequestHandler(
           (h) =>
             !h.key.startsWith(":") &&
             !(INTERNAL_DISPATCH_HEADERS as readonly string[]).includes(h.key.toLowerCase()) &&
+            !(UNTRUSTED_NEXT_REQUEST_HEADERS as readonly string[]).includes(h.key.toLowerCase()) &&
             h.key.toLowerCase() !== INTERNAL_SECRET_HEADER,
         )
         .map((h) => [h.key, h.value ?? h.rawValue?.toString("utf-8") ?? ""] as [string, string]),
@@ -263,7 +265,7 @@ export function createRequestHandler(
     if (middlewareModule && method !== "GET" && method !== "HEAD") {
       return buildHeaderMutationResponse(
         [],
-        [...INTERNAL_DISPATCH_HEADERS, INTERNAL_SECRET_HEADER],
+        [...INTERNAL_DISPATCH_HEADERS, ...UNTRUSTED_NEXT_REQUEST_HEADERS, INTERNAL_SECRET_HEADER],
       );
     }
 
@@ -691,7 +693,7 @@ export function createRequestHandler(
       // cost the body backstop pays, and it is the fail-safe direction.)
       return buildHeaderMutationResponse(
         [],
-        [...INTERNAL_DISPATCH_HEADERS, INTERNAL_SECRET_HEADER],
+        [...INTERNAL_DISPATCH_HEADERS, ...UNTRUSTED_NEXT_REQUEST_HEADERS, INTERNAL_SECRET_HEADER],
       );
     }
 
@@ -717,7 +719,11 @@ export function createRequestHandler(
     // Every internal dispatch header the extension does NOT set this response must be actively
     // removed, so a client can't smuggle one past the extension (setHeaders only overwrites the
     // keys it lists). We start by clearing all of them, then un-clear each key we set below.
-    const clear = new Set<string>([...INTERNAL_DISPATCH_HEADERS, INTERNAL_SECRET_HEADER]);
+    const clear = new Set<string>([
+      ...INTERNAL_DISPATCH_HEADERS,
+      ...UNTRUSTED_NEXT_REQUEST_HEADERS,
+      INTERNAL_SECRET_HEADER,
+    ]);
     const setDispatch = (key: string, value: string) => {
       mutations.push({ key, value });
       clear.delete(key);
@@ -890,7 +896,7 @@ export function createRequestHandler(
       );
       return buildHeaderMutationResponse(
         [],
-        [...INTERNAL_DISPATCH_HEADERS, INTERNAL_SECRET_HEADER],
+        [...INTERNAL_DISPATCH_HEADERS, ...UNTRUSTED_NEXT_REQUEST_HEADERS, INTERNAL_SECRET_HEADER],
       );
     }
 

--- a/tests/pool-server/server.test.ts
+++ b/tests/pool-server/server.test.ts
@@ -211,6 +211,41 @@ describe("internal header security", () => {
       expect(authHeader).toBe("Bearer token123");
     });
 
+    it("always strips client-supplied Next resume headers on a trusted dispatch hop", async () => {
+      let outputId: string | undefined;
+      let nextResume: string | undefined;
+      let resumeStateLength: string | undefined;
+      const onRequest = vi.fn((req: IncomingMessage, res: ServerResponse) => {
+        outputId = req.headers["x-output-id"] as string | undefined;
+        nextResume = req.headers["next-resume"] as string | undefined;
+        resumeStateLength = req.headers["x-next-resume-state-length"] as string | undefined;
+        res.writeHead(200);
+        res.end("ok");
+      });
+
+      server = createPoolServer({
+        onRequest,
+        port: 0,
+        internalSecret: "the-secret",
+      });
+      const { port } = await server.start();
+
+      await fetch(`http://127.0.0.1:${port}/page`, {
+        method: "POST",
+        headers: {
+          "x-internal-secret": "the-secret",
+          "x-output-id": "/page",
+          "next-resume": "1",
+          "x-next-resume-state-length": "32",
+        },
+        body: "attacker-controlled-postponed-state",
+      });
+
+      expect(outputId).toBe("/page");
+      expect(nextResume).toBeUndefined();
+      expect(resumeStateLength).toBeUndefined();
+    });
+
     it("preserves the public Pages Router middleware prefetch hint", async () => {
       let prefetchHeader: string | undefined;
       let privateHeader: string | undefined;

--- a/tests/routing-common.tier-parity.test.ts
+++ b/tests/routing-common.tier-parity.test.ts
@@ -35,6 +35,7 @@ import {
   INTERNAL_DISPATCH_HEADERS,
   INTERNAL_SECRET_HEADER,
   parseRequestUrl,
+  UNTRUSTED_NEXT_REQUEST_HEADERS,
 } from "../src/routing-common.js";
 
 const ORIGIN = "http://app.example.com";
@@ -725,7 +726,11 @@ describe("Phase 1 / Phase 2 middleware response parity (N40 / findings #16, #35,
     // … and must clear the WHOLE vocabulary (plus the secret) so the pool re-resolves untrusted.
     expect(r.phase2.dispatch("x-mw-evaluated")).toBeUndefined();
     expect(new Set(r.phase2.removeHeaders)).toEqual(
-      new Set([...INTERNAL_DISPATCH_HEADERS, INTERNAL_SECRET_HEADER]),
+      new Set([
+        ...INTERNAL_DISPATCH_HEADERS,
+        ...UNTRUSTED_NEXT_REQUEST_HEADERS,
+        INTERNAL_SECRET_HEADER,
+      ]),
     );
   });
 

--- a/tests/routing-service/handler.test.ts
+++ b/tests/routing-service/handler.test.ts
@@ -9,7 +9,11 @@ import {
   type ProcessingResponse as ProtoProcessingResponse,
 } from "../../src/routing-service/protos/envoy/service/ext_proc/v3/external_processor_pb.js";
 import { mockRouting } from "../helpers/mock-outputs.js";
-import { INTERNAL_DISPATCH_HEADERS, INTERNAL_SECRET_HEADER } from "../../src/routing-common.js";
+import {
+  INTERNAL_DISPATCH_HEADERS,
+  INTERNAL_SECRET_HEADER,
+  UNTRUSTED_NEXT_REQUEST_HEADERS,
+} from "../../src/routing-common.js";
 import type { RoutingManifest } from "../../src/types.js";
 import type { HeaderValue } from "../../src/routing-service/ext-proc-types.js";
 
@@ -175,7 +179,11 @@ describe("createRequestHandler", () => {
     // Every internal dispatch header AND the secret must be removed, or a client could
     // smuggle a spoofed x-output-id past the extension on this path.
     expect(new Set(mutation.removeHeaders)).toEqual(
-      new Set([...INTERNAL_DISPATCH_HEADERS, INTERNAL_SECRET_HEADER]),
+      new Set([
+        ...INTERNAL_DISPATCH_HEADERS,
+        ...UNTRUSTED_NEXT_REQUEST_HEADERS,
+        INTERNAL_SECRET_HEADER,
+      ]),
     );
   });
 
@@ -493,6 +501,28 @@ describe("createRequestHandler ingress hygiene", () => {
     }
     // …while legitimate client headers pass through untouched.
     expect(seenHeaders.get("host")).toBe("app.example.com");
+  });
+
+  it("strips client-supplied Next resume headers before routing and forwarding", async () => {
+    const handler = createRequestHandler(makeManifest(), null);
+    vi.mocked(resolveRoutes).mockResolvedValue({
+      resolvedPathname: "/about",
+      invocationTarget: { pathname: "/about", query: {} },
+    } as any);
+
+    const response = await handler([
+      ...makeHeaders("/about"),
+      { key: "next-resume", value: "1" },
+      { key: "x-next-resume-state-length", value: "32" },
+    ]);
+
+    const seenHeaders = vi.mocked(resolveRoutes).mock.calls[0]![0].headers as Headers;
+    expect(seenHeaders.get("next-resume")).toBeNull();
+    expect(seenHeaders.get("x-next-resume-state-length")).toBeNull();
+
+    const removeHeaders = response.requestHeaders!.response!.headerMutation!.removeHeaders ?? [];
+    expect(removeHeaders).toContain("next-resume");
+    expect(removeHeaders).toContain("x-next-resume-state-length");
   });
 
   it("never leaks the :path query string into the dispatch fallback pathname", async () => {
@@ -1716,7 +1746,11 @@ describe("N40b: pool header-budget guard", () => {
     // the request as untrusted and re-resolves it locally (running middleware itself).
     const mutation = response.requestHeaders!.response!.headerMutation!;
     expect(mutation.setHeaders ?? []).toHaveLength(0);
-    for (const name of [...INTERNAL_DISPATCH_HEADERS, INTERNAL_SECRET_HEADER]) {
+    for (const name of [
+      ...INTERNAL_DISPATCH_HEADERS,
+      ...UNTRUSTED_NEXT_REQUEST_HEADERS,
+      INTERNAL_SECRET_HEADER,
+    ]) {
       expect(mutation.removeHeaders).toContain(name);
     }
     // Nothing is silently lost: without `x-mw-evaluated` the pool cannot skip its own


### PR DESCRIPTION
- Strip client-supplied `next-resume` and `x-next-resume-state-length` headers at both ingress boundaries.
- Preserve legitimate PPR resume handling created by the private loopback invocation.
- Add routing-service, pool-server, and tier-parity regression coverage.