### PR TITLE
Adopt stable Next 16.3 and make builds portable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Lint
+        run: npm run lint
+
+      - name: Typecheck
+        run: npm run typecheck
+
       - name: Build
         run: npm run build
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Check formatting
+        run: npm run fmt:check
+
       - name: Lint
         run: npm run lint
 

--- a/.github/workflows/test-e2e-baseline-apphosting.yml
+++ b/.github/workflows/test-e2e-baseline-apphosting.yml
@@ -9,7 +9,7 @@ on:
         type: string
       nextVersion:
         description: "npm version for next"
-        default: "16.2.1"
+        default: "16.3.0"
         type: string
       reactVersion:
         description: "npm version for react/react-dom"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## What this is
 
-`@next-community/adapter-k8s` — a Next.js adapter (Next 16.2+ `adapterPath` API) that deploys
+`@next-community/adapter-k8s` — a Next.js adapter (Next 16.3+ `adapterPath` API) that deploys
 Next.js apps to GKE. At build time it analyzes the route structure and generates pool servers, an
 ext_proc routing service, a Helm chart, and Dockerfiles. A CLI (`adapter-k8s`) provisions GCP
 infrastructure and runs zero-downtime blue/green deploys.

--- a/README.md
+++ b/README.md
@@ -212,10 +212,7 @@ export default createK8sAdapter({
     API_KEY: { secret: "app-secrets", key: "api-key" }, // -> secretKeyRef
     FLAGS: { configMap: "app-config", key: "flags" }, // -> configMapKeyRef
   },
-  envFrom: [
-    { secret: "app-secrets" },
-    { configMap: "app-config", prefix: "CFG_" },
-  ],
+  envFrom: [{ secret: "app-secrets" }, { configMap: "app-config", prefix: "CFG_" }],
 
   pools: {
     // Merged OVER the top-level map, so a pool can override a shared default.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # @next-community/adapter-k8s
 
-Deploy full-fidelity Next.js—middleware, Partial Prerendering, cache components, ISR—to Kubernetes with a single command. The adapter plugs into Next.js 16.2+'s `adapterPath` API and generates everything from your build output—Helm charts, Dockerfiles, routing manifests—so your infrastructure evolves with your routes, not with hand-maintained YAML.
+Deploy full-fidelity Next.js—middleware, Partial Prerendering, cache components, ISR—to Kubernetes with a single command. The adapter plugs into Next.js 16.3+'s `adapterPath` API and generates everything from your build output—Helm charts, Dockerfiles, routing manifests—so your infrastructure evolves with your routes, not with hand-maintained YAML.
 
 ```bash
 npx adapter-k8s deploy
@@ -32,7 +32,7 @@ Middleware, PPR, cache components, and ISR are verified through the upstream Nex
 ## Requirements
 
 - Node.js >= 20.9.0
-- Next.js >= 16.2.0
+- Next.js >= 16.3.0
 - A Kubernetes cluster:
   - **GKE** (Autopilot or Standard) for `provider.gke`, plus `gcloud` in PATH
   - **any conformant cluster** for `provider.generic`, with [Envoy Gateway](https://gateway.envoyproxy.io/) installed and a CNI that enforces NetworkPolicy

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ Please report suspected vulnerabilities privately via GitHub's [private vulnerab
 
 ## Threat model in one paragraph
 
-The sensitive asset is the **internal dispatch secret**. The routing service resolves each request (runs middleware, classifies the route) and communicates its verdict to the pool servers via headers authenticated with this secret. Anything that holds the secret can hand a pool a forged, pre-trusted verdict—including "middleware already ran"—and have middleware skipped for arbitrary requests. The design therefore reduces to two questions: *who can reach the routing service*, and *who can obtain the secret at rest*. Everything below serves one of those two.
+The sensitive asset is the **internal dispatch secret**. The routing service resolves each request (runs middleware, classifies the route) and communicates its verdict to the pool servers via headers authenticated with this secret. Anything that holds the secret can hand a pool a forged, pre-trusted verdict—including "middleware already ran"—and have middleware skipped for arbitrary requests. The design therefore reduces to two questions: _who can reach the routing service_, and _who can obtain the secret at rest_. Everything below serves one of those two.
 
 ## Workload hardening
 
@@ -29,12 +29,12 @@ The ext_proc listener authenticates only the server (TLS with no client-certific
 
 The chart emits default-deny ingress NetworkPolicies with a positive allowlist:
 
-| source | reaches | why |
-| --- | --- | --- |
-| `35.191.0.0/16`, `130.211.0.0/22`, `2600:2d00:1:1::/64` | pools `:3000`, routing `:8443` | GFE proxy ranges for a global external Application Load Balancer with zonal `GCE_VM_IP_PORT` NEG backends—the topology this chart emits. The ext_proc callout arrives from the same ranges. |
-| `35.191.0.0/16`, `2600:2d00:1:b029::/64` | same | Health-check probers for GFE-based load balancers (the Gateway's pool checks and the routing tier's TCP check on `:8443`). |
-| node CIDRs (auto-discovered) | pools `:3000`, routing `:8081` | kubelet liveness/readiness probes originate from the **node** IP, which no Google range covers. The template fails at render time if the range is unknown, rather than leaving every pod unready at rollout. |
-| sibling pool pods (label selector) | pools `:3000` | cross-pool proxying. The routing service cannot originate pool traffic. |
+| source                                                  | reaches                        | why                                                                                                                                                                                                          |
+| ------------------------------------------------------- | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `35.191.0.0/16`, `130.211.0.0/22`, `2600:2d00:1:1::/64` | pools `:3000`, routing `:8443` | GFE proxy ranges for a global external Application Load Balancer with zonal `GCE_VM_IP_PORT` NEG backends—the topology this chart emits. The ext_proc callout arrives from the same ranges.                  |
+| `35.191.0.0/16`, `2600:2d00:1:b029::/64`                | same                           | Health-check probers for GFE-based load balancers (the Gateway's pool checks and the routing tier's TCP check on `:8443`).                                                                                   |
+| node CIDRs (auto-discovered)                            | pools `:3000`, routing `:8081` | kubelet liveness/readiness probes originate from the **node** IP, which no Google range covers. The template fails at render time if the range is unknown, rather than leaving every pod unready at rollout. |
+| sibling pool pods (label selector)                      | pools `:3000`                  | cross-pool proxying. The routing service cannot originate pool traffic.                                                                                                                                      |
 
 Both CIDR sets are discovered at deploy time (cluster subnetwork plus any node-pool subnets on Standard clusters); nothing needs setting by hand. To pin them, or to fall back to a pod-CIDR denylist:
 
@@ -42,8 +42,8 @@ Both CIDR sets are discovered at deploy time (cluster subnetwork plus any node-p
 # .k8s-adapter/helm/values.override.yaml
 global:
   networkPolicy:
-    strict: true                  # default; false = 0.0.0.0/0-except-pod-CIDR denylist
-    nodeCidrs: ["10.128.0.0/20"]  # normally discovered
+    strict: true # default; false = 0.0.0.0/0-except-pod-CIDR denylist
+    nodeCidrs: ["10.128.0.0/20"] # normally discovered
 ```
 
 The denylist exists for compatibility but is **not** a boundary for the dispatch secret: its edge is the pod CIDR, and VMs on the VPC, `hostNetwork` pods using node IPs, and pods in peered clusters all sit outside it while still being routable to `:8443`. The allowlist is the default because it is what actually closes that.
@@ -53,7 +53,7 @@ What you accept in exchange:
 1. Google publishes these ranges but guarantees nothing—new probers can appear without notification, and a future range addition would surface as unhealthy backends, not a warning.
 2. IPv6 ranges are included unconditionally (inert on single-stack clusters).
 3. The discovered node range is usually the whole cluster subnet, so any VM sharing that subnet keeps its reach—give the cluster its own subnet if that matters.
-4. The allowlist trusts the Google LB ranges wholesale; a network-level control cannot distinguish *your* load balancer's traffic from anything else sourced from those ranges.
+4. The allowlist trusts the Google LB ranges wholesale; a network-level control cannot distinguish _your_ load balancer's traffic from anything else sourced from those ranges.
 
 Neither posture governs **egress** (`policyTypes: [Ingress]`), so pool → Valkey/GCS/Artifact Registry/DNS traffic is unaffected. Standard clusters are created with `--enable-network-policy`; Autopilot always enforces it. `deploy` discovers the pod and node ranges and **aborts** if it can't—`--allow-no-network-policy` deploys without isolation, which disables everything in this section.
 
@@ -85,7 +85,7 @@ One asymmetry worth knowing: a **rolled-back** routing tier is pinned by tag rat
 
 ## Cache security
 
-Memorystore's own defaults are AUTH off and transit encryption off, and the chart's NetworkPolicies govern ingress to *pods* only—so a plaintext instance is readable **and writable** by any workload with VPC reachability. Writable matters: overwriting cached HTML/RSC is content injection into the site.
+Memorystore's own defaults are AUTH off and transit encryption off, and the chart's NetworkPolicies govern ingress to _pods_ only—so a plaintext instance is readable **and writable** by any workload with VPC reachability. Writable matters: overwriting cached HTML/RSC is content injection into the site.
 
 The adapter therefore creates instances **with AUTH + TLS** (`SERVER_AUTHENTICATION`); pods connect over `rediss://` with the AUTH string and server CA injected from the connection Secret. Because AUTH is creation-only on Memorystore, there are three config states:
 

--- a/fixtures/edge/app/edge-catchall/[[...slug]]/route.ts
+++ b/fixtures/edge/app/edge-catchall/[[...slug]]/route.ts
@@ -1,8 +1,5 @@
 export const runtime = "edge";
 
-export async function GET(
-  _request: Request,
-  { params }: { params: Promise<{ slug?: string[] }> },
-) {
+export async function GET(_request: Request, { params }: { params: Promise<{ slug?: string[] }> }) {
   return Response.json(await params);
 }

--- a/fixtures/edge/next-env.d.ts
+++ b/fixtures/edge/next-env.d.ts
@@ -1,6 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
 import "./.next/types/routes.d.ts";
+import "./.next/types/root-params.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/fixtures/edge/package-lock.json
+++ b/fixtures/edge/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@next-community/adapter-k8s": "file:../..",
-        "next": "^16.2.0",
+        "next": "^16.3.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0"
       },
@@ -28,9 +28,10 @@
         "@bufbuild/protobuf": "^2.12.1",
         "@connectrpc/connect": "^2.1.2",
         "@connectrpc/connect-node": "^2.1.2",
-        "@next/routing": "^16.2.0",
+        "@next/routing": "16.3.0",
         "boxen": "^8.0.1",
-        "minimatch": "^10.2.4"
+        "minimatch": "^10.2.4",
+        "redos-detector": "^6.1.4"
       },
       "bin": {
         "adapter-k8s": "dist/cli.cjs"
@@ -42,7 +43,7 @@
         "esbuild": "^0.27.4",
         "ioredis": "^5.11.1",
         "oxfmt": "^0.42.0",
-        "oxlint": "^1.57.0",
+        "oxlint": "1.73.0",
         "typescript": "^6.0.2",
         "vitest": "^4.1.1"
       },
@@ -50,13 +51,13 @@
         "node": ">= 20.9.0"
       },
       "peerDependencies": {
-        "next": "^16.2.0"
+        "next": "^16.3.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
-      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -74,9 +75,9 @@
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
-      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
+      "integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
       "cpu": [
         "arm64"
       ],
@@ -86,19 +87,19 @@
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+        "@img/sharp-libvips-darwin-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
-      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
+      "integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
       "cpu": [
         "x64"
       ],
@@ -108,19 +109,38 @@
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.2.4"
+        "@img/sharp-libvips-darwin-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
+      "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
-      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
+      "integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
       "cpu": [
         "arm64"
       ],
@@ -134,9 +154,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
-      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
+      "integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
       "cpu": [
         "x64"
       ],
@@ -150,9 +170,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
-      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
+      "integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
       "cpu": [
         "arm"
       ],
@@ -169,9 +189,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
-      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
+      "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
       ],
@@ -188,9 +208,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
-      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
+      "integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
       "cpu": [
         "ppc64"
       ],
@@ -207,9 +227,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-riscv64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
-      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
+      "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
       "cpu": [
         "riscv64"
       ],
@@ -226,9 +246,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
-      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
+      "integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
       "cpu": [
         "s390x"
       ],
@@ -245,9 +265,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
-      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
+      "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
       "cpu": [
         "x64"
       ],
@@ -264,9 +284,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
-      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
+      "integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
       "cpu": [
         "arm64"
       ],
@@ -283,9 +303,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
-      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
+      "integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
       "cpu": [
         "x64"
       ],
@@ -302,9 +322,9 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
-      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
+      "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
       ],
@@ -317,19 +337,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.2.4"
+        "@img/sharp-libvips-linux-arm": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
-      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
+      "integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
       "cpu": [
         "arm64"
       ],
@@ -342,19 +362,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.2.4"
+        "@img/sharp-libvips-linux-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
-      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
+      "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
       "cpu": [
         "ppc64"
       ],
@@ -367,19 +387,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+        "@img/sharp-libvips-linux-ppc64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-riscv64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
-      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
+      "integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
       "cpu": [
         "riscv64"
       ],
@@ -392,19 +412,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+        "@img/sharp-libvips-linux-riscv64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
-      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
+      "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
       "cpu": [
         "s390x"
       ],
@@ -417,19 +437,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.2.4"
+        "@img/sharp-libvips-linux-s390x": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
-      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
+      "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
       "cpu": [
         "x64"
       ],
@@ -442,19 +462,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.2.4"
+        "@img/sharp-libvips-linux-x64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
-      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
+      "integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
       "cpu": [
         "arm64"
       ],
@@ -467,19 +487,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
-      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
+      "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
       ],
@@ -492,38 +512,54 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
-      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
-      "cpu": [
-        "wasm32"
-      ],
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
+      "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/runtime": "^1.7.0"
+        "@emnapi/runtime": "^1.11.1"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
+      "integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
-      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
+      "integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
       "cpu": [
         "arm64"
       ],
@@ -533,16 +569,16 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
-      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
+      "integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
       "cpu": [
         "ia32"
       ],
@@ -552,16 +588,16 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": "^20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
-      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
+      "integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
       "cpu": [
         "x64"
       ],
@@ -571,7 +607,7 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
@@ -582,15 +618,15 @@
       "link": true
     },
     "node_modules/@next/env": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.10.tgz",
-      "integrity": "sha512-zLPxg9M0MEHmygpj5OuxjQ+vHMiy/K7cSp74G8ecYolmgUWw0RwN02tF56npup/+qaI8JB97hQgS/r2Hb6QwVA==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.3.0.tgz",
+      "integrity": "sha512-o9r1S0BNiNreHP9Vs+Qnqd9kviDkJh8xIACY7UFZSmiGbbQRzPBBosvHzAU4TULHOIuOj/18RSsyz2qrREmIFw==",
       "license": "MIT"
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.10.tgz",
-      "integrity": "sha512-v9IdJCa0H0mbo+8z5zwUpOk1Vj7RjkcI5uNYf5Ws1y6szf/p3Mzl9hLaST8SCt6L9h8NGnruZcd2+o0NTNwDhA==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.3.0.tgz",
+      "integrity": "sha512-55hpqq18bEVAlxedlTt3tFqZmKg2nUXT1kn1G/BGEy0R13h3LwtwHPVzzjG6P4LLeOHE32PFDQUVaJEWvBEZBw==",
       "cpu": [
         "arm64"
       ],
@@ -604,9 +640,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.10.tgz",
-      "integrity": "sha512-17IS0jJRViROGmA9uGdNR8VPJpfbnaVG7E9qhso5jDLkmyd0lSDORWxbcKINzcFqzZqGwGtMSnrFRxBpuUYjLQ==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.3.0.tgz",
+      "integrity": "sha512-SOi96kSaF5T+0wW4koiM1bWzSPwjzTesC1p3df+FjdOi5LIQkBK/blxh7HdoKnNuI4PURF1OO7TZqtfnbWDSgw==",
       "cpu": [
         "x64"
       ],
@@ -620,9 +656,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.10.tgz",
-      "integrity": "sha512-GRQRsRtuciNJvB54AvvuQTiq0oZtFwa1owQqtZD8wwnGpM2L39MV22kpI72YSXLKIyY40LC66EiLFv4PiicXxg==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.3.0.tgz",
+      "integrity": "sha512-P0gZAoPMF4dyTRzhmkV4PrqVzSOB6t4mC1oI3c4dqijJ+OVEVx5clIXAKR4/uQpsqw2KKM/0D5tVumcR2r5blg==",
       "cpu": [
         "arm64"
       ],
@@ -639,9 +675,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.10.tgz",
-      "integrity": "sha512-zkN9MQYS7UQBro+FnISUq1itaQjXI9xqISzuQ+2bc921NcJ1x4yPCqrn77tVN6/dOOXaaWVX3k6/bR07pPwK+A==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.3.0.tgz",
+      "integrity": "sha512-tXXGKJw0m37O0eKJARVTX/TheKPhz0QFVtVVZXmOig+9YKLQOSP6hvf2pxv5DO7CLEJyTHx3Pg043CDQkv1G4Q==",
       "cpu": [
         "arm64"
       ],
@@ -658,9 +694,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.10.tgz",
-      "integrity": "sha512-iCVJnwvrPYECvA6WM/7+oo+OiTvedIKLxtCLAZP4xZR3nXa1zmzZyLPbYCmWvpd4CvMYF1EMTafd0ii3DygLvA==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.3.0.tgz",
+      "integrity": "sha512-pjGxK5EY7yWml78ALejFkWmgHsU7wbFQrISiugpH6FbUJhgEvw3xFZ/EBAtLl7QtL0WdQKiG9eWJ3mOKGTukHw==",
       "cpu": [
         "x64"
       ],
@@ -677,9 +713,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.10.tgz",
-      "integrity": "sha512-ov2g4H0dHY9bPoOU83m91hWT7Iq5qy13bUnyyshLU3HGR1Ownn0X9QpmDPc5iIUaahTp7f7LeGAhV4DSFtackw==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.3.0.tgz",
+      "integrity": "sha512-sjo++Xx+lomlPs3HRsHWhVDyGG6ms1kGW5EtHLERdII8AyG1i+f6aq68xHREO6AEMlhjTNEWBSmfJfqm9orf7g==",
       "cpu": [
         "x64"
       ],
@@ -696,9 +732,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.10.tgz",
-      "integrity": "sha512-DwAnhLX76HQiFFQNgWlcK+JzlnD1rZ+UK/WY0ZMI/deXpvgnesjNYrqcfo1JzBuz4Kf7o3brIBL0glI1junatA==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.3.0.tgz",
+      "integrity": "sha512-C5JSgiO54wURdaxdEUIXqkz04uMqC9UmPX1gtDrV/5Tf1UowdWYI8uA5hfFbPolTlp0q4KZ60xlHePNibf0VIw==",
       "cpu": [
         "arm64"
       ],
@@ -712,9 +748,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.10.tgz",
-      "integrity": "sha512-0JXq3b85Jk9Jg4ntLUbXSPvoDw3gpZou7twuKdoFG2jOw635v7+IiXfTaa0TxVMyx78pUjnrVYwLgjKfX4e6/A==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.3.0.tgz",
+      "integrity": "sha512-fDOggsweNb5SSw0ZKVk6U+gxSyGFFlIBY/LBc1r8GUj4u/6t6oArL+Pmkg0MBnsgR+KkdsURilVH4F3GXUGepA==",
       "cpu": [
         "x64"
       ],
@@ -822,9 +858,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -840,16 +876,16 @@
       }
     },
     "node_modules/next": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.2.10.tgz",
-      "integrity": "sha512-2som5AVXb3kE6Yjine3/mNbBayYF58eguBWIVVUdr1y/L426xyVEgYxgBG+1QC34P2x5E+tcDup6XkuOAX3dCA==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.3.0.tgz",
+      "integrity": "sha512-NEdGOzH+08eTXMUp9UYkA99Nhi5N6Thrhc1jgFOQgfgnGK/dA2hRwBpXep+exdFQrnwlRf/3Wixyp8lLBUpE2A==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.2.10",
+        "@next/env": "16.3.0",
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
-        "postcss": "8.4.31",
+        "postcss": "8.5.23",
         "styled-jsx": "5.1.6"
       },
       "bin": {
@@ -859,15 +895,15 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.2.10",
-        "@next/swc-darwin-x64": "16.2.10",
-        "@next/swc-linux-arm64-gnu": "16.2.10",
-        "@next/swc-linux-arm64-musl": "16.2.10",
-        "@next/swc-linux-x64-gnu": "16.2.10",
-        "@next/swc-linux-x64-musl": "16.2.10",
-        "@next/swc-win32-arm64-msvc": "16.2.10",
-        "@next/swc-win32-x64-msvc": "16.2.10",
-        "sharp": "^0.34.5"
+        "@next/swc-darwin-arm64": "16.3.0",
+        "@next/swc-darwin-x64": "16.3.0",
+        "@next/swc-linux-arm64-gnu": "16.3.0",
+        "@next/swc-linux-arm64-musl": "16.3.0",
+        "@next/swc-linux-x64-gnu": "16.3.0",
+        "@next/swc-linux-x64-musl": "16.3.0",
+        "@next/swc-win32-arm64-msvc": "16.3.0",
+        "@next/swc-win32-x64-msvc": "16.3.0",
+        "sharp": "^0.35.3"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
@@ -899,9 +935,9 @@
       "license": "ISC"
     },
     "node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",
@@ -918,9 +954,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -967,48 +1003,53 @@
       }
     },
     "node_modules/sharp": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
-      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
-      "hasInstallScript": true,
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
+      "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@img/colour": "^1.0.0",
+        "@img/colour": "^1.1.0",
         "detect-libc": "^2.1.2",
-        "semver": "^7.7.3"
+        "semver": "^7.8.5"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.34.5",
-        "@img/sharp-darwin-x64": "0.34.5",
-        "@img/sharp-libvips-darwin-arm64": "1.2.4",
-        "@img/sharp-libvips-darwin-x64": "1.2.4",
-        "@img/sharp-libvips-linux-arm": "1.2.4",
-        "@img/sharp-libvips-linux-arm64": "1.2.4",
-        "@img/sharp-libvips-linux-ppc64": "1.2.4",
-        "@img/sharp-libvips-linux-riscv64": "1.2.4",
-        "@img/sharp-libvips-linux-s390x": "1.2.4",
-        "@img/sharp-libvips-linux-x64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
-        "@img/sharp-linux-arm": "0.34.5",
-        "@img/sharp-linux-arm64": "0.34.5",
-        "@img/sharp-linux-ppc64": "0.34.5",
-        "@img/sharp-linux-riscv64": "0.34.5",
-        "@img/sharp-linux-s390x": "0.34.5",
-        "@img/sharp-linux-x64": "0.34.5",
-        "@img/sharp-linuxmusl-arm64": "0.34.5",
-        "@img/sharp-linuxmusl-x64": "0.34.5",
-        "@img/sharp-wasm32": "0.34.5",
-        "@img/sharp-win32-arm64": "0.34.5",
-        "@img/sharp-win32-ia32": "0.34.5",
-        "@img/sharp-win32-x64": "0.34.5"
+        "@img/sharp-darwin-arm64": "0.35.3",
+        "@img/sharp-darwin-x64": "0.35.3",
+        "@img/sharp-freebsd-wasm32": "0.35.3",
+        "@img/sharp-libvips-darwin-arm64": "1.3.2",
+        "@img/sharp-libvips-darwin-x64": "1.3.2",
+        "@img/sharp-libvips-linux-arm": "1.3.2",
+        "@img/sharp-libvips-linux-arm64": "1.3.2",
+        "@img/sharp-libvips-linux-ppc64": "1.3.2",
+        "@img/sharp-libvips-linux-riscv64": "1.3.2",
+        "@img/sharp-libvips-linux-s390x": "1.3.2",
+        "@img/sharp-libvips-linux-x64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2",
+        "@img/sharp-linux-arm": "0.35.3",
+        "@img/sharp-linux-arm64": "0.35.3",
+        "@img/sharp-linux-ppc64": "0.35.3",
+        "@img/sharp-linux-riscv64": "0.35.3",
+        "@img/sharp-linux-s390x": "0.35.3",
+        "@img/sharp-linux-x64": "0.35.3",
+        "@img/sharp-linuxmusl-arm64": "0.35.3",
+        "@img/sharp-linuxmusl-x64": "0.35.3",
+        "@img/sharp-webcontainers-wasm32": "0.35.3",
+        "@img/sharp-win32-arm64": "0.35.3",
+        "@img/sharp-win32-ia32": "0.35.3",
+        "@img/sharp-win32-x64": "0.35.3"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/source-map-js": {

--- a/fixtures/edge/package.json
+++ b/fixtures/edge/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@next-community/adapter-k8s": "file:../..",
-    "next": "^16.2.0",
+    "next": "^16.3.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"
   },

--- a/fixtures/edge/tsconfig.json
+++ b/fixtures/edge/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": false,
@@ -31,7 +27,5 @@
     "**/*.ts",
     "**/*.tsx"
   ],
-  "exclude": [
-    "node_modules"
-  ]
+  "exclude": ["node_modules"]
 }

--- a/fixtures/i18n-rewrite/next-env.d.ts
+++ b/fixtures/i18n-rewrite/next-env.d.ts
@@ -1,6 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
 import "./.next/types/routes.d.ts";
+import "./.next/types/root-params.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/fixtures/i18n-rewrite/package-lock.json
+++ b/fixtures/i18n-rewrite/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@next-community/adapter-k8s": "file:../..",
-        "next": "^16.2.0",
+        "next": "^16.3.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0"
       },
@@ -28,9 +28,10 @@
         "@bufbuild/protobuf": "^2.12.1",
         "@connectrpc/connect": "^2.1.2",
         "@connectrpc/connect-node": "^2.1.2",
-        "@next/routing": "^16.2.0",
+        "@next/routing": "16.3.0",
         "boxen": "^8.0.1",
-        "minimatch": "^10.2.4"
+        "minimatch": "^10.2.4",
+        "redos-detector": "^6.1.4"
       },
       "bin": {
         "adapter-k8s": "dist/cli.cjs"
@@ -42,7 +43,7 @@
         "esbuild": "^0.27.4",
         "ioredis": "^5.11.1",
         "oxfmt": "^0.42.0",
-        "oxlint": "^1.57.0",
+        "oxlint": "1.73.0",
         "typescript": "^6.0.2",
         "vitest": "^4.1.1"
       },
@@ -50,13 +51,13 @@
         "node": ">= 20.9.0"
       },
       "peerDependencies": {
-        "next": "^16.2.0"
+        "next": "^16.3.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
-      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -74,9 +75,9 @@
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
-      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
+      "integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
       "cpu": [
         "arm64"
       ],
@@ -86,19 +87,19 @@
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+        "@img/sharp-libvips-darwin-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
-      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
+      "integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
       "cpu": [
         "x64"
       ],
@@ -108,19 +109,38 @@
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.2.4"
+        "@img/sharp-libvips-darwin-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
+      "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
-      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
+      "integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
       "cpu": [
         "arm64"
       ],
@@ -134,9 +154,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
-      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
+      "integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
       "cpu": [
         "x64"
       ],
@@ -150,9 +170,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
-      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
+      "integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
       "cpu": [
         "arm"
       ],
@@ -169,9 +189,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
-      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
+      "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
       ],
@@ -188,9 +208,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
-      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
+      "integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
       "cpu": [
         "ppc64"
       ],
@@ -207,9 +227,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-riscv64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
-      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
+      "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
       "cpu": [
         "riscv64"
       ],
@@ -226,9 +246,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
-      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
+      "integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
       "cpu": [
         "s390x"
       ],
@@ -245,9 +265,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
-      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
+      "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
       "cpu": [
         "x64"
       ],
@@ -264,9 +284,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
-      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
+      "integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
       "cpu": [
         "arm64"
       ],
@@ -283,9 +303,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
-      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
+      "integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
       "cpu": [
         "x64"
       ],
@@ -302,9 +322,9 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
-      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
+      "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
       ],
@@ -317,19 +337,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.2.4"
+        "@img/sharp-libvips-linux-arm": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
-      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
+      "integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
       "cpu": [
         "arm64"
       ],
@@ -342,19 +362,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.2.4"
+        "@img/sharp-libvips-linux-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
-      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
+      "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
       "cpu": [
         "ppc64"
       ],
@@ -367,19 +387,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+        "@img/sharp-libvips-linux-ppc64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-riscv64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
-      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
+      "integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
       "cpu": [
         "riscv64"
       ],
@@ -392,19 +412,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+        "@img/sharp-libvips-linux-riscv64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
-      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
+      "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
       "cpu": [
         "s390x"
       ],
@@ -417,19 +437,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.2.4"
+        "@img/sharp-libvips-linux-s390x": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
-      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
+      "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
       "cpu": [
         "x64"
       ],
@@ -442,19 +462,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.2.4"
+        "@img/sharp-libvips-linux-x64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
-      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
+      "integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
       "cpu": [
         "arm64"
       ],
@@ -467,19 +487,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
-      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
+      "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
       ],
@@ -492,38 +512,54 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
-      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
-      "cpu": [
-        "wasm32"
-      ],
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
+      "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/runtime": "^1.7.0"
+        "@emnapi/runtime": "^1.11.1"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
+      "integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
-      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
+      "integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
       "cpu": [
         "arm64"
       ],
@@ -533,16 +569,16 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
-      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
+      "integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
       "cpu": [
         "ia32"
       ],
@@ -552,16 +588,16 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": "^20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
-      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
+      "integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
       "cpu": [
         "x64"
       ],
@@ -571,7 +607,7 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
@@ -582,15 +618,15 @@
       "link": true
     },
     "node_modules/@next/env": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.10.tgz",
-      "integrity": "sha512-zLPxg9M0MEHmygpj5OuxjQ+vHMiy/K7cSp74G8ecYolmgUWw0RwN02tF56npup/+qaI8JB97hQgS/r2Hb6QwVA==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.3.0.tgz",
+      "integrity": "sha512-o9r1S0BNiNreHP9Vs+Qnqd9kviDkJh8xIACY7UFZSmiGbbQRzPBBosvHzAU4TULHOIuOj/18RSsyz2qrREmIFw==",
       "license": "MIT"
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.10.tgz",
-      "integrity": "sha512-v9IdJCa0H0mbo+8z5zwUpOk1Vj7RjkcI5uNYf5Ws1y6szf/p3Mzl9hLaST8SCt6L9h8NGnruZcd2+o0NTNwDhA==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.3.0.tgz",
+      "integrity": "sha512-55hpqq18bEVAlxedlTt3tFqZmKg2nUXT1kn1G/BGEy0R13h3LwtwHPVzzjG6P4LLeOHE32PFDQUVaJEWvBEZBw==",
       "cpu": [
         "arm64"
       ],
@@ -604,9 +640,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.10.tgz",
-      "integrity": "sha512-17IS0jJRViROGmA9uGdNR8VPJpfbnaVG7E9qhso5jDLkmyd0lSDORWxbcKINzcFqzZqGwGtMSnrFRxBpuUYjLQ==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.3.0.tgz",
+      "integrity": "sha512-SOi96kSaF5T+0wW4koiM1bWzSPwjzTesC1p3df+FjdOi5LIQkBK/blxh7HdoKnNuI4PURF1OO7TZqtfnbWDSgw==",
       "cpu": [
         "x64"
       ],
@@ -620,9 +656,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.10.tgz",
-      "integrity": "sha512-GRQRsRtuciNJvB54AvvuQTiq0oZtFwa1owQqtZD8wwnGpM2L39MV22kpI72YSXLKIyY40LC66EiLFv4PiicXxg==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.3.0.tgz",
+      "integrity": "sha512-P0gZAoPMF4dyTRzhmkV4PrqVzSOB6t4mC1oI3c4dqijJ+OVEVx5clIXAKR4/uQpsqw2KKM/0D5tVumcR2r5blg==",
       "cpu": [
         "arm64"
       ],
@@ -639,9 +675,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.10.tgz",
-      "integrity": "sha512-zkN9MQYS7UQBro+FnISUq1itaQjXI9xqISzuQ+2bc921NcJ1x4yPCqrn77tVN6/dOOXaaWVX3k6/bR07pPwK+A==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.3.0.tgz",
+      "integrity": "sha512-tXXGKJw0m37O0eKJARVTX/TheKPhz0QFVtVVZXmOig+9YKLQOSP6hvf2pxv5DO7CLEJyTHx3Pg043CDQkv1G4Q==",
       "cpu": [
         "arm64"
       ],
@@ -658,9 +694,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.10.tgz",
-      "integrity": "sha512-iCVJnwvrPYECvA6WM/7+oo+OiTvedIKLxtCLAZP4xZR3nXa1zmzZyLPbYCmWvpd4CvMYF1EMTafd0ii3DygLvA==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.3.0.tgz",
+      "integrity": "sha512-pjGxK5EY7yWml78ALejFkWmgHsU7wbFQrISiugpH6FbUJhgEvw3xFZ/EBAtLl7QtL0WdQKiG9eWJ3mOKGTukHw==",
       "cpu": [
         "x64"
       ],
@@ -677,9 +713,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.10.tgz",
-      "integrity": "sha512-ov2g4H0dHY9bPoOU83m91hWT7Iq5qy13bUnyyshLU3HGR1Ownn0X9QpmDPc5iIUaahTp7f7LeGAhV4DSFtackw==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.3.0.tgz",
+      "integrity": "sha512-sjo++Xx+lomlPs3HRsHWhVDyGG6ms1kGW5EtHLERdII8AyG1i+f6aq68xHREO6AEMlhjTNEWBSmfJfqm9orf7g==",
       "cpu": [
         "x64"
       ],
@@ -696,9 +732,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.10.tgz",
-      "integrity": "sha512-DwAnhLX76HQiFFQNgWlcK+JzlnD1rZ+UK/WY0ZMI/deXpvgnesjNYrqcfo1JzBuz4Kf7o3brIBL0glI1junatA==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.3.0.tgz",
+      "integrity": "sha512-C5JSgiO54wURdaxdEUIXqkz04uMqC9UmPX1gtDrV/5Tf1UowdWYI8uA5hfFbPolTlp0q4KZ60xlHePNibf0VIw==",
       "cpu": [
         "arm64"
       ],
@@ -712,9 +748,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.10.tgz",
-      "integrity": "sha512-0JXq3b85Jk9Jg4ntLUbXSPvoDw3gpZou7twuKdoFG2jOw635v7+IiXfTaa0TxVMyx78pUjnrVYwLgjKfX4e6/A==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.3.0.tgz",
+      "integrity": "sha512-fDOggsweNb5SSw0ZKVk6U+gxSyGFFlIBY/LBc1r8GUj4u/6t6oArL+Pmkg0MBnsgR+KkdsURilVH4F3GXUGepA==",
       "cpu": [
         "x64"
       ],
@@ -822,9 +858,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -840,16 +876,16 @@
       }
     },
     "node_modules/next": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.2.10.tgz",
-      "integrity": "sha512-2som5AVXb3kE6Yjine3/mNbBayYF58eguBWIVVUdr1y/L426xyVEgYxgBG+1QC34P2x5E+tcDup6XkuOAX3dCA==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.3.0.tgz",
+      "integrity": "sha512-NEdGOzH+08eTXMUp9UYkA99Nhi5N6Thrhc1jgFOQgfgnGK/dA2hRwBpXep+exdFQrnwlRf/3Wixyp8lLBUpE2A==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.2.10",
+        "@next/env": "16.3.0",
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
-        "postcss": "8.4.31",
+        "postcss": "8.5.23",
         "styled-jsx": "5.1.6"
       },
       "bin": {
@@ -859,15 +895,15 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.2.10",
-        "@next/swc-darwin-x64": "16.2.10",
-        "@next/swc-linux-arm64-gnu": "16.2.10",
-        "@next/swc-linux-arm64-musl": "16.2.10",
-        "@next/swc-linux-x64-gnu": "16.2.10",
-        "@next/swc-linux-x64-musl": "16.2.10",
-        "@next/swc-win32-arm64-msvc": "16.2.10",
-        "@next/swc-win32-x64-msvc": "16.2.10",
-        "sharp": "^0.34.5"
+        "@next/swc-darwin-arm64": "16.3.0",
+        "@next/swc-darwin-x64": "16.3.0",
+        "@next/swc-linux-arm64-gnu": "16.3.0",
+        "@next/swc-linux-arm64-musl": "16.3.0",
+        "@next/swc-linux-x64-gnu": "16.3.0",
+        "@next/swc-linux-x64-musl": "16.3.0",
+        "@next/swc-win32-arm64-msvc": "16.3.0",
+        "@next/swc-win32-x64-msvc": "16.3.0",
+        "sharp": "^0.35.3"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
@@ -899,9 +935,9 @@
       "license": "ISC"
     },
     "node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",
@@ -918,9 +954,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -967,48 +1003,53 @@
       }
     },
     "node_modules/sharp": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
-      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
-      "hasInstallScript": true,
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
+      "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@img/colour": "^1.0.0",
+        "@img/colour": "^1.1.0",
         "detect-libc": "^2.1.2",
-        "semver": "^7.7.3"
+        "semver": "^7.8.5"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.34.5",
-        "@img/sharp-darwin-x64": "0.34.5",
-        "@img/sharp-libvips-darwin-arm64": "1.2.4",
-        "@img/sharp-libvips-darwin-x64": "1.2.4",
-        "@img/sharp-libvips-linux-arm": "1.2.4",
-        "@img/sharp-libvips-linux-arm64": "1.2.4",
-        "@img/sharp-libvips-linux-ppc64": "1.2.4",
-        "@img/sharp-libvips-linux-riscv64": "1.2.4",
-        "@img/sharp-libvips-linux-s390x": "1.2.4",
-        "@img/sharp-libvips-linux-x64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
-        "@img/sharp-linux-arm": "0.34.5",
-        "@img/sharp-linux-arm64": "0.34.5",
-        "@img/sharp-linux-ppc64": "0.34.5",
-        "@img/sharp-linux-riscv64": "0.34.5",
-        "@img/sharp-linux-s390x": "0.34.5",
-        "@img/sharp-linux-x64": "0.34.5",
-        "@img/sharp-linuxmusl-arm64": "0.34.5",
-        "@img/sharp-linuxmusl-x64": "0.34.5",
-        "@img/sharp-wasm32": "0.34.5",
-        "@img/sharp-win32-arm64": "0.34.5",
-        "@img/sharp-win32-ia32": "0.34.5",
-        "@img/sharp-win32-x64": "0.34.5"
+        "@img/sharp-darwin-arm64": "0.35.3",
+        "@img/sharp-darwin-x64": "0.35.3",
+        "@img/sharp-freebsd-wasm32": "0.35.3",
+        "@img/sharp-libvips-darwin-arm64": "1.3.2",
+        "@img/sharp-libvips-darwin-x64": "1.3.2",
+        "@img/sharp-libvips-linux-arm": "1.3.2",
+        "@img/sharp-libvips-linux-arm64": "1.3.2",
+        "@img/sharp-libvips-linux-ppc64": "1.3.2",
+        "@img/sharp-libvips-linux-riscv64": "1.3.2",
+        "@img/sharp-libvips-linux-s390x": "1.3.2",
+        "@img/sharp-libvips-linux-x64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2",
+        "@img/sharp-linux-arm": "0.35.3",
+        "@img/sharp-linux-arm64": "0.35.3",
+        "@img/sharp-linux-ppc64": "0.35.3",
+        "@img/sharp-linux-riscv64": "0.35.3",
+        "@img/sharp-linux-s390x": "0.35.3",
+        "@img/sharp-linux-x64": "0.35.3",
+        "@img/sharp-linuxmusl-arm64": "0.35.3",
+        "@img/sharp-linuxmusl-x64": "0.35.3",
+        "@img/sharp-webcontainers-wasm32": "0.35.3",
+        "@img/sharp-win32-arm64": "0.35.3",
+        "@img/sharp-win32-ia32": "0.35.3",
+        "@img/sharp-win32-x64": "0.35.3"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/source-map-js": {

--- a/fixtures/i18n-rewrite/package.json
+++ b/fixtures/i18n-rewrite/package.json
@@ -2,7 +2,6 @@
   "name": "adapter-k8s-i18n-rewrite-e2e-app",
   "version": "0.1.0",
   "private": true,
-  "packageManager": "npm@11.6.2",
   "scripts": {
     "build": "next build",
     "start": "next start"
@@ -18,5 +17,6 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "typescript": "^6"
-  }
+  },
+  "packageManager": "npm@11.6.2"
 }

--- a/fixtures/i18n-rewrite/package.json
+++ b/fixtures/i18n-rewrite/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@next-community/adapter-k8s": "file:../..",
-    "next": "^16.2.0",
+    "next": "^16.3.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"
   },

--- a/fixtures/interception/next-env.d.ts
+++ b/fixtures/interception/next-env.d.ts
@@ -1,6 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
 import "./.next/types/routes.d.ts";
+import "./.next/types/root-params.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/fixtures/interception/package-lock.json
+++ b/fixtures/interception/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@next-community/adapter-k8s": "file:../..",
-        "next": "^16.2.0",
+        "next": "^16.3.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0"
       },
@@ -28,9 +28,10 @@
         "@bufbuild/protobuf": "^2.12.1",
         "@connectrpc/connect": "^2.1.2",
         "@connectrpc/connect-node": "^2.1.2",
-        "@next/routing": "^16.2.0",
+        "@next/routing": "16.3.0",
         "boxen": "^8.0.1",
-        "minimatch": "^10.2.4"
+        "minimatch": "^10.2.4",
+        "redos-detector": "^6.1.4"
       },
       "bin": {
         "adapter-k8s": "dist/cli.cjs"
@@ -42,7 +43,7 @@
         "esbuild": "^0.27.4",
         "ioredis": "^5.11.1",
         "oxfmt": "^0.42.0",
-        "oxlint": "^1.57.0",
+        "oxlint": "1.73.0",
         "typescript": "^6.0.2",
         "vitest": "^4.1.1"
       },
@@ -50,13 +51,13 @@
         "node": ">= 20.9.0"
       },
       "peerDependencies": {
-        "next": "^16.2.0"
+        "next": "^16.3.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
-      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -74,9 +75,9 @@
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
-      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
+      "integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
       "cpu": [
         "arm64"
       ],
@@ -86,19 +87,19 @@
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+        "@img/sharp-libvips-darwin-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
-      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
+      "integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
       "cpu": [
         "x64"
       ],
@@ -108,19 +109,38 @@
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.2.4"
+        "@img/sharp-libvips-darwin-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
+      "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
-      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
+      "integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
       "cpu": [
         "arm64"
       ],
@@ -134,9 +154,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
-      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
+      "integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
       "cpu": [
         "x64"
       ],
@@ -150,9 +170,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
-      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
+      "integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
       "cpu": [
         "arm"
       ],
@@ -169,9 +189,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
-      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
+      "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
       ],
@@ -188,9 +208,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
-      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
+      "integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
       "cpu": [
         "ppc64"
       ],
@@ -207,9 +227,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-riscv64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
-      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
+      "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
       "cpu": [
         "riscv64"
       ],
@@ -226,9 +246,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
-      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
+      "integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
       "cpu": [
         "s390x"
       ],
@@ -245,9 +265,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
-      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
+      "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
       "cpu": [
         "x64"
       ],
@@ -264,9 +284,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
-      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
+      "integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
       "cpu": [
         "arm64"
       ],
@@ -283,9 +303,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
-      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
+      "integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
       "cpu": [
         "x64"
       ],
@@ -302,9 +322,9 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
-      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
+      "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
       ],
@@ -317,19 +337,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.2.4"
+        "@img/sharp-libvips-linux-arm": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
-      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
+      "integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
       "cpu": [
         "arm64"
       ],
@@ -342,19 +362,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.2.4"
+        "@img/sharp-libvips-linux-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
-      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
+      "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
       "cpu": [
         "ppc64"
       ],
@@ -367,19 +387,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+        "@img/sharp-libvips-linux-ppc64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-riscv64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
-      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
+      "integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
       "cpu": [
         "riscv64"
       ],
@@ -392,19 +412,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+        "@img/sharp-libvips-linux-riscv64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
-      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
+      "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
       "cpu": [
         "s390x"
       ],
@@ -417,19 +437,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.2.4"
+        "@img/sharp-libvips-linux-s390x": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
-      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
+      "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
       "cpu": [
         "x64"
       ],
@@ -442,19 +462,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.2.4"
+        "@img/sharp-libvips-linux-x64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
-      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
+      "integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
       "cpu": [
         "arm64"
       ],
@@ -467,19 +487,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
-      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
+      "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
       ],
@@ -492,38 +512,54 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
-      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
-      "cpu": [
-        "wasm32"
-      ],
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
+      "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/runtime": "^1.7.0"
+        "@emnapi/runtime": "^1.11.1"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
+      "integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
-      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
+      "integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
       "cpu": [
         "arm64"
       ],
@@ -533,16 +569,16 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
-      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
+      "integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
       "cpu": [
         "ia32"
       ],
@@ -552,16 +588,16 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": "^20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
-      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
+      "integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
       "cpu": [
         "x64"
       ],
@@ -571,7 +607,7 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
@@ -582,15 +618,15 @@
       "link": true
     },
     "node_modules/@next/env": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.10.tgz",
-      "integrity": "sha512-zLPxg9M0MEHmygpj5OuxjQ+vHMiy/K7cSp74G8ecYolmgUWw0RwN02tF56npup/+qaI8JB97hQgS/r2Hb6QwVA==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.3.0.tgz",
+      "integrity": "sha512-o9r1S0BNiNreHP9Vs+Qnqd9kviDkJh8xIACY7UFZSmiGbbQRzPBBosvHzAU4TULHOIuOj/18RSsyz2qrREmIFw==",
       "license": "MIT"
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.10.tgz",
-      "integrity": "sha512-v9IdJCa0H0mbo+8z5zwUpOk1Vj7RjkcI5uNYf5Ws1y6szf/p3Mzl9hLaST8SCt6L9h8NGnruZcd2+o0NTNwDhA==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.3.0.tgz",
+      "integrity": "sha512-55hpqq18bEVAlxedlTt3tFqZmKg2nUXT1kn1G/BGEy0R13h3LwtwHPVzzjG6P4LLeOHE32PFDQUVaJEWvBEZBw==",
       "cpu": [
         "arm64"
       ],
@@ -604,9 +640,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.10.tgz",
-      "integrity": "sha512-17IS0jJRViROGmA9uGdNR8VPJpfbnaVG7E9qhso5jDLkmyd0lSDORWxbcKINzcFqzZqGwGtMSnrFRxBpuUYjLQ==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.3.0.tgz",
+      "integrity": "sha512-SOi96kSaF5T+0wW4koiM1bWzSPwjzTesC1p3df+FjdOi5LIQkBK/blxh7HdoKnNuI4PURF1OO7TZqtfnbWDSgw==",
       "cpu": [
         "x64"
       ],
@@ -620,9 +656,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.10.tgz",
-      "integrity": "sha512-GRQRsRtuciNJvB54AvvuQTiq0oZtFwa1owQqtZD8wwnGpM2L39MV22kpI72YSXLKIyY40LC66EiLFv4PiicXxg==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.3.0.tgz",
+      "integrity": "sha512-P0gZAoPMF4dyTRzhmkV4PrqVzSOB6t4mC1oI3c4dqijJ+OVEVx5clIXAKR4/uQpsqw2KKM/0D5tVumcR2r5blg==",
       "cpu": [
         "arm64"
       ],
@@ -639,9 +675,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.10.tgz",
-      "integrity": "sha512-zkN9MQYS7UQBro+FnISUq1itaQjXI9xqISzuQ+2bc921NcJ1x4yPCqrn77tVN6/dOOXaaWVX3k6/bR07pPwK+A==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.3.0.tgz",
+      "integrity": "sha512-tXXGKJw0m37O0eKJARVTX/TheKPhz0QFVtVVZXmOig+9YKLQOSP6hvf2pxv5DO7CLEJyTHx3Pg043CDQkv1G4Q==",
       "cpu": [
         "arm64"
       ],
@@ -658,9 +694,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.10.tgz",
-      "integrity": "sha512-iCVJnwvrPYECvA6WM/7+oo+OiTvedIKLxtCLAZP4xZR3nXa1zmzZyLPbYCmWvpd4CvMYF1EMTafd0ii3DygLvA==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.3.0.tgz",
+      "integrity": "sha512-pjGxK5EY7yWml78ALejFkWmgHsU7wbFQrISiugpH6FbUJhgEvw3xFZ/EBAtLl7QtL0WdQKiG9eWJ3mOKGTukHw==",
       "cpu": [
         "x64"
       ],
@@ -677,9 +713,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.10.tgz",
-      "integrity": "sha512-ov2g4H0dHY9bPoOU83m91hWT7Iq5qy13bUnyyshLU3HGR1Ownn0X9QpmDPc5iIUaahTp7f7LeGAhV4DSFtackw==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.3.0.tgz",
+      "integrity": "sha512-sjo++Xx+lomlPs3HRsHWhVDyGG6ms1kGW5EtHLERdII8AyG1i+f6aq68xHREO6AEMlhjTNEWBSmfJfqm9orf7g==",
       "cpu": [
         "x64"
       ],
@@ -696,9 +732,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.10.tgz",
-      "integrity": "sha512-DwAnhLX76HQiFFQNgWlcK+JzlnD1rZ+UK/WY0ZMI/deXpvgnesjNYrqcfo1JzBuz4Kf7o3brIBL0glI1junatA==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.3.0.tgz",
+      "integrity": "sha512-C5JSgiO54wURdaxdEUIXqkz04uMqC9UmPX1gtDrV/5Tf1UowdWYI8uA5hfFbPolTlp0q4KZ60xlHePNibf0VIw==",
       "cpu": [
         "arm64"
       ],
@@ -712,9 +748,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.10.tgz",
-      "integrity": "sha512-0JXq3b85Jk9Jg4ntLUbXSPvoDw3gpZou7twuKdoFG2jOw635v7+IiXfTaa0TxVMyx78pUjnrVYwLgjKfX4e6/A==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.3.0.tgz",
+      "integrity": "sha512-fDOggsweNb5SSw0ZKVk6U+gxSyGFFlIBY/LBc1r8GUj4u/6t6oArL+Pmkg0MBnsgR+KkdsURilVH4F3GXUGepA==",
       "cpu": [
         "x64"
       ],
@@ -822,9 +858,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -840,16 +876,16 @@
       }
     },
     "node_modules/next": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.2.10.tgz",
-      "integrity": "sha512-2som5AVXb3kE6Yjine3/mNbBayYF58eguBWIVVUdr1y/L426xyVEgYxgBG+1QC34P2x5E+tcDup6XkuOAX3dCA==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.3.0.tgz",
+      "integrity": "sha512-NEdGOzH+08eTXMUp9UYkA99Nhi5N6Thrhc1jgFOQgfgnGK/dA2hRwBpXep+exdFQrnwlRf/3Wixyp8lLBUpE2A==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.2.10",
+        "@next/env": "16.3.0",
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
-        "postcss": "8.4.31",
+        "postcss": "8.5.23",
         "styled-jsx": "5.1.6"
       },
       "bin": {
@@ -859,15 +895,15 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.2.10",
-        "@next/swc-darwin-x64": "16.2.10",
-        "@next/swc-linux-arm64-gnu": "16.2.10",
-        "@next/swc-linux-arm64-musl": "16.2.10",
-        "@next/swc-linux-x64-gnu": "16.2.10",
-        "@next/swc-linux-x64-musl": "16.2.10",
-        "@next/swc-win32-arm64-msvc": "16.2.10",
-        "@next/swc-win32-x64-msvc": "16.2.10",
-        "sharp": "^0.34.5"
+        "@next/swc-darwin-arm64": "16.3.0",
+        "@next/swc-darwin-x64": "16.3.0",
+        "@next/swc-linux-arm64-gnu": "16.3.0",
+        "@next/swc-linux-arm64-musl": "16.3.0",
+        "@next/swc-linux-x64-gnu": "16.3.0",
+        "@next/swc-linux-x64-musl": "16.3.0",
+        "@next/swc-win32-arm64-msvc": "16.3.0",
+        "@next/swc-win32-x64-msvc": "16.3.0",
+        "sharp": "^0.35.3"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
@@ -899,9 +935,9 @@
       "license": "ISC"
     },
     "node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",
@@ -918,9 +954,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -967,48 +1003,53 @@
       }
     },
     "node_modules/sharp": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
-      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
-      "hasInstallScript": true,
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
+      "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@img/colour": "^1.0.0",
+        "@img/colour": "^1.1.0",
         "detect-libc": "^2.1.2",
-        "semver": "^7.7.3"
+        "semver": "^7.8.5"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.34.5",
-        "@img/sharp-darwin-x64": "0.34.5",
-        "@img/sharp-libvips-darwin-arm64": "1.2.4",
-        "@img/sharp-libvips-darwin-x64": "1.2.4",
-        "@img/sharp-libvips-linux-arm": "1.2.4",
-        "@img/sharp-libvips-linux-arm64": "1.2.4",
-        "@img/sharp-libvips-linux-ppc64": "1.2.4",
-        "@img/sharp-libvips-linux-riscv64": "1.2.4",
-        "@img/sharp-libvips-linux-s390x": "1.2.4",
-        "@img/sharp-libvips-linux-x64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
-        "@img/sharp-linux-arm": "0.34.5",
-        "@img/sharp-linux-arm64": "0.34.5",
-        "@img/sharp-linux-ppc64": "0.34.5",
-        "@img/sharp-linux-riscv64": "0.34.5",
-        "@img/sharp-linux-s390x": "0.34.5",
-        "@img/sharp-linux-x64": "0.34.5",
-        "@img/sharp-linuxmusl-arm64": "0.34.5",
-        "@img/sharp-linuxmusl-x64": "0.34.5",
-        "@img/sharp-wasm32": "0.34.5",
-        "@img/sharp-win32-arm64": "0.34.5",
-        "@img/sharp-win32-ia32": "0.34.5",
-        "@img/sharp-win32-x64": "0.34.5"
+        "@img/sharp-darwin-arm64": "0.35.3",
+        "@img/sharp-darwin-x64": "0.35.3",
+        "@img/sharp-freebsd-wasm32": "0.35.3",
+        "@img/sharp-libvips-darwin-arm64": "1.3.2",
+        "@img/sharp-libvips-darwin-x64": "1.3.2",
+        "@img/sharp-libvips-linux-arm": "1.3.2",
+        "@img/sharp-libvips-linux-arm64": "1.3.2",
+        "@img/sharp-libvips-linux-ppc64": "1.3.2",
+        "@img/sharp-libvips-linux-riscv64": "1.3.2",
+        "@img/sharp-libvips-linux-s390x": "1.3.2",
+        "@img/sharp-libvips-linux-x64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2",
+        "@img/sharp-linux-arm": "0.35.3",
+        "@img/sharp-linux-arm64": "0.35.3",
+        "@img/sharp-linux-ppc64": "0.35.3",
+        "@img/sharp-linux-riscv64": "0.35.3",
+        "@img/sharp-linux-s390x": "0.35.3",
+        "@img/sharp-linux-x64": "0.35.3",
+        "@img/sharp-linuxmusl-arm64": "0.35.3",
+        "@img/sharp-linuxmusl-x64": "0.35.3",
+        "@img/sharp-webcontainers-wasm32": "0.35.3",
+        "@img/sharp-win32-arm64": "0.35.3",
+        "@img/sharp-win32-ia32": "0.35.3",
+        "@img/sharp-win32-x64": "0.35.3"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/source-map-js": {

--- a/fixtures/interception/package.json
+++ b/fixtures/interception/package.json
@@ -2,7 +2,6 @@
   "name": "adapter-k8s-interception-e2e-app",
   "version": "0.1.0",
   "private": true,
-  "packageManager": "npm@11.6.2",
   "scripts": {
     "build": "next build",
     "start": "next start"
@@ -18,5 +17,6 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "typescript": "^6"
-  }
+  },
+  "packageManager": "npm@11.6.2"
 }

--- a/fixtures/interception/package.json
+++ b/fixtures/interception/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@next-community/adapter-k8s": "file:../..",
-    "next": "^16.2.0",
+    "next": "^16.3.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"
   },

--- a/fixtures/interception/tsconfig.json
+++ b/fixtures/interception/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -30,7 +26,5 @@
     "**/*.tsx",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": [
-    "node_modules"
-  ]
+  "exclude": ["node_modules"]
 }

--- a/fixtures/main/app/encoded-key/[key]/page.tsx
+++ b/fixtures/main/app/encoded-key/[key]/page.tsx
@@ -1,11 +1,7 @@
 import { connection } from "next/server";
 import { Suspense } from "react";
 
-async function EncodedKey({
-  params,
-}: {
-  params: Promise<{ key: string }>;
-}) {
+async function EncodedKey({ params }: { params: Promise<{ key: string }> }) {
   await connection();
   const { key } = await params;
   return (

--- a/fixtures/main/app/novel/[slug]/page.tsx
+++ b/fixtures/main/app/novel/[slug]/page.tsx
@@ -26,11 +26,7 @@ async function Work({ slug }: { slug: string }) {
   );
 }
 
-export default async function Page({
-  params,
-}: {
-  params: Promise<{ slug: string }>;
-}) {
+export default async function Page({ params }: { params: Promise<{ slug: string }> }) {
   const { slug } = await params;
   if (slug === "prerendered") {
     return null;

--- a/fixtures/main/next-env.d.ts
+++ b/fixtures/main/next-env.d.ts
@@ -2,6 +2,7 @@
 /// <reference types="next/image-types/global" />
 /// <reference types="next/navigation-types/compat/navigation" />
 import "./.next/types/routes.d.ts";
+import "./.next/types/root-params.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/fixtures/main/next.config.ts
+++ b/fixtures/main/next.config.ts
@@ -34,9 +34,7 @@ const nextConfig: NextConfig = {
         // Service workers are mutable build artifacts: the browser must check for an update, but
         // an ETag should turn an unchanged check into a body-less 304. This local fixture locks the
         // same cache contract as Next's generated `_next/static/service-worker/*` output.
-        headers: [
-          { key: "Cache-Control", value: "public, max-age=0, must-revalidate" },
-        ],
+        headers: [{ key: "Cache-Control", value: "public, max-age=0, must-revalidate" }],
       },
     ];
   },

--- a/fixtures/main/package-lock.json
+++ b/fixtures/main/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@next-community/adapter-k8s": "file:../..",
-        "next": "^16.2.0",
+        "next": "^16.3.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0"
       },
@@ -28,9 +28,10 @@
         "@bufbuild/protobuf": "^2.12.1",
         "@connectrpc/connect": "^2.1.2",
         "@connectrpc/connect-node": "^2.1.2",
-        "@next/routing": "^16.2.0",
+        "@next/routing": "16.3.0",
         "boxen": "^8.0.1",
-        "minimatch": "^10.2.4"
+        "minimatch": "^10.2.4",
+        "redos-detector": "^6.1.4"
       },
       "bin": {
         "adapter-k8s": "dist/cli.cjs"
@@ -42,7 +43,7 @@
         "esbuild": "^0.27.4",
         "ioredis": "^5.11.1",
         "oxfmt": "^0.42.0",
-        "oxlint": "^1.57.0",
+        "oxlint": "1.73.0",
         "typescript": "^6.0.2",
         "vitest": "^4.1.1"
       },
@@ -50,13 +51,13 @@
         "node": ">= 20.9.0"
       },
       "peerDependencies": {
-        "next": "^16.2.0"
+        "next": "^16.3.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
-      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -74,9 +75,9 @@
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
-      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
+      "integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
       "cpu": [
         "arm64"
       ],
@@ -86,19 +87,19 @@
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+        "@img/sharp-libvips-darwin-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
-      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
+      "integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
       "cpu": [
         "x64"
       ],
@@ -108,19 +109,38 @@
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.2.4"
+        "@img/sharp-libvips-darwin-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
+      "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
-      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
+      "integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
       "cpu": [
         "arm64"
       ],
@@ -134,9 +154,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
-      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
+      "integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
       "cpu": [
         "x64"
       ],
@@ -150,9 +170,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
-      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
+      "integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
       "cpu": [
         "arm"
       ],
@@ -169,9 +189,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
-      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
+      "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
       ],
@@ -188,9 +208,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
-      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
+      "integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
       "cpu": [
         "ppc64"
       ],
@@ -207,9 +227,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-riscv64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
-      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
+      "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
       "cpu": [
         "riscv64"
       ],
@@ -226,9 +246,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
-      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
+      "integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
       "cpu": [
         "s390x"
       ],
@@ -245,9 +265,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
-      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
+      "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
       "cpu": [
         "x64"
       ],
@@ -264,9 +284,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
-      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
+      "integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
       "cpu": [
         "arm64"
       ],
@@ -283,9 +303,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
-      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
+      "integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
       "cpu": [
         "x64"
       ],
@@ -302,9 +322,9 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
-      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
+      "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
       ],
@@ -317,19 +337,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.2.4"
+        "@img/sharp-libvips-linux-arm": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
-      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
+      "integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
       "cpu": [
         "arm64"
       ],
@@ -342,19 +362,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.2.4"
+        "@img/sharp-libvips-linux-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
-      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
+      "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
       "cpu": [
         "ppc64"
       ],
@@ -367,19 +387,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+        "@img/sharp-libvips-linux-ppc64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-riscv64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
-      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
+      "integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
       "cpu": [
         "riscv64"
       ],
@@ -392,19 +412,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+        "@img/sharp-libvips-linux-riscv64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
-      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
+      "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
       "cpu": [
         "s390x"
       ],
@@ -417,19 +437,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.2.4"
+        "@img/sharp-libvips-linux-s390x": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
-      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
+      "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
       "cpu": [
         "x64"
       ],
@@ -442,19 +462,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.2.4"
+        "@img/sharp-libvips-linux-x64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
-      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
+      "integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
       "cpu": [
         "arm64"
       ],
@@ -467,19 +487,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
-      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
+      "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
       ],
@@ -492,38 +512,54 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
-      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
-      "cpu": [
-        "wasm32"
-      ],
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
+      "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/runtime": "^1.7.0"
+        "@emnapi/runtime": "^1.11.1"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
+      "integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
-      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
+      "integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
       "cpu": [
         "arm64"
       ],
@@ -533,16 +569,16 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
-      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
+      "integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
       "cpu": [
         "ia32"
       ],
@@ -552,16 +588,16 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": "^20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
-      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
+      "integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
       "cpu": [
         "x64"
       ],
@@ -571,7 +607,7 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
@@ -582,15 +618,15 @@
       "link": true
     },
     "node_modules/@next/env": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.10.tgz",
-      "integrity": "sha512-zLPxg9M0MEHmygpj5OuxjQ+vHMiy/K7cSp74G8ecYolmgUWw0RwN02tF56npup/+qaI8JB97hQgS/r2Hb6QwVA==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.3.0.tgz",
+      "integrity": "sha512-o9r1S0BNiNreHP9Vs+Qnqd9kviDkJh8xIACY7UFZSmiGbbQRzPBBosvHzAU4TULHOIuOj/18RSsyz2qrREmIFw==",
       "license": "MIT"
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.10.tgz",
-      "integrity": "sha512-v9IdJCa0H0mbo+8z5zwUpOk1Vj7RjkcI5uNYf5Ws1y6szf/p3Mzl9hLaST8SCt6L9h8NGnruZcd2+o0NTNwDhA==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.3.0.tgz",
+      "integrity": "sha512-55hpqq18bEVAlxedlTt3tFqZmKg2nUXT1kn1G/BGEy0R13h3LwtwHPVzzjG6P4LLeOHE32PFDQUVaJEWvBEZBw==",
       "cpu": [
         "arm64"
       ],
@@ -604,9 +640,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.10.tgz",
-      "integrity": "sha512-17IS0jJRViROGmA9uGdNR8VPJpfbnaVG7E9qhso5jDLkmyd0lSDORWxbcKINzcFqzZqGwGtMSnrFRxBpuUYjLQ==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.3.0.tgz",
+      "integrity": "sha512-SOi96kSaF5T+0wW4koiM1bWzSPwjzTesC1p3df+FjdOi5LIQkBK/blxh7HdoKnNuI4PURF1OO7TZqtfnbWDSgw==",
       "cpu": [
         "x64"
       ],
@@ -620,9 +656,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.10.tgz",
-      "integrity": "sha512-GRQRsRtuciNJvB54AvvuQTiq0oZtFwa1owQqtZD8wwnGpM2L39MV22kpI72YSXLKIyY40LC66EiLFv4PiicXxg==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.3.0.tgz",
+      "integrity": "sha512-P0gZAoPMF4dyTRzhmkV4PrqVzSOB6t4mC1oI3c4dqijJ+OVEVx5clIXAKR4/uQpsqw2KKM/0D5tVumcR2r5blg==",
       "cpu": [
         "arm64"
       ],
@@ -639,9 +675,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.10.tgz",
-      "integrity": "sha512-zkN9MQYS7UQBro+FnISUq1itaQjXI9xqISzuQ+2bc921NcJ1x4yPCqrn77tVN6/dOOXaaWVX3k6/bR07pPwK+A==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.3.0.tgz",
+      "integrity": "sha512-tXXGKJw0m37O0eKJARVTX/TheKPhz0QFVtVVZXmOig+9YKLQOSP6hvf2pxv5DO7CLEJyTHx3Pg043CDQkv1G4Q==",
       "cpu": [
         "arm64"
       ],
@@ -658,9 +694,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.10.tgz",
-      "integrity": "sha512-iCVJnwvrPYECvA6WM/7+oo+OiTvedIKLxtCLAZP4xZR3nXa1zmzZyLPbYCmWvpd4CvMYF1EMTafd0ii3DygLvA==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.3.0.tgz",
+      "integrity": "sha512-pjGxK5EY7yWml78ALejFkWmgHsU7wbFQrISiugpH6FbUJhgEvw3xFZ/EBAtLl7QtL0WdQKiG9eWJ3mOKGTukHw==",
       "cpu": [
         "x64"
       ],
@@ -677,9 +713,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.10.tgz",
-      "integrity": "sha512-ov2g4H0dHY9bPoOU83m91hWT7Iq5qy13bUnyyshLU3HGR1Ownn0X9QpmDPc5iIUaahTp7f7LeGAhV4DSFtackw==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.3.0.tgz",
+      "integrity": "sha512-sjo++Xx+lomlPs3HRsHWhVDyGG6ms1kGW5EtHLERdII8AyG1i+f6aq68xHREO6AEMlhjTNEWBSmfJfqm9orf7g==",
       "cpu": [
         "x64"
       ],
@@ -696,9 +732,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.10.tgz",
-      "integrity": "sha512-DwAnhLX76HQiFFQNgWlcK+JzlnD1rZ+UK/WY0ZMI/deXpvgnesjNYrqcfo1JzBuz4Kf7o3brIBL0glI1junatA==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.3.0.tgz",
+      "integrity": "sha512-C5JSgiO54wURdaxdEUIXqkz04uMqC9UmPX1gtDrV/5Tf1UowdWYI8uA5hfFbPolTlp0q4KZ60xlHePNibf0VIw==",
       "cpu": [
         "arm64"
       ],
@@ -712,9 +748,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.10.tgz",
-      "integrity": "sha512-0JXq3b85Jk9Jg4ntLUbXSPvoDw3gpZou7twuKdoFG2jOw635v7+IiXfTaa0TxVMyx78pUjnrVYwLgjKfX4e6/A==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.3.0.tgz",
+      "integrity": "sha512-fDOggsweNb5SSw0ZKVk6U+gxSyGFFlIBY/LBc1r8GUj4u/6t6oArL+Pmkg0MBnsgR+KkdsURilVH4F3GXUGepA==",
       "cpu": [
         "x64"
       ],
@@ -822,9 +858,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -840,16 +876,16 @@
       }
     },
     "node_modules/next": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.2.10.tgz",
-      "integrity": "sha512-2som5AVXb3kE6Yjine3/mNbBayYF58eguBWIVVUdr1y/L426xyVEgYxgBG+1QC34P2x5E+tcDup6XkuOAX3dCA==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.3.0.tgz",
+      "integrity": "sha512-NEdGOzH+08eTXMUp9UYkA99Nhi5N6Thrhc1jgFOQgfgnGK/dA2hRwBpXep+exdFQrnwlRf/3Wixyp8lLBUpE2A==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.2.10",
+        "@next/env": "16.3.0",
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
-        "postcss": "8.4.31",
+        "postcss": "8.5.23",
         "styled-jsx": "5.1.6"
       },
       "bin": {
@@ -859,15 +895,15 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.2.10",
-        "@next/swc-darwin-x64": "16.2.10",
-        "@next/swc-linux-arm64-gnu": "16.2.10",
-        "@next/swc-linux-arm64-musl": "16.2.10",
-        "@next/swc-linux-x64-gnu": "16.2.10",
-        "@next/swc-linux-x64-musl": "16.2.10",
-        "@next/swc-win32-arm64-msvc": "16.2.10",
-        "@next/swc-win32-x64-msvc": "16.2.10",
-        "sharp": "^0.34.5"
+        "@next/swc-darwin-arm64": "16.3.0",
+        "@next/swc-darwin-x64": "16.3.0",
+        "@next/swc-linux-arm64-gnu": "16.3.0",
+        "@next/swc-linux-arm64-musl": "16.3.0",
+        "@next/swc-linux-x64-gnu": "16.3.0",
+        "@next/swc-linux-x64-musl": "16.3.0",
+        "@next/swc-win32-arm64-msvc": "16.3.0",
+        "@next/swc-win32-x64-msvc": "16.3.0",
+        "sharp": "^0.35.3"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
@@ -899,9 +935,9 @@
       "license": "ISC"
     },
     "node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",
@@ -918,9 +954,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -967,48 +1003,53 @@
       }
     },
     "node_modules/sharp": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
-      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
-      "hasInstallScript": true,
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
+      "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@img/colour": "^1.0.0",
+        "@img/colour": "^1.1.0",
         "detect-libc": "^2.1.2",
-        "semver": "^7.7.3"
+        "semver": "^7.8.5"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.34.5",
-        "@img/sharp-darwin-x64": "0.34.5",
-        "@img/sharp-libvips-darwin-arm64": "1.2.4",
-        "@img/sharp-libvips-darwin-x64": "1.2.4",
-        "@img/sharp-libvips-linux-arm": "1.2.4",
-        "@img/sharp-libvips-linux-arm64": "1.2.4",
-        "@img/sharp-libvips-linux-ppc64": "1.2.4",
-        "@img/sharp-libvips-linux-riscv64": "1.2.4",
-        "@img/sharp-libvips-linux-s390x": "1.2.4",
-        "@img/sharp-libvips-linux-x64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
-        "@img/sharp-linux-arm": "0.34.5",
-        "@img/sharp-linux-arm64": "0.34.5",
-        "@img/sharp-linux-ppc64": "0.34.5",
-        "@img/sharp-linux-riscv64": "0.34.5",
-        "@img/sharp-linux-s390x": "0.34.5",
-        "@img/sharp-linux-x64": "0.34.5",
-        "@img/sharp-linuxmusl-arm64": "0.34.5",
-        "@img/sharp-linuxmusl-x64": "0.34.5",
-        "@img/sharp-wasm32": "0.34.5",
-        "@img/sharp-win32-arm64": "0.34.5",
-        "@img/sharp-win32-ia32": "0.34.5",
-        "@img/sharp-win32-x64": "0.34.5"
+        "@img/sharp-darwin-arm64": "0.35.3",
+        "@img/sharp-darwin-x64": "0.35.3",
+        "@img/sharp-freebsd-wasm32": "0.35.3",
+        "@img/sharp-libvips-darwin-arm64": "1.3.2",
+        "@img/sharp-libvips-darwin-x64": "1.3.2",
+        "@img/sharp-libvips-linux-arm": "1.3.2",
+        "@img/sharp-libvips-linux-arm64": "1.3.2",
+        "@img/sharp-libvips-linux-ppc64": "1.3.2",
+        "@img/sharp-libvips-linux-riscv64": "1.3.2",
+        "@img/sharp-libvips-linux-s390x": "1.3.2",
+        "@img/sharp-libvips-linux-x64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2",
+        "@img/sharp-linux-arm": "0.35.3",
+        "@img/sharp-linux-arm64": "0.35.3",
+        "@img/sharp-linux-ppc64": "0.35.3",
+        "@img/sharp-linux-riscv64": "0.35.3",
+        "@img/sharp-linux-s390x": "0.35.3",
+        "@img/sharp-linux-x64": "0.35.3",
+        "@img/sharp-linuxmusl-arm64": "0.35.3",
+        "@img/sharp-linuxmusl-x64": "0.35.3",
+        "@img/sharp-webcontainers-wasm32": "0.35.3",
+        "@img/sharp-win32-arm64": "0.35.3",
+        "@img/sharp-win32-ia32": "0.35.3",
+        "@img/sharp-win32-x64": "0.35.3"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/source-map-js": {

--- a/fixtures/main/package.json
+++ b/fixtures/main/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@next-community/adapter-k8s": "file:../..",
-    "next": "^16.2.0",
+    "next": "^16.3.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"
   },

--- a/fixtures/pages/adapter.config.mjs
+++ b/fixtures/pages/adapter.config.mjs
@@ -4,7 +4,7 @@ import { createK8sAdapter } from "@next-community/adapter-k8s";
 // of emitting a standalone /404 handler. Keep it separate from the App Router/PPR fixture so the
 // App Router's /_not-found output cannot hide the Pages entrypoint contract under test.
 export default createK8sAdapter({
-  pools: { default: { routes: ["pages"] } },
+  pools: { default: { routes: ["pages", "pagesApi"] } },
   containerStrategy: "traced-assets",
   provider: {
     gke: {

--- a/fixtures/pages/next-env.d.ts
+++ b/fixtures/pages/next-env.d.ts
@@ -1,6 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
 import "./.next/types/routes.d.ts";
+import "./.next/types/root-params.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/fixtures/pages/package-lock.json
+++ b/fixtures/pages/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@next-community/adapter-k8s": "file:../..",
-        "next": "^16.2.0",
+        "next": "^16.3.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0"
       },
@@ -28,9 +28,10 @@
         "@bufbuild/protobuf": "^2.12.1",
         "@connectrpc/connect": "^2.1.2",
         "@connectrpc/connect-node": "^2.1.2",
-        "@next/routing": "^16.2.0",
+        "@next/routing": "16.3.0",
         "boxen": "^8.0.1",
-        "minimatch": "^10.2.4"
+        "minimatch": "^10.2.4",
+        "redos-detector": "^6.1.4"
       },
       "bin": {
         "adapter-k8s": "dist/cli.cjs"
@@ -42,7 +43,7 @@
         "esbuild": "^0.27.4",
         "ioredis": "^5.11.1",
         "oxfmt": "^0.42.0",
-        "oxlint": "^1.57.0",
+        "oxlint": "1.73.0",
         "typescript": "^6.0.2",
         "vitest": "^4.1.1"
       },
@@ -50,13 +51,13 @@
         "node": ">= 20.9.0"
       },
       "peerDependencies": {
-        "next": "^16.2.0"
+        "next": "^16.3.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
-      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -74,9 +75,9 @@
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
-      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
+      "integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
       "cpu": [
         "arm64"
       ],
@@ -86,19 +87,19 @@
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+        "@img/sharp-libvips-darwin-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
-      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
+      "integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
       "cpu": [
         "x64"
       ],
@@ -108,19 +109,38 @@
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.2.4"
+        "@img/sharp-libvips-darwin-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
+      "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
-      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
+      "integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
       "cpu": [
         "arm64"
       ],
@@ -134,9 +154,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
-      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
+      "integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
       "cpu": [
         "x64"
       ],
@@ -150,9 +170,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
-      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
+      "integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
       "cpu": [
         "arm"
       ],
@@ -169,9 +189,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
-      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
+      "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
       ],
@@ -188,9 +208,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
-      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
+      "integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
       "cpu": [
         "ppc64"
       ],
@@ -207,9 +227,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-riscv64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
-      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
+      "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
       "cpu": [
         "riscv64"
       ],
@@ -226,9 +246,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
-      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
+      "integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
       "cpu": [
         "s390x"
       ],
@@ -245,9 +265,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
-      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
+      "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
       "cpu": [
         "x64"
       ],
@@ -264,9 +284,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
-      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
+      "integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
       "cpu": [
         "arm64"
       ],
@@ -283,9 +303,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
-      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
+      "integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
       "cpu": [
         "x64"
       ],
@@ -302,9 +322,9 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
-      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
+      "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
       ],
@@ -317,19 +337,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.2.4"
+        "@img/sharp-libvips-linux-arm": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
-      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
+      "integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
       "cpu": [
         "arm64"
       ],
@@ -342,19 +362,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.2.4"
+        "@img/sharp-libvips-linux-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
-      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
+      "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
       "cpu": [
         "ppc64"
       ],
@@ -367,19 +387,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+        "@img/sharp-libvips-linux-ppc64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-riscv64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
-      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
+      "integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
       "cpu": [
         "riscv64"
       ],
@@ -392,19 +412,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+        "@img/sharp-libvips-linux-riscv64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
-      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
+      "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
       "cpu": [
         "s390x"
       ],
@@ -417,19 +437,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.2.4"
+        "@img/sharp-libvips-linux-s390x": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
-      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
+      "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
       "cpu": [
         "x64"
       ],
@@ -442,19 +462,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.2.4"
+        "@img/sharp-libvips-linux-x64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
-      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
+      "integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
       "cpu": [
         "arm64"
       ],
@@ -467,19 +487,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
-      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
+      "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
       ],
@@ -492,38 +512,54 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
-      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
-      "cpu": [
-        "wasm32"
-      ],
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
+      "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/runtime": "^1.7.0"
+        "@emnapi/runtime": "^1.11.1"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
+      "integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
-      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
+      "integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
       "cpu": [
         "arm64"
       ],
@@ -533,16 +569,16 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
-      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
+      "integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
       "cpu": [
         "ia32"
       ],
@@ -552,16 +588,16 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": "^20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
-      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
+      "integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
       "cpu": [
         "x64"
       ],
@@ -571,7 +607,7 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
@@ -582,15 +618,15 @@
       "link": true
     },
     "node_modules/@next/env": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.10.tgz",
-      "integrity": "sha512-zLPxg9M0MEHmygpj5OuxjQ+vHMiy/K7cSp74G8ecYolmgUWw0RwN02tF56npup/+qaI8JB97hQgS/r2Hb6QwVA==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.3.0.tgz",
+      "integrity": "sha512-o9r1S0BNiNreHP9Vs+Qnqd9kviDkJh8xIACY7UFZSmiGbbQRzPBBosvHzAU4TULHOIuOj/18RSsyz2qrREmIFw==",
       "license": "MIT"
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.10.tgz",
-      "integrity": "sha512-v9IdJCa0H0mbo+8z5zwUpOk1Vj7RjkcI5uNYf5Ws1y6szf/p3Mzl9hLaST8SCt6L9h8NGnruZcd2+o0NTNwDhA==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.3.0.tgz",
+      "integrity": "sha512-55hpqq18bEVAlxedlTt3tFqZmKg2nUXT1kn1G/BGEy0R13h3LwtwHPVzzjG6P4LLeOHE32PFDQUVaJEWvBEZBw==",
       "cpu": [
         "arm64"
       ],
@@ -604,9 +640,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.10.tgz",
-      "integrity": "sha512-17IS0jJRViROGmA9uGdNR8VPJpfbnaVG7E9qhso5jDLkmyd0lSDORWxbcKINzcFqzZqGwGtMSnrFRxBpuUYjLQ==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.3.0.tgz",
+      "integrity": "sha512-SOi96kSaF5T+0wW4koiM1bWzSPwjzTesC1p3df+FjdOi5LIQkBK/blxh7HdoKnNuI4PURF1OO7TZqtfnbWDSgw==",
       "cpu": [
         "x64"
       ],
@@ -620,9 +656,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.10.tgz",
-      "integrity": "sha512-GRQRsRtuciNJvB54AvvuQTiq0oZtFwa1owQqtZD8wwnGpM2L39MV22kpI72YSXLKIyY40LC66EiLFv4PiicXxg==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.3.0.tgz",
+      "integrity": "sha512-P0gZAoPMF4dyTRzhmkV4PrqVzSOB6t4mC1oI3c4dqijJ+OVEVx5clIXAKR4/uQpsqw2KKM/0D5tVumcR2r5blg==",
       "cpu": [
         "arm64"
       ],
@@ -639,9 +675,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.10.tgz",
-      "integrity": "sha512-zkN9MQYS7UQBro+FnISUq1itaQjXI9xqISzuQ+2bc921NcJ1x4yPCqrn77tVN6/dOOXaaWVX3k6/bR07pPwK+A==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.3.0.tgz",
+      "integrity": "sha512-tXXGKJw0m37O0eKJARVTX/TheKPhz0QFVtVVZXmOig+9YKLQOSP6hvf2pxv5DO7CLEJyTHx3Pg043CDQkv1G4Q==",
       "cpu": [
         "arm64"
       ],
@@ -658,9 +694,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.10.tgz",
-      "integrity": "sha512-iCVJnwvrPYECvA6WM/7+oo+OiTvedIKLxtCLAZP4xZR3nXa1zmzZyLPbYCmWvpd4CvMYF1EMTafd0ii3DygLvA==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.3.0.tgz",
+      "integrity": "sha512-pjGxK5EY7yWml78ALejFkWmgHsU7wbFQrISiugpH6FbUJhgEvw3xFZ/EBAtLl7QtL0WdQKiG9eWJ3mOKGTukHw==",
       "cpu": [
         "x64"
       ],
@@ -677,9 +713,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.10.tgz",
-      "integrity": "sha512-ov2g4H0dHY9bPoOU83m91hWT7Iq5qy13bUnyyshLU3HGR1Ownn0X9QpmDPc5iIUaahTp7f7LeGAhV4DSFtackw==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.3.0.tgz",
+      "integrity": "sha512-sjo++Xx+lomlPs3HRsHWhVDyGG6ms1kGW5EtHLERdII8AyG1i+f6aq68xHREO6AEMlhjTNEWBSmfJfqm9orf7g==",
       "cpu": [
         "x64"
       ],
@@ -696,9 +732,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.10.tgz",
-      "integrity": "sha512-DwAnhLX76HQiFFQNgWlcK+JzlnD1rZ+UK/WY0ZMI/deXpvgnesjNYrqcfo1JzBuz4Kf7o3brIBL0glI1junatA==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.3.0.tgz",
+      "integrity": "sha512-C5JSgiO54wURdaxdEUIXqkz04uMqC9UmPX1gtDrV/5Tf1UowdWYI8uA5hfFbPolTlp0q4KZ60xlHePNibf0VIw==",
       "cpu": [
         "arm64"
       ],
@@ -712,9 +748,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.10.tgz",
-      "integrity": "sha512-0JXq3b85Jk9Jg4ntLUbXSPvoDw3gpZou7twuKdoFG2jOw635v7+IiXfTaa0TxVMyx78pUjnrVYwLgjKfX4e6/A==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.3.0.tgz",
+      "integrity": "sha512-fDOggsweNb5SSw0ZKVk6U+gxSyGFFlIBY/LBc1r8GUj4u/6t6oArL+Pmkg0MBnsgR+KkdsURilVH4F3GXUGepA==",
       "cpu": [
         "x64"
       ],
@@ -822,9 +858,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -840,16 +876,16 @@
       }
     },
     "node_modules/next": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.2.10.tgz",
-      "integrity": "sha512-2som5AVXb3kE6Yjine3/mNbBayYF58eguBWIVVUdr1y/L426xyVEgYxgBG+1QC34P2x5E+tcDup6XkuOAX3dCA==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.3.0.tgz",
+      "integrity": "sha512-NEdGOzH+08eTXMUp9UYkA99Nhi5N6Thrhc1jgFOQgfgnGK/dA2hRwBpXep+exdFQrnwlRf/3Wixyp8lLBUpE2A==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.2.10",
+        "@next/env": "16.3.0",
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
-        "postcss": "8.4.31",
+        "postcss": "8.5.23",
         "styled-jsx": "5.1.6"
       },
       "bin": {
@@ -859,15 +895,15 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.2.10",
-        "@next/swc-darwin-x64": "16.2.10",
-        "@next/swc-linux-arm64-gnu": "16.2.10",
-        "@next/swc-linux-arm64-musl": "16.2.10",
-        "@next/swc-linux-x64-gnu": "16.2.10",
-        "@next/swc-linux-x64-musl": "16.2.10",
-        "@next/swc-win32-arm64-msvc": "16.2.10",
-        "@next/swc-win32-x64-msvc": "16.2.10",
-        "sharp": "^0.34.5"
+        "@next/swc-darwin-arm64": "16.3.0",
+        "@next/swc-darwin-x64": "16.3.0",
+        "@next/swc-linux-arm64-gnu": "16.3.0",
+        "@next/swc-linux-arm64-musl": "16.3.0",
+        "@next/swc-linux-x64-gnu": "16.3.0",
+        "@next/swc-linux-x64-musl": "16.3.0",
+        "@next/swc-win32-arm64-msvc": "16.3.0",
+        "@next/swc-win32-x64-msvc": "16.3.0",
+        "sharp": "^0.35.3"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
@@ -899,9 +935,9 @@
       "license": "ISC"
     },
     "node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",
@@ -918,9 +954,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -967,48 +1003,53 @@
       }
     },
     "node_modules/sharp": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
-      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
-      "hasInstallScript": true,
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
+      "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@img/colour": "^1.0.0",
+        "@img/colour": "^1.1.0",
         "detect-libc": "^2.1.2",
-        "semver": "^7.7.3"
+        "semver": "^7.8.5"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.34.5",
-        "@img/sharp-darwin-x64": "0.34.5",
-        "@img/sharp-libvips-darwin-arm64": "1.2.4",
-        "@img/sharp-libvips-darwin-x64": "1.2.4",
-        "@img/sharp-libvips-linux-arm": "1.2.4",
-        "@img/sharp-libvips-linux-arm64": "1.2.4",
-        "@img/sharp-libvips-linux-ppc64": "1.2.4",
-        "@img/sharp-libvips-linux-riscv64": "1.2.4",
-        "@img/sharp-libvips-linux-s390x": "1.2.4",
-        "@img/sharp-libvips-linux-x64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
-        "@img/sharp-linux-arm": "0.34.5",
-        "@img/sharp-linux-arm64": "0.34.5",
-        "@img/sharp-linux-ppc64": "0.34.5",
-        "@img/sharp-linux-riscv64": "0.34.5",
-        "@img/sharp-linux-s390x": "0.34.5",
-        "@img/sharp-linux-x64": "0.34.5",
-        "@img/sharp-linuxmusl-arm64": "0.34.5",
-        "@img/sharp-linuxmusl-x64": "0.34.5",
-        "@img/sharp-wasm32": "0.34.5",
-        "@img/sharp-win32-arm64": "0.34.5",
-        "@img/sharp-win32-ia32": "0.34.5",
-        "@img/sharp-win32-x64": "0.34.5"
+        "@img/sharp-darwin-arm64": "0.35.3",
+        "@img/sharp-darwin-x64": "0.35.3",
+        "@img/sharp-freebsd-wasm32": "0.35.3",
+        "@img/sharp-libvips-darwin-arm64": "1.3.2",
+        "@img/sharp-libvips-darwin-x64": "1.3.2",
+        "@img/sharp-libvips-linux-arm": "1.3.2",
+        "@img/sharp-libvips-linux-arm64": "1.3.2",
+        "@img/sharp-libvips-linux-ppc64": "1.3.2",
+        "@img/sharp-libvips-linux-riscv64": "1.3.2",
+        "@img/sharp-libvips-linux-s390x": "1.3.2",
+        "@img/sharp-libvips-linux-x64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2",
+        "@img/sharp-linux-arm": "0.35.3",
+        "@img/sharp-linux-arm64": "0.35.3",
+        "@img/sharp-linux-ppc64": "0.35.3",
+        "@img/sharp-linux-riscv64": "0.35.3",
+        "@img/sharp-linux-s390x": "0.35.3",
+        "@img/sharp-linux-x64": "0.35.3",
+        "@img/sharp-linuxmusl-arm64": "0.35.3",
+        "@img/sharp-linuxmusl-x64": "0.35.3",
+        "@img/sharp-webcontainers-wasm32": "0.35.3",
+        "@img/sharp-win32-arm64": "0.35.3",
+        "@img/sharp-win32-ia32": "0.35.3",
+        "@img/sharp-win32-x64": "0.35.3"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/source-map-js": {

--- a/fixtures/pages/package.json
+++ b/fixtures/pages/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@next-community/adapter-k8s": "file:../..",
-    "next": "^16.2.0",
+    "next": "^16.3.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"
   },

--- a/fixtures/pages/package.json
+++ b/fixtures/pages/package.json
@@ -2,7 +2,6 @@
   "name": "adapter-k8s-pages-e2e-app",
   "version": "0.1.0",
   "private": true,
-  "packageManager": "npm@11.6.2",
   "scripts": {
     "build": "next build",
     "start": "next start"
@@ -18,5 +17,6 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "typescript": "^6"
-  }
+  },
+  "packageManager": "npm@11.6.2"
 }

--- a/fixtures/pages/pages/api/probe.ts
+++ b/fixtures/pages/pages/api/probe.ts
@@ -1,0 +1,9 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export default function handler(request: NextApiRequest, response: NextApiResponse) {
+  response.status(200).json({
+    router: "pages-api",
+    method: request.method,
+    query: request.query,
+  });
+}

--- a/fixtures/pages/pages/isr/[slug].tsx
+++ b/fixtures/pages/pages/isr/[slug].tsx
@@ -1,0 +1,22 @@
+import type { GetStaticPaths, GetStaticProps } from "next";
+
+type Props = { slug: string; generatedAt: string };
+
+export default function IsrPage({ slug, generatedAt }: Props) {
+  return (
+    <main>
+      <p id="isr-slug">{slug}</p>
+      <p id="isr-generated-at">{generatedAt}</p>
+    </main>
+  );
+}
+
+export const getStaticPaths: GetStaticPaths = async () => ({ paths: [], fallback: "blocking" });
+
+export const getStaticProps: GetStaticProps<Props> = async ({ params }) => ({
+  props: {
+    slug: String(params?.slug ?? ""),
+    generatedAt: new Date().toISOString(),
+  },
+  revalidate: 30,
+});

--- a/fixtures/pages/tsconfig.json
+++ b/fixtures/pages/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": false,
@@ -18,13 +14,6 @@
     "isolatedModules": true,
     "jsx": "react-jsx"
   },
-  "include": [
-    "next-env.d.ts",
-    "**/*.mts",
-    "**/*.ts",
-    "**/*.tsx"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["next-env.d.ts", "**/*.mts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "esbuild": "^0.27.4",
         "ioredis": "^5.11.1",
         "oxfmt": "^0.42.0",
-        "oxlint": "^1.57.0",
+        "oxlint": "1.73.0",
         "typescript": "^6.0.2",
         "vitest": "^4.1.1"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@bufbuild/protobuf": "^2.12.1",
         "@connectrpc/connect": "^2.1.2",
         "@connectrpc/connect-node": "^2.1.2",
-        "@next/routing": "16.3.0-preview.10",
+        "@next/routing": "16.3.0",
         "boxen": "^8.0.1",
         "minimatch": "^10.2.4",
         "redos-detector": "^6.1.4"
@@ -35,7 +35,7 @@
         "node": ">= 20.9.0"
       },
       "peerDependencies": {
-        "next": "^16.2.0"
+        "next": "^16.3.0"
       }
     },
     "node_modules/@bufbuild/buf": {
@@ -749,9 +749,9 @@
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
-      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
+      "integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
       "cpu": [
         "arm64"
       ],
@@ -762,19 +762,19 @@
       ],
       "peer": true,
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+        "@img/sharp-libvips-darwin-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
-      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
+      "integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
       "cpu": [
         "x64"
       ],
@@ -785,19 +785,39 @@
       ],
       "peer": true,
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.2.4"
+        "@img/sharp-libvips-darwin-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
+      "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
-      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
+      "integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
       "cpu": [
         "arm64"
       ],
@@ -812,9 +832,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
-      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
+      "integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
       "cpu": [
         "x64"
       ],
@@ -829,11 +849,14 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
-      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
+      "integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
       "cpu": [
         "arm"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -846,11 +869,14 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
-      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
+      "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -863,11 +889,14 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
-      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
+      "integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
       "cpu": [
         "ppc64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -880,11 +909,14 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-riscv64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
-      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
+      "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
       "cpu": [
         "riscv64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -897,11 +929,14 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
-      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
+      "integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
       "cpu": [
         "s390x"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -914,11 +949,14 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
-      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
+      "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -931,11 +969,14 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
-      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
+      "integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -948,11 +989,14 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
-      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
+      "integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -965,12 +1009,15 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
-      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
+      "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -978,21 +1025,24 @@
       ],
       "peer": true,
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.2.4"
+        "@img/sharp-libvips-linux-arm": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
-      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
+      "integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1001,22 +1051,25 @@
       ],
       "peer": true,
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.2.4"
+        "@img/sharp-libvips-linux-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
-      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
+      "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
       "cpu": [
         "ppc64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1024,22 +1077,25 @@
       ],
       "peer": true,
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+        "@img/sharp-libvips-linux-ppc64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-riscv64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
-      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
+      "integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
       "cpu": [
         "riscv64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1047,22 +1103,25 @@
       ],
       "peer": true,
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+        "@img/sharp-libvips-linux-riscv64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
-      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
+      "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
       "cpu": [
         "s390x"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1070,21 +1129,24 @@
       ],
       "peer": true,
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.2.4"
+        "@img/sharp-libvips-linux-s390x": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
-      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
+      "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1093,22 +1155,25 @@
       ],
       "peer": true,
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.2.4"
+        "@img/sharp-libvips-linux-x64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
-      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
+      "integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "musl"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1116,21 +1181,24 @@
       ],
       "peer": true,
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
-      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
+      "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1139,39 +1207,56 @@
       ],
       "peer": true,
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
-      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
-      "cpu": [
-        "wasm32"
-      ],
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
+      "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "@emnapi/runtime": "^1.7.0"
+        "@emnapi/runtime": "^1.11.1"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
+      "integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
-      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
+      "integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
       "cpu": [
         "arm64"
       ],
@@ -1182,16 +1267,16 @@
       ],
       "peer": true,
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
-      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
+      "integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
       "cpu": [
         "ia32"
       ],
@@ -1202,16 +1287,16 @@
       ],
       "peer": true,
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": "^20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
-      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
+      "integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
       "cpu": [
         "x64"
       ],
@@ -1222,7 +1307,7 @@
       ],
       "peer": true,
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
@@ -1262,22 +1347,22 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.10.tgz",
-      "integrity": "sha512-zLPxg9M0MEHmygpj5OuxjQ+vHMiy/K7cSp74G8ecYolmgUWw0RwN02tF56npup/+qaI8JB97hQgS/r2Hb6QwVA==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.3.0.tgz",
+      "integrity": "sha512-o9r1S0BNiNreHP9Vs+Qnqd9kviDkJh8xIACY7UFZSmiGbbQRzPBBosvHzAU4TULHOIuOj/18RSsyz2qrREmIFw==",
       "license": "MIT",
       "peer": true
     },
     "node_modules/@next/routing": {
-      "version": "16.3.0-preview.10",
-      "resolved": "https://registry.npmjs.org/@next/routing/-/routing-16.3.0-preview.10.tgz",
-      "integrity": "sha512-Ny3AdQsy5Oz4eo/L8279YeQ7aXNMyVoiSsRkhpJpdb3C88OYL2C4czTZVBjmXYG/FMcuBDyeFWYjRIApG01p9Q==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/routing/-/routing-16.3.0.tgz",
+      "integrity": "sha512-Qj5fnjrT096Tu27Dl/ivaTID9FUxE55dx4Zcd/Se6ueTnOzcXfqI8avj0ZEeQ1K0USfx5nTpz8Rvx3+vMME2Qw==",
       "license": "MIT"
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.10.tgz",
-      "integrity": "sha512-v9IdJCa0H0mbo+8z5zwUpOk1Vj7RjkcI5uNYf5Ws1y6szf/p3Mzl9hLaST8SCt6L9h8NGnruZcd2+o0NTNwDhA==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.3.0.tgz",
+      "integrity": "sha512-55hpqq18bEVAlxedlTt3tFqZmKg2nUXT1kn1G/BGEy0R13h3LwtwHPVzzjG6P4LLeOHE32PFDQUVaJEWvBEZBw==",
       "cpu": [
         "arm64"
       ],
@@ -1292,9 +1377,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.10.tgz",
-      "integrity": "sha512-17IS0jJRViROGmA9uGdNR8VPJpfbnaVG7E9qhso5jDLkmyd0lSDORWxbcKINzcFqzZqGwGtMSnrFRxBpuUYjLQ==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.3.0.tgz",
+      "integrity": "sha512-SOi96kSaF5T+0wW4koiM1bWzSPwjzTesC1p3df+FjdOi5LIQkBK/blxh7HdoKnNuI4PURF1OO7TZqtfnbWDSgw==",
       "cpu": [
         "x64"
       ],
@@ -1309,11 +1394,14 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.10.tgz",
-      "integrity": "sha512-GRQRsRtuciNJvB54AvvuQTiq0oZtFwa1owQqtZD8wwnGpM2L39MV22kpI72YSXLKIyY40LC66EiLFv4PiicXxg==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.3.0.tgz",
+      "integrity": "sha512-P0gZAoPMF4dyTRzhmkV4PrqVzSOB6t4mC1oI3c4dqijJ+OVEVx5clIXAKR4/uQpsqw2KKM/0D5tVumcR2r5blg==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -1326,11 +1414,14 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.10.tgz",
-      "integrity": "sha512-zkN9MQYS7UQBro+FnISUq1itaQjXI9xqISzuQ+2bc921NcJ1x4yPCqrn77tVN6/dOOXaaWVX3k6/bR07pPwK+A==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.3.0.tgz",
+      "integrity": "sha512-tXXGKJw0m37O0eKJARVTX/TheKPhz0QFVtVVZXmOig+9YKLQOSP6hvf2pxv5DO7CLEJyTHx3Pg043CDQkv1G4Q==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1343,11 +1434,14 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.10.tgz",
-      "integrity": "sha512-iCVJnwvrPYECvA6WM/7+oo+OiTvedIKLxtCLAZP4xZR3nXa1zmzZyLPbYCmWvpd4CvMYF1EMTafd0ii3DygLvA==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.3.0.tgz",
+      "integrity": "sha512-pjGxK5EY7yWml78ALejFkWmgHsU7wbFQrISiugpH6FbUJhgEvw3xFZ/EBAtLl7QtL0WdQKiG9eWJ3mOKGTukHw==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -1360,11 +1454,14 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.10.tgz",
-      "integrity": "sha512-ov2g4H0dHY9bPoOU83m91hWT7Iq5qy13bUnyyshLU3HGR1Ownn0X9QpmDPc5iIUaahTp7f7LeGAhV4DSFtackw==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.3.0.tgz",
+      "integrity": "sha512-sjo++Xx+lomlPs3HRsHWhVDyGG6ms1kGW5EtHLERdII8AyG1i+f6aq68xHREO6AEMlhjTNEWBSmfJfqm9orf7g==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1377,9 +1474,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.10.tgz",
-      "integrity": "sha512-DwAnhLX76HQiFFQNgWlcK+JzlnD1rZ+UK/WY0ZMI/deXpvgnesjNYrqcfo1JzBuz4Kf7o3brIBL0glI1junatA==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.3.0.tgz",
+      "integrity": "sha512-C5JSgiO54wURdaxdEUIXqkz04uMqC9UmPX1gtDrV/5Tf1UowdWYI8uA5hfFbPolTlp0q4KZ60xlHePNibf0VIw==",
       "cpu": [
         "arm64"
       ],
@@ -1394,9 +1491,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.10.tgz",
-      "integrity": "sha512-0JXq3b85Jk9Jg4ntLUbXSPvoDw3gpZou7twuKdoFG2jOw635v7+IiXfTaa0TxVMyx78pUjnrVYwLgjKfX4e6/A==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.3.0.tgz",
+      "integrity": "sha512-fDOggsweNb5SSw0ZKVk6U+gxSyGFFlIBY/LBc1r8GUj4u/6t6oArL+Pmkg0MBnsgR+KkdsURilVH4F3GXUGepA==",
       "cpu": [
         "x64"
       ],
@@ -2659,15 +2756,15 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/camelcase": {
@@ -3235,12 +3332,12 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.5"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -3257,9 +3354,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "funding": [
         {
           "type": "github",
@@ -3275,17 +3372,17 @@
       }
     },
     "node_modules/next": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.2.10.tgz",
-      "integrity": "sha512-2som5AVXb3kE6Yjine3/mNbBayYF58eguBWIVVUdr1y/L426xyVEgYxgBG+1QC34P2x5E+tcDup6XkuOAX3dCA==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.3.0.tgz",
+      "integrity": "sha512-NEdGOzH+08eTXMUp9UYkA99Nhi5N6Thrhc1jgFOQgfgnGK/dA2hRwBpXep+exdFQrnwlRf/3Wixyp8lLBUpE2A==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@next/env": "16.2.10",
+        "@next/env": "16.3.0",
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
-        "postcss": "8.4.31",
+        "postcss": "8.5.23",
         "styled-jsx": "5.1.6"
       },
       "bin": {
@@ -3295,15 +3392,15 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.2.10",
-        "@next/swc-darwin-x64": "16.2.10",
-        "@next/swc-linux-arm64-gnu": "16.2.10",
-        "@next/swc-linux-arm64-musl": "16.2.10",
-        "@next/swc-linux-x64-gnu": "16.2.10",
-        "@next/swc-linux-x64-musl": "16.2.10",
-        "@next/swc-win32-arm64-msvc": "16.2.10",
-        "@next/swc-win32-x64-msvc": "16.2.10",
-        "sharp": "^0.34.5"
+        "@next/swc-darwin-arm64": "16.3.0",
+        "@next/swc-darwin-x64": "16.3.0",
+        "@next/swc-linux-arm64-gnu": "16.3.0",
+        "@next/swc-linux-arm64-musl": "16.3.0",
+        "@next/swc-linux-x64-gnu": "16.3.0",
+        "@next/swc-linux-x64-musl": "16.3.0",
+        "@next/swc-win32-arm64-msvc": "16.3.0",
+        "@next/swc-win32-x64-msvc": "16.3.0",
+        "sharp": "^0.35.3"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
@@ -3458,9 +3555,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",
@@ -3476,11 +3573,10 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -3615,49 +3711,54 @@
       }
     },
     "node_modules/sharp": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
-      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
-      "hasInstallScript": true,
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
+      "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
       "license": "Apache-2.0",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "@img/colour": "^1.0.0",
+        "@img/colour": "^1.1.0",
         "detect-libc": "^2.1.2",
-        "semver": "^7.7.3"
+        "semver": "^7.8.5"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.34.5",
-        "@img/sharp-darwin-x64": "0.34.5",
-        "@img/sharp-libvips-darwin-arm64": "1.2.4",
-        "@img/sharp-libvips-darwin-x64": "1.2.4",
-        "@img/sharp-libvips-linux-arm": "1.2.4",
-        "@img/sharp-libvips-linux-arm64": "1.2.4",
-        "@img/sharp-libvips-linux-ppc64": "1.2.4",
-        "@img/sharp-libvips-linux-riscv64": "1.2.4",
-        "@img/sharp-libvips-linux-s390x": "1.2.4",
-        "@img/sharp-libvips-linux-x64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
-        "@img/sharp-linux-arm": "0.34.5",
-        "@img/sharp-linux-arm64": "0.34.5",
-        "@img/sharp-linux-ppc64": "0.34.5",
-        "@img/sharp-linux-riscv64": "0.34.5",
-        "@img/sharp-linux-s390x": "0.34.5",
-        "@img/sharp-linux-x64": "0.34.5",
-        "@img/sharp-linuxmusl-arm64": "0.34.5",
-        "@img/sharp-linuxmusl-x64": "0.34.5",
-        "@img/sharp-wasm32": "0.34.5",
-        "@img/sharp-win32-arm64": "0.34.5",
-        "@img/sharp-win32-ia32": "0.34.5",
-        "@img/sharp-win32-x64": "0.34.5"
+        "@img/sharp-darwin-arm64": "0.35.3",
+        "@img/sharp-darwin-x64": "0.35.3",
+        "@img/sharp-freebsd-wasm32": "0.35.3",
+        "@img/sharp-libvips-darwin-arm64": "1.3.2",
+        "@img/sharp-libvips-darwin-x64": "1.3.2",
+        "@img/sharp-libvips-linux-arm": "1.3.2",
+        "@img/sharp-libvips-linux-arm64": "1.3.2",
+        "@img/sharp-libvips-linux-ppc64": "1.3.2",
+        "@img/sharp-libvips-linux-riscv64": "1.3.2",
+        "@img/sharp-libvips-linux-s390x": "1.3.2",
+        "@img/sharp-libvips-linux-x64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2",
+        "@img/sharp-linux-arm": "0.35.3",
+        "@img/sharp-linux-arm64": "0.35.3",
+        "@img/sharp-linux-ppc64": "0.35.3",
+        "@img/sharp-linux-riscv64": "0.35.3",
+        "@img/sharp-linux-s390x": "0.35.3",
+        "@img/sharp-linux-x64": "0.35.3",
+        "@img/sharp-linuxmusl-arm64": "0.35.3",
+        "@img/sharp-linuxmusl-x64": "0.35.3",
+        "@img/sharp-webcontainers-wasm32": "0.35.3",
+        "@img/sharp-win32-arm64": "0.35.3",
+        "@img/sharp-win32-ia32": "0.35.3",
+        "@img/sharp-win32-x64": "0.35.3"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/siginfo": {
@@ -3922,35 +4023,6 @@
         "yaml": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vite/node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.12",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/vitest": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@bufbuild/protobuf": "^2.12.1",
     "@connectrpc/connect": "^2.1.2",
     "@connectrpc/connect-node": "^2.1.2",
-    "@next/routing": "16.3.0-preview.10",
+    "@next/routing": "16.3.0",
     "boxen": "^8.0.1",
     "minimatch": "^10.2.4",
     "redos-detector": "^6.1.4"
@@ -77,7 +77,7 @@
     "vitest": "^4.1.1"
   },
   "peerDependencies": {
-    "next": "^16.2.0"
+    "next": "^16.3.0"
   },
   "engines": {
     "node": ">= 20.9.0"

--- a/package.json
+++ b/package.json
@@ -53,8 +53,9 @@
     "build": "npm run build:clean && npm run build:types && npm run build:adapter && npm run build:pool-server && npm run build:cache-handler && npm run build:protos && npm run build:routing-service && npm run build:cli",
     "fmt": "oxfmt",
     "fmt:check": "oxfmt --check",
-    "lint": "oxlint",
-    "lint:fix": "oxlint --fix"
+    "lint": "oxlint --deny-warnings",
+    "lint:fix": "oxlint --fix",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@bufbuild/protobuf": "^2.12.1",
@@ -72,7 +73,7 @@
     "esbuild": "^0.27.4",
     "ioredis": "^5.11.1",
     "oxfmt": "^0.42.0",
-    "oxlint": "^1.57.0",
+    "oxlint": "1.73.0",
     "typescript": "^6.0.2",
     "vitest": "^4.1.1"
   },

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -1244,7 +1244,7 @@ export function createK8sAdapter(userConfig?: K8sAdapterConfig): NextAdapter {
   const adapter: NextAdapter = {
     name: "k8s",
 
-    async modifyConfig(nextConfig, ctx) {
+    async modifyConfig(nextConfig, _ctx) {
       // The stable adapter API ctx has { phase, nextVersion } — no projectDir.
       // Use process.cwd() which is the project root during build.
       const cfg = await ensureConfig(process.cwd());
@@ -1341,7 +1341,7 @@ export function createK8sAdapter(userConfig?: K8sAdapterConfig): NextAdapter {
         // asset split regresses client bootstrap (asset URLs move under /_next/static/immutable/).
         const disabled = process.env.ADAPTER_K8S_DISABLE_IMMUTABLE_ASSETS === "1";
         modified.experimental = {
-          ...((modified.experimental as Record<string, unknown>) ?? {}),
+          ...(modified.experimental as Record<string, unknown> | undefined),
           supportsImmutableAssets: disabled ? false : (userImmutable ?? true),
         };
       }
@@ -1351,7 +1351,7 @@ export function createK8sAdapter(userConfig?: K8sAdapterConfig): NextAdapter {
       const buildCpus = parseInt(process.env.ADAPTER_K8S_BUILD_CPUS ?? "", 10);
       if (buildCpus > 0) {
         modified.experimental = {
-          ...((modified.experimental as Record<string, unknown>) ?? {}),
+          ...(modified.experimental as Record<string, unknown> | undefined),
           cpus: buildCpus,
           memoryBasedWorkersCount: false,
           parallelServerCompiles: false,
@@ -1392,7 +1392,7 @@ export function createK8sAdapter(userConfig?: K8sAdapterConfig): NextAdapter {
         // 3,342/0 without it (2026-07-28). Absent a measured need, a build-wide define stays
         // out; if it is ever reconsidered, land it alone and re-run the full suite.
         modified.experimental = {
-          ...((modified.experimental as Record<string, unknown>) ?? {}),
+          ...(modified.experimental as Record<string, unknown> | undefined),
           ...(allowedOrigins.size > 0
             ? {
                 serverActions: {
@@ -1400,7 +1400,7 @@ export function createK8sAdapter(userConfig?: K8sAdapterConfig): NextAdapter {
                   allowedOrigins: [...allowedOrigins],
                 },
               }
-            : {}),
+            : undefined),
         };
       }
 

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -1740,23 +1740,6 @@ export function createK8sAdapter(userConfig?: K8sAdapterConfig): NextAdapter {
           `[adapter-k8s] Unsafe namespace in .k8s-adapter/infrastructure.json: ${(err as Error).message}`,
         );
       }
-      // The namespace feeds ONLY the ext_proc extension-chain authority
-      // (`<release>-routing-service.<namespace>.svc.cluster.local`, extension-chain.ts)
-      // — every kubectl/helm call in the CLI pins the literal K8S_NAMESPACE, and init
-      // binds Workload Identity to default/<release>-deploy-sa. A non-default value
-      // here would land workloads in "default" while the GXLB callout targets the
-      // other namespace: every edge callout fails, and diagnostics chase the "wrong"
-      // resources. Fail fast at build time instead of emitting a skewed chain.
-      if (namespace !== K8S_NAMESPACE) {
-        throw new Error(
-          `[adapter-k8s] Unsupported namespace "${namespace}" in ` +
-            `.k8s-adapter/infrastructure.json: this adapter version deploys only to the ` +
-            `"${K8S_NAMESPACE}" namespace (init binds Workload Identity to ` +
-            `${K8S_NAMESPACE}/<release>-deploy-sa and every kubectl/helm call pins it). ` +
-            `Remove "namespace" from infrastructure.json.`,
-        );
-      }
-
       const configuredRegistry = infra.containerRegistry ?? process.env.IMAGE_REGISTRY;
       if (configuredRegistry !== undefined) {
         try {
@@ -2551,6 +2534,7 @@ export function createK8sAdapter(userConfig?: K8sAdapterConfig): NextAdapter {
           // provider-specific decisions (kube context, digest resolution, NetworkPolicy
           // discovery) on that basis.
           provider: resolveProvider(cfg).name,
+          namespace,
           // The chart bakes this registry into image references; deploy refuses a chart whose
           // registry does not match the infrastructure it is deploying with.
           containerRegistry: imageRegistry,

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -644,7 +644,6 @@ export function assertStagedWithin(stageDir: string, absDest: string, destRelati
   }
 }
 
-
 /**
  * `config/` inside a build context is the ADAPTER'S reserved namespace — the fresh
  * routing/pool/static manifests are written there by this build, and the routing image's
@@ -667,10 +666,7 @@ function isReservedContextDest(relDest: string): boolean {
  * files and every PPR fs-mirror seed silently missed in containers (measured:
  * resume-data-cache pods) while local runs — cwd = the real build dir — worked.
  */
-export function prerenderSiblingFiles(asset: {
-  filePath: string;
-  prerender?: boolean;
-}): string[] {
+export function prerenderSiblingFiles(asset: { filePath: string; prerender?: boolean }): string[] {
   if (!asset.prerender) return [];
   if (!/(^|[/\\])server[/\\](app|pages)[/\\]/.test(asset.filePath)) return [];
   if (!asset.filePath.endsWith(".html")) return [];
@@ -2527,7 +2523,13 @@ export function createK8sAdapter(userConfig?: K8sAdapterConfig): NextAdapter {
             await resolveAndCopyExternals(nextNodeModules, nextNodeModulesDest);
             // Same externals-dependency rule as the pool contexts (node middleware may pull
             // in instrumentation-adjacent externals through its bundle).
-            await stageExternalsDependencies(projectDir, nextNodeModules, "routing-service", false, path.join(projectDir, routingServiceContextDir));
+            await stageExternalsDependencies(
+              projectDir,
+              nextNodeModules,
+              "routing-service",
+              false,
+              path.join(projectDir, routingServiceContextDir),
+            );
           }
           if (existsSync(chunksDir)) {
             // Replace the whole chunk set (not merge) so a stale prior build's chunks can't linger

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -755,11 +755,7 @@ export const SHARP_RUNTIME_PACKAGES = [
 // bundle no longer inlines sharp's JS, so the version that matters is the one the APP's
 // next install brought — resolving adapter-first staged a different generation's
 // binaries than the app's sharp JS expects and 503'd every /_next/image.
-export function resolveSharpDepDir(dep: string, projectDir: string): string | undefined {
-  const fromFiles = [
-    path.join(projectDir, "package.json"), // app root (authoritative version)
-    path.join(_dirname, "index.js"), // adapter package (dist/) fallback
-  ];
+function resolvePackageDirFromFiles(dep: string, fromFiles: string[]): string | undefined {
   for (const fromFile of fromFiles) {
     const req = createRequire(fromFile);
     for (const subpath of [`${dep}/package`, `${dep}/package.json`]) {
@@ -792,6 +788,16 @@ export function resolveSharpDepDir(dep: string, projectDir: string): string | un
       // not resolvable from this root at all
     }
   }
+  return undefined;
+}
+
+export function resolveSharpDepDir(dep: string, projectDir: string): string | undefined {
+  const fromFiles = [
+    path.join(projectDir, "package.json"), // app root (authoritative version)
+    path.join(_dirname, "index.js"), // adapter package (dist/) fallback
+  ];
+  const resolved = resolvePackageDirFromFiles(dep, fromFiles);
+  if (resolved) return resolved;
   if (dep !== "sharp") {
     // Check the sibling of EVERY resolvable sharp copy — one root's copy may simply not
     // have this platform package installed while another root's does.
@@ -844,16 +850,7 @@ async function stagePackageTree(
       if (seen.has(dep)) continue;
       seen.add(dep);
       // Resolve the dep relative to its dependent first (nested installs), then the app.
-      const req = createRequire(path.join(dir, "package.json"));
-      let depDir: string | undefined;
-      for (const subpath of [`${dep}/package.json`, `${dep}/package`]) {
-        try {
-          depDir = path.dirname(req.resolve(subpath));
-          break;
-        } catch {
-          // next shape
-        }
-      }
+      let depDir = resolvePackageDirFromFiles(dep, [path.join(dir, "package.json")]);
       depDir ??= resolveSharpDepDir(dep, projectDir);
       if (depDir) queue.push([dep, depDir]);
       else {
@@ -885,13 +882,7 @@ export async function stageExternalsDependencies(
   if (!existsSync(externalsDir)) return { staged, unresolved };
 
   const fromApp = (dep: string): string | undefined => {
-    try {
-      return path.dirname(
-        createRequire(path.join(projectDir, "package.json")).resolve(`${dep}/package.json`),
-      );
-    } catch {
-      return undefined;
-    }
+    return resolvePackageDirFromFiles(dep, [path.join(projectDir, "package.json")]);
   };
 
   const packageDirs: string[] = [];
@@ -969,13 +960,7 @@ export async function stageNextRuntimeDependencies(
   // (and its deps) into an app that has none — a version pairing guaranteed not to match the
   // build output. An app without a resolvable next is not buildable anyway.
   const fromDir = (dep: string, dir: string): string | undefined => {
-    try {
-      return path.dirname(
-        createRequire(path.join(dir, "package.json")).resolve(`${dep}/package.json`),
-      );
-    } catch {
-      return undefined;
-    }
+    return resolvePackageDirFromFiles(dep, [path.join(dir, "package.json")]);
   };
   const nextDir = (resolveDep ?? fromDir)("next", projectDir);
   const staged: string[] = [];

--- a/src/cli/container-runtime.ts
+++ b/src/cli/container-runtime.ts
@@ -71,7 +71,11 @@ async function canBuild(candidate: ContainerCli): Promise<boolean> {
         "",
       ];
   for (const host of hosts) {
-    const res = await execCapture("buildctl", ["debug", "workers"], (host ? { env: { BUILDKIT_HOST: host } } : {})).catch(() => null);
+    const res = await execCapture(
+      "buildctl",
+      ["debug", "workers"],
+      host ? { env: { BUILDKIT_HOST: host } } : {},
+    ).catch(() => null);
     if (res && res.exitCode === 0) return true;
   }
   return false;

--- a/src/cli/container-runtime.ts
+++ b/src/cli/container-runtime.ts
@@ -71,9 +71,7 @@ async function canBuild(candidate: ContainerCli): Promise<boolean> {
         "",
       ];
   for (const host of hosts) {
-    const res = await execCapture("buildctl", ["debug", "workers"], {
-      ...(host ? { env: { BUILDKIT_HOST: host } } : {}),
-    }).catch(() => null);
+    const res = await execCapture("buildctl", ["debug", "workers"], (host ? { env: { BUILDKIT_HOST: host } } : {})).catch(() => null);
     if (res && res.exitCode === 0) return true;
   }
   return false;

--- a/src/cli/deploy.ts
+++ b/src/cli/deploy.ts
@@ -57,15 +57,11 @@ import {
   findBuildIdNameCollision,
   findEmittedNameCollision,
   assertSafeImageRegistry,
-  assertSafeNamespace,
   assertSafeProbePath,
   assertSafeProjectId,
   assertSafeRegion,
   poolResourceNames,
-  // init binds Workload Identity to [default/<release>-deploy-sa]; the release lives
-  // in the literal "default" namespace. Pin it on every kubectl/helm call instead of
-  // trusting whatever namespace the operator's context happens to have.
-  K8S_NAMESPACE,
+  resolveK8sNamespace,
 } from "../emit/templates/utils.js";
 import { sanitizeForTerminal } from "./terminal.js";
 import { resolveContainerCli, targetPlatform } from "./container-runtime.js";
@@ -172,17 +168,21 @@ function promptConfirmation(question: string): Promise<string> {
  * Throws (never returns a guess) when the cluster cannot be read, when pools disagree, or
  * when the selected build has no Deployment.
  */
-export async function discoverServingBuildId(releaseName: string): Promise<string> {
+export async function discoverServingBuildId(
+  releaseName: string,
+  configuredNamespace?: string,
+): Promise<string> {
+  const namespace = resolveK8sNamespace(configuredNamespace);
   const REPAIR =
     `Repair deploy state before deploying: run \`npx adapter-k8s doctor\`, then either ` +
     `restore .k8s-adapter/state.json or fix access to the ${releaseName}-adapter-state ` +
-    `ConfigMap in namespace ${K8S_NAMESPACE}.`;
+    `ConfigMap in namespace ${namespace}.`;
 
   const svcResult = await execCapture("kubectl", [
     "get",
     "svc",
     "-n",
-    K8S_NAMESPACE,
+    namespace,
     "-l",
     `app.kubernetes.io/name=${releaseName}`,
     "-o",
@@ -210,7 +210,7 @@ export async function discoverServingBuildId(releaseName: string): Promise<strin
   if (labels.size === 0) {
     throw new Error(
       `Deploy state could not be determined and no active pool Service in namespace ` +
-        `${K8S_NAMESPACE} carries an app.kubernetes.io/version selector, so the live build ` +
+        `${namespace} carries an app.kubernetes.io/version selector, so the live build ` +
         `is unknown. Refusing to deploy as if this were a first deploy. ${REPAIR}`,
     );
   }
@@ -227,7 +227,7 @@ export async function discoverServingBuildId(releaseName: string): Promise<strin
     "get",
     "deployments",
     "-n",
-    K8S_NAMESPACE,
+    namespace,
     "-l",
     `app.kubernetes.io/name=${releaseName},app.kubernetes.io/version=${label},` +
       `app.kubernetes.io/component!=routing-service`,
@@ -737,6 +737,7 @@ export function buildHelmUpgradeArgs(options: {
   buildId: string;
   registry: string;
   previousBuildId: string | null;
+  namespace?: string;
   overridesFile?: string;
   podCidrs?: string | null;
   /** S22: node/subnet range(s) for the strict posture's kubelet allowance. */
@@ -756,12 +757,14 @@ export function buildHelmUpgradeArgs(options: {
     buildId,
     registry,
     previousBuildId,
+    namespace: configuredNamespace,
     overridesFile,
     podCidrs,
     nodeCidrs,
     imageDigests,
     poolHealthCheckPath,
   } = options;
+  const namespace = resolveK8sNamespace(configuredNamespace);
   // H2: these values land in `helm --set` assignments — reject helm metacharacters
   // (","  "\"  quotes) before they can split one assignment into several. The buildId
   // comes from generateBuildId()/git refs and the registry from infrastructure.json.
@@ -781,7 +784,7 @@ export function buildHelmUpgradeArgs(options: {
     // The release lives in the namespace init binds Workload Identity to — pin it rather
     // than installing into whatever namespace the operator's context happens to have.
     "--namespace",
-    "default",
+    namespace,
     "--create-namespace",
     "--set",
     `global.image.tag=${buildId}`,
@@ -1118,22 +1121,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
   // assignments / docker tags (containerRegistry) — validate before any use.
   if (infra.projectId) assertSafeProjectId(infra.projectId);
   if (infra.region) assertSafeRegion(infra.region);
-  if (infra.namespace) assertSafeNamespace(infra.namespace);
-  // Same fail-fast as build time (adapter.ts): every kubectl/helm call below pins
-  // K8S_NAMESPACE, but the build-time extension chain derives the ext_proc authority
-  // from infra.namespace — honoring any other value would put the workloads in
-  // "default" while the GXLB callout targets the other namespace, failing every edge
-  // callout. Reject instead of deploying skewed. (Deploy-time too, not just build
-  // time: --skip-build deploys ship a chart built elsewhere, possibly before this
-  // guard existed.)
-  if (infra.namespace !== undefined && infra.namespace !== K8S_NAMESPACE) {
-    throw new Error(
-      `Unsupported namespace "${infra.namespace}" in .k8s-adapter/infrastructure.json: ` +
-        `this adapter version deploys only to the "${K8S_NAMESPACE}" namespace (init binds ` +
-        `Workload Identity to ${K8S_NAMESPACE}/<release>-deploy-sa and every kubectl/helm ` +
-        `call pins it). Remove "namespace" from infrastructure.json.`,
-    );
-  }
+  const namespace = resolveK8sNamespace(infra.namespace);
   if (infra.containerRegistry) assertSafeImageRegistry(infra.containerRegistry);
   // Without a registry, docker tags and the helm --set image registry can't be formed —
   // fail with a pointer to the fix instead of a raw TypeError deep in the deploy.
@@ -1189,6 +1177,18 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
         `(and fail to authenticate against a registry this cluster cannot reach).\n` +
         `${process.env.ADAPTER_K8S_CONFIG ? `You are using ADAPTER_K8S_CONFIG=${process.env.ADAPTER_K8S_CONFIG}; the output directory is shared between variants.\n` : ""}` +
         `Re-run without --skip-build so the chart is emitted for this target.`,
+    );
+  }
+  // Build metadata predating namespace support has no field and therefore targets the
+  // historical default namespace.
+  const builtNamespace = resolveK8sNamespace(metadata.namespace);
+  if (builtNamespace !== namespace) {
+    throw new Error(
+      `The build output in .k8s-adapter/output was emitted for namespace ` +
+        `"${builtNamespace}", but this deploy targets "${namespace}". The ext_proc authority ` +
+        `is namespace-qualified at build time, so deploying this chart would make routing ` +
+        `callouts target the wrong Service. Re-run without --skip-build so the chart is ` +
+        `emitted for this target.`,
     );
   }
 
@@ -1455,7 +1455,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
         "secret",
         `${releaseName}-valkey`,
         "-n",
-        K8S_NAMESPACE,
+        namespace,
         "--ignore-not-found",
       ]);
       if (secretDelete.stdout.trim())
@@ -1632,7 +1632,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
     state = await readState(projectDir).catch(() => null);
   } else {
     try {
-      state = await readState(projectDir, releaseName);
+      state = await readState(projectDir, releaseName, { namespace });
     } catch (err) {
       if (!(err instanceof StateUnavailableError)) throw err;
       stateUnavailable = err.message;
@@ -1649,7 +1649,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
     console.warn(
       `\n  ! Committed deploy state could not be determined:\n    ${sanitizeForTerminal(stateUnavailable)}`,
     );
-    previousBuildId = await discoverServingBuildId(releaseName);
+    previousBuildId = await discoverServingBuildId(releaseName, namespace);
     console.warn(
       `  ! Recovered the currently-serving build "${previousBuildId}" from the active ` +
         `Service selector. Proceeding with it as the previous build — its recorded CDN tag ` +
@@ -1729,6 +1729,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
     buildId,
     registry: infra.containerRegistry,
     previousBuildId,
+    namespace,
     overridesFile,
     podCidrs: podCidr,
     nodeCidrs: nodeCidr,
@@ -1832,7 +1833,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
           "deployment",
           poolPrevName,
           "-n",
-          K8S_NAMESPACE,
+          namespace,
           "--ignore-not-found",
           "-o",
           // N66: one probe, one round trip — every field the retained manifest must
@@ -1897,7 +1898,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
             "service",
             activeServiceName,
             "-n",
-            K8S_NAMESPACE,
+            namespace,
             "--ignore-not-found",
             "-o",
             "name",
@@ -2055,7 +2056,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
   // revert the edge IMAGE — silently, with the degradation recorded nowhere.
   let unretainedManifestBuild: string | null = null;
   if (!dryRun) {
-    const retention = await retainLiveRoutingManifest(releaseName);
+    const retention = await retainLiveRoutingManifest(releaseName, namespace);
     if (retention.status === "failed") {
       if (!allowUnretainedManifest) {
         throw new Error(
@@ -2095,7 +2096,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
     const keepAnnotation = "helm.sh/resource-policy=keep";
     if (dryRun) {
       console.log(
-        `    [dry-run] kubectl annotate secret ${legacySecret} -n ${K8S_NAMESPACE} ` +
+        `    [dry-run] kubectl annotate secret ${legacySecret} -n ${namespace} ` +
           `${keepAnnotation} --overwrite (if it exists)`,
       );
     } else {
@@ -2104,7 +2105,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
         "secret",
         legacySecret,
         "-n",
-        K8S_NAMESPACE,
+        namespace,
         "--ignore-not-found",
         "-o",
         "name",
@@ -2126,7 +2127,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
           "secret",
           legacySecret,
           "-n",
-          K8S_NAMESPACE,
+          namespace,
           keepAnnotation,
           "--overwrite",
         ]);
@@ -2181,6 +2182,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
     try {
       await revertRoutingServiceToBuild({
         releaseName,
+        namespace,
         targetBuildId: previousBuildId,
         registry: infra.containerRegistry,
         targetImageDigest: state?.routingImageDigests?.[previousBuildId],
@@ -2214,7 +2216,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
       `  The edge (ext_proc) is running build ${buildId}'s middleware and routing manifest ` +
         `while the pools serve ${previousBuildId}. Mismatched routes fall back to pool-local ` +
         `re-resolution (invariant 1), but edge middleware is the NEW build's until repaired:`,
-      `    kubectl -n ${K8S_NAMESPACE} set image deployment/` +
+      `    kubectl -n ${namespace} set image deployment/` +
         `${routingServiceDeploymentName(releaseName)} routing-service=` +
         `${infra.containerRegistry}/routing-service:${previousBuildId}`,
     ];
@@ -2228,7 +2230,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
       "httproute",
       `${releaseName}-routes`,
       "-n",
-      K8S_NAMESPACE,
+      namespace,
       "-o",
       "jsonpath={.spec.rules[*].filters[*].extensionRef.kind}",
     ]);
@@ -2237,7 +2239,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
     } else {
       console.warn(
         "  ! Could not confirm the Cloud CDN filter on the HTTPRoute (non-fatal). " +
-          `Inspect with: kubectl get httproute ${releaseName}-routes -o yaml`,
+          `Inspect with: kubectl get httproute ${releaseName}-routes -n ${namespace} -o yaml`,
       );
     }
   }
@@ -2263,7 +2265,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
       "get",
       "deployments",
       "-n",
-      K8S_NAMESPACE,
+      namespace,
       "-l",
       `app.kubernetes.io/name=${releaseName},app.kubernetes.io/version=${safeBuildId}`,
       "-o",
@@ -2284,7 +2286,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
         "status",
         `deployment/${deployName}`,
         "-n",
-        K8S_NAMESPACE,
+        namespace,
         KUBECTL_ROLLOUT_TIMEOUT,
       ]);
       // The pod-health gate below is the real readiness gate, but don't walk into it on
@@ -2300,7 +2302,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
               `NOT switched — the previous build's pools are still serving.`,
             // L14: kubectl rollout output carries controller/admission messages.
             `${sanitizeForTerminal((rollout.stderr || rollout.stdout).trim())}`,
-            `Inspect: kubectl logs deployment/${deployName} -n ${K8S_NAMESPACE} --tail=40`,
+            `Inspect: kubectl logs deployment/${deployName} -n ${namespace} --tail=40`,
             ...edgeStatusLines(edge),
           ].join("\n"),
         );
@@ -2317,7 +2319,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
       "deployment",
       routingDeploy,
       "-n",
-      K8S_NAMESPACE,
+      namespace,
       "--ignore-not-found",
       "-o",
       "name",
@@ -2329,7 +2331,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
         "status",
         `deployment/${routingDeploy}`,
         "-n",
-        K8S_NAMESPACE,
+        namespace,
         KUBECTL_ROLLOUT_TIMEOUT,
       ]);
       if (rsRollout.exitCode !== 0) {
@@ -2342,7 +2344,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
             `Routing service (${routingDeploy}) did not become healthy. Traffic was NOT ` +
               `switched — the previous build's pools are still serving.`,
             `${(rsRollout.stderr || rsRollout.stdout).trim()}`,
-            `Inspect: kubectl logs -l app.kubernetes.io/component=routing-service -n ${K8S_NAMESPACE} --tail=40`,
+            `Inspect: kubectl logs -l app.kubernetes.io/component=routing-service -n ${namespace} --tail=40`,
             ...edgeStatusLines(edge),
           ].join("\n"),
         );
@@ -2360,7 +2362,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
         "--for=condition=complete",
         `job/${currentRouteExtJob}`,
         "-n",
-        K8S_NAMESPACE,
+        namespace,
         "--timeout=600s",
       ]);
       if (wait.exitCode !== 0) {
@@ -2371,7 +2373,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
               `traffic cutover because middleware may not be wired.`,
             // L14: kubectl wait output carries controller/admission messages.
             `${sanitizeForTerminal((wait.stderr || wait.stdout).trim())}`,
-            `Inspect: kubectl logs job/${currentRouteExtJob} -n ${K8S_NAMESPACE}`,
+            `Inspect: kubectl logs job/${currentRouteExtJob} -n ${namespace}`,
             ...edgeStatusLines(edge),
           ].join("\n"),
         );
@@ -2406,7 +2408,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
           "envoyextensionpolicy",
           policyName,
           "-n",
-          K8S_NAMESPACE,
+          namespace,
           "-o",
           "json",
         ]);
@@ -2457,7 +2459,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
               `${status || "unknown"}); refusing traffic cutover because middleware would not ` +
               `run at the edge.`,
             sanitizeForTerminal(detail),
-            `Inspect: kubectl describe envoyextensionpolicy ${policyName} -n ${K8S_NAMESPACE}`,
+            `Inspect: kubectl describe envoyextensionpolicy ${policyName} -n ${namespace}`,
             `Common causes: the GatewayClass controller is not Envoy Gateway (an ` +
               `EnvoyExtensionPolicy only applies to one), or the Gateway it targets does not exist.`,
             ...edgeStatusLines(edge),
@@ -2503,7 +2505,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
           "hpa",
           name,
           "-n",
-          K8S_NAMESPACE,
+          namespace,
           "--type=merge",
           // Same field-manager rationale as the Service/Deployment patches: helm owns the
           // chart-rendered HPA, so the next `helm upgrade` must not conflict here.
@@ -2519,7 +2521,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
               `(${restore.stderr.trim() || `exit ${restore.exitCode}`}) — it is STILL widened ` +
               `for the pre-cutover warm-up, so this pool may autoscale above its configured ` +
               `ceiling until the next \`helm upgrade\` re-renders it. Fix it with: kubectl -n ` +
-              `${K8S_NAMESPACE} patch hpa ${name} --type=merge -p ` +
+              `${namespace} patch hpa ${name} --type=merge -p ` +
               `'{"spec":{"maxReplicas":${max}}}'`,
           );
         }
@@ -2559,7 +2561,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
         "hpa",
         newHpaName,
         "-n",
-        K8S_NAMESPACE,
+        namespace,
         "--ignore-not-found",
         "-o",
         "jsonpath={.metadata.name}|{.spec.minReplicas}|{.spec.maxReplicas}",
@@ -2589,7 +2591,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
             "hpa",
             newHpaName,
             "-n",
-            K8S_NAMESPACE,
+            namespace,
             "--type=merge",
             "--field-manager=helm",
             "-p",
@@ -2622,7 +2624,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
         "deployment",
         newDeployName,
         "-n",
-        K8S_NAMESPACE,
+        namespace,
         "--ignore-not-found",
         "-o",
         "jsonpath={.metadata.name}|{.spec.replicas}",
@@ -2648,7 +2650,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
         "scale",
         `deployment/${newDeployName}`,
         "-n",
-        K8S_NAMESPACE,
+        namespace,
         `--replicas=${expected}`,
       ]);
       if (scaleUp.exitCode !== 0) {
@@ -2688,7 +2690,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
         "get",
         "pods",
         "-n",
-        K8S_NAMESPACE,
+        namespace,
         "-l",
         // The routing service shares the version label; exclude it by its component label
         // (exact — a name substring match would also drop pool pods named similarly).
@@ -2758,7 +2760,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
         "get",
         "pods",
         "-n",
-        K8S_NAMESPACE,
+        namespace,
         "-l",
         `app.kubernetes.io/name=${releaseName},app.kubernetes.io/version=${safeBuildId},app.kubernetes.io/component!=routing-service`,
         "-o",
@@ -2780,7 +2782,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
             "exec",
             podName,
             "-n",
-            K8S_NAMESPACE,
+            namespace,
             "--",
             "node",
             "-e",
@@ -2804,7 +2806,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
             "logs",
             podName,
             "-n",
-            K8S_NAMESPACE,
+            namespace,
             "--tail=20",
           ]);
           if (logsResult.exitCode === 0) {
@@ -2856,7 +2858,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
         "service",
         activeServiceName,
         "-n",
-        K8S_NAMESPACE,
+        namespace,
         "--type=json",
         // Impersonate helm as the field manager so the next helm upgrade (server-side
         // apply, manager "helm") does not conflict on the selector field we flip here.
@@ -2898,7 +2900,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
             "service",
             serviceName,
             "-n",
-            K8S_NAMESPACE,
+            namespace,
             "--type=json",
             "--field-manager=helm",
             "-p",
@@ -3000,6 +3002,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
           basedOnGeneration: state?.generation ?? null,
         },
         releaseName,
+        namespace,
       );
     } catch (err) {
       // N67: the warm-up widening is scoped to the warm-up on this path too — traffic HAS
@@ -3075,14 +3078,14 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
           "hpa",
           poolPrevHpa,
           "-n",
-          K8S_NAMESPACE,
+          namespace,
           "--ignore-not-found",
         ]);
         const scaleDown = await execCapture("kubectl", [
           "scale",
           `deployment/${poolPrevName}`,
           "-n",
-          K8S_NAMESPACE,
+          namespace,
           "--replicas=0",
         ]);
         if (hpaDelete.exitCode !== 0 || scaleDown.exitCode !== 0) {
@@ -3119,7 +3122,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
       "get",
       "deployments",
       "-n",
-      K8S_NAMESPACE,
+      namespace,
       "-l",
       `app.kubernetes.io/name=${releaseName}`,
       "-o",
@@ -3150,10 +3153,8 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
         }
         // Delete everything else
         console.log(`  → Deleting old build: ${name}`);
-        await execCapture("kubectl", ["delete", "deployment", name, "-n", K8S_NAMESPACE]);
-        await execCapture("kubectl", ["delete", "service", name, "-n", K8S_NAMESPACE]).catch(
-          () => {},
-        );
+        await execCapture("kubectl", ["delete", "deployment", name, "-n", namespace]);
+        await execCapture("kubectl", ["delete", "service", name, "-n", namespace]).catch(() => {});
         // This build's raw release/pool/buildId parts are unknowable here (`name` is a
         // cluster-listed deployment of a build state no longer tracks), so the HCP name
         // can't go through poolResourceNames. Re-sanitizing the deployment name with the
@@ -3167,7 +3168,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
           "healthcheckpolicy",
           sanitizeK8sName(name, "-hcp"),
           "-n",
-          K8S_NAMESPACE,
+          namespace,
         ]).catch(() => {});
       }
     }
@@ -3180,7 +3181,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
       "get",
       "jobs",
       "-n",
-      K8S_NAMESPACE,
+      namespace,
       "-l",
       `app.kubernetes.io/name=${releaseName},app.kubernetes.io/component=route-ext-job`,
       "-o",
@@ -3189,7 +3190,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
     if (oldJobs.exitCode === 0) {
       for (const jobName of oldJobs.stdout.trim().split("\n")) {
         if (!jobName || jobName === currentRouteExtJob) continue;
-        await execCapture("kubectl", ["delete", "job", jobName, "-n", K8S_NAMESPACE]);
+        await execCapture("kubectl", ["delete", "job", jobName, "-n", namespace]);
       }
     }
 
@@ -3209,7 +3210,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
         "get",
         "configmaps",
         "-n",
-        K8S_NAMESPACE,
+        namespace,
         "-l",
         `app.kubernetes.io/name=${releaseName},app.kubernetes.io/managed-by=adapter-k8s,` +
           `app.kubernetes.io/component=routing-manifest-snapshot`,
@@ -3220,7 +3221,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
         for (const cmName of snapshots.stdout.trim().split("\n")) {
           if (!cmName || keepSnapshots.has(cmName)) continue;
           console.log(`  → Deleting old routing-manifest snapshot: ${cmName}`);
-          await execCapture("kubectl", ["delete", "configmap", cmName, "-n", K8S_NAMESPACE]);
+          await execCapture("kubectl", ["delete", "configmap", cmName, "-n", namespace]);
         }
       }
     }
@@ -3245,7 +3246,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
       "get",
       "deployments",
       "-n",
-      K8S_NAMESPACE,
+      namespace,
       "-l",
       `app.kubernetes.io/name=${releaseName}`,
       "-o",
@@ -3297,7 +3298,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
         "get",
         "secrets",
         "-n",
-        K8S_NAMESPACE,
+        namespace,
         "-l",
         `app.kubernetes.io/name=${releaseName},` +
           `app.kubernetes.io/component=${INTERNAL_SECRET_COMPONENT}`,
@@ -3308,7 +3309,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
         for (const secretName of internalSecrets.stdout.trim().split("\n")) {
           if (!secretName || referencedSecrets.has(secretName)) continue;
           console.log(`  → Deleting unreferenced internal dispatch Secret: ${secretName}`);
-          await execCapture("kubectl", ["delete", "secret", secretName, "-n", K8S_NAMESPACE]);
+          await execCapture("kubectl", ["delete", "secret", secretName, "-n", namespace]);
         }
       }
     }

--- a/src/cli/deploy.ts
+++ b/src/cli/deploy.ts
@@ -1144,7 +1144,8 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
   }
 
   // 2. Read build metadata to get buildId and pool names
-  const outputDir = path.join(projectDir, ".k8s-adapter", outputDirName());
+  const outputDirRelative = path.join(".k8s-adapter", outputDirName());
+  const outputDir = path.join(projectDir, outputDirRelative);
   const metadataPath = path.join(outputDir, "build-metadata.json");
   if (!existsSync(metadataPath)) {
     throw new Error(`Build metadata not found at ${metadataPath}. Did next build run?`);
@@ -1159,10 +1160,9 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
   // which is what every build before this change was.
   const buildProvider: string = typeof metadata.provider === "string" ? metadata.provider : "gke";
 
-  // TARGET FINGERPRINT. `.k8s-adapter/output` is shared across config variants, and the routing
-  // tier's image registry is baked into its Deployment template at BUILD time — so `--skip-build`
-  // will happily deploy another target's chart. MEASURED: a Scaleway deploy reused a GKE chart
-  // from minutes earlier and its routing pods went ImagePullBackOff trying to pull
+  // TARGET FINGERPRINT. The routing tier's image registry is baked into its Deployment template
+  // at BUILD time, so copied or pre-variant output can still belong to another target. MEASURED:
+  // a Scaleway deploy reused a GKE chart and its routing pods went ImagePullBackOff trying to pull
   // `us-central1-docker.pkg.dev/...` with a 403, after helm had already applied.
   //
   // Refuse before helm instead. This compares what the chart was BUILT for against what we are
@@ -1171,11 +1171,11 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
     typeof metadata.containerRegistry === "string" ? metadata.containerRegistry : undefined;
   if (builtRegistry !== undefined && builtRegistry !== infra.containerRegistry) {
     throw new Error(
-      `The build output in .k8s-adapter/output was emitted for registry ` +
+      `The build output in ${outputDirRelative} was emitted for registry ` +
         `"${builtRegistry}", but this deploy targets "${infra.containerRegistry}". The chart bakes ` +
         `image references at build time, so deploying it would pull another target's images ` +
         `(and fail to authenticate against a registry this cluster cannot reach).\n` +
-        `${process.env.ADAPTER_K8S_CONFIG ? `You are using ADAPTER_K8S_CONFIG=${process.env.ADAPTER_K8S_CONFIG}; the output directory is shared between variants.\n` : ""}` +
+        `${process.env.ADAPTER_K8S_CONFIG ? `You are using ADAPTER_K8S_CONFIG=${process.env.ADAPTER_K8S_CONFIG}; the selected variant output does not match its infrastructure.\n` : ""}` +
         `Re-run without --skip-build so the chart is emitted for this target.`,
     );
   }
@@ -1184,7 +1184,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
   const builtNamespace = resolveK8sNamespace(metadata.namespace);
   if (builtNamespace !== namespace) {
     throw new Error(
-      `The build output in .k8s-adapter/output was emitted for namespace ` +
+      `The build output in ${outputDirRelative} was emitted for namespace ` +
         `"${builtNamespace}", but this deploy targets "${namespace}". The ext_proc authority ` +
         `is namespace-qualified at build time, so deploying this chart would make routing ` +
         `callouts target the wrong Service. Re-run without --skip-build so the chart is ` +
@@ -1511,7 +1511,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
       pools,
       buildId,
       registry: infra.containerRegistry,
-      outputDir: ".k8s-adapter/output",
+      outputDir: outputDirRelative,
       containerStrategy,
       containerCli,
     });

--- a/src/cli/describe.ts
+++ b/src/cli/describe.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import boxen from "boxen";
 import { execCapture } from "./exec.js";
 import { sanitizeForTerminal } from "./terminal.js";
-import { sanitizeK8sName } from "../emit/templates/utils.js";
+import { resolveK8sNamespace, sanitizeK8sName } from "../emit/templates/utils.js";
 import {
   assertSafeInfrastructure,
   infrastructurePath,
@@ -32,10 +32,12 @@ export async function runDescribe(options: {
         projectId?: string;
         region?: string;
         hosts?: string[];
+        namespace?: string;
       } | null)
     : null;
   // S13: validate before any of these reach a gcloud/kubectl argv.
   assertSafeInfrastructure(infra);
+  const namespace = resolveK8sNamespace(infra?.namespace);
 
   // Ensure kubectl is pointing at the right cluster BEFORE reading state — readState
   // prefers the cluster ConfigMap, and with kubectl still pinned to a stale context it
@@ -66,7 +68,7 @@ export async function runDescribe(options: {
   const { readState, StateUnavailableError } = await import("./state.js");
   // N20: state reads now throw when state is indeterminate. describe is diagnostic — report
   // and continue rather than crashing the one command an operator runs to inspect a release.
-  const state = await readState(projectDir, releaseName).catch((err: unknown) => {
+  const state = await readState(projectDir, releaseName, { namespace }).catch((err: unknown) => {
     if (!(err instanceof StateUnavailableError)) throw err;
     console.warn(
       `  ! Deploy state could not be determined: ${(err as Error).message.split("\n")[0]}`,
@@ -119,10 +121,8 @@ export async function runDescribe(options: {
   const deploymentsResult = await execCapture("kubectl", [
     "get",
     "deployments",
-    // The release lives in the literal "default" namespace (same pin as deploy/
-    // rollback/state) — a kubeconfig namespace override would otherwise show nothing.
     "-n",
-    "default",
+    namespace,
     "-l",
     `app.kubernetes.io/name=${releaseName}`,
     "-o",

--- a/src/cli/destroy.ts
+++ b/src/cli/destroy.ts
@@ -5,7 +5,7 @@ import { execCapture } from "./exec.js";
 import { cliServiceAccountEmail, deployExtRoleId, deployServiceAccountEmail } from "./init.js";
 import { sanitizeForTerminal } from "./terminal.js";
 import { INTERNAL_SECRET_COMPONENT } from "../emit/templates/internal-secret.js";
-import { K8S_NAMESPACE } from "../emit/templates/utils.js";
+import { resolveK8sNamespace } from "../emit/templates/utils.js";
 import { assertSafeInfrastructure, infrastructurePath } from "./infrastructure-validation.js";
 
 export interface DestroyOptions {
@@ -163,6 +163,7 @@ export async function runDestroy(options: DestroyOptions): Promise<void> {
   const infra = existsSync(infraPath) ? JSON.parse(readFileSync(infraPath, "utf-8")) : undefined;
   // S13: validate before any of these reach a gcloud/kubectl argv.
   assertSafeInfrastructure(infra);
+  const namespace = resolveK8sNamespace(infra?.namespace);
   const projectId: string | undefined = infra?.projectId;
   const region: string | undefined = infra?.region;
 
@@ -295,13 +296,12 @@ export async function runDestroy(options: DestroyOptions): Promise<void> {
     }
   }
 
-  // 1. Helm uninstall. The release lives in the "default" namespace — the same one init
-  // binds Workload Identity to — so pin it instead of trusting the context's namespace.
+  // Pin every cluster-side deletion to the release namespace instead of trusting the context.
   if (dryRun) {
-    console.log(`  [dry-run] helm uninstall ${releaseName} --namespace default`);
+    console.log(`  [dry-run] helm uninstall ${releaseName} --namespace ${namespace}`);
   } else {
     console.log("  → Running helm uninstall...");
-    const res = await execCapture("helm", ["uninstall", releaseName, "--namespace", "default"]);
+    const res = await execCapture("helm", ["uninstall", releaseName, "--namespace", namespace]);
     if (res.exitCode !== 0) {
       if (isAlreadyGoneError(res.stderr)) {
         console.log("    (release not found or already uninstalled)");
@@ -323,7 +323,7 @@ export async function runDestroy(options: DestroyOptions): Promise<void> {
     "delete",
     "configmap",
     "-n",
-    "default",
+    namespace,
     "-l",
     `app.kubernetes.io/name=${releaseName},app.kubernetes.io/managed-by=adapter-k8s`,
     "--ignore-not-found",
@@ -336,7 +336,7 @@ export async function runDestroy(options: DestroyOptions): Promise<void> {
       console.warn(
         `    WARNING: could not delete adapter state ConfigMaps: ` +
           `${sanitizeForTerminal(res.stderr.trim()) || `exit ${res.exitCode}`}. Delete them manually ` +
-          `(kubectl delete configmap -n default -l app.kubernetes.io/name=${releaseName},` +
+          `(kubectl delete configmap -n ${namespace} -l app.kubernetes.io/name=${releaseName},` +
           `app.kubernetes.io/managed-by=adapter-k8s) or the next deploy may see stale state.`,
       );
     }
@@ -354,7 +354,7 @@ export async function runDestroy(options: DestroyOptions): Promise<void> {
     "delete",
     "secret",
     "-n",
-    K8S_NAMESPACE,
+    namespace,
     "-l",
     `app.kubernetes.io/name=${releaseName},app.kubernetes.io/component=${INTERNAL_SECRET_COMPONENT}`,
     "--ignore-not-found",
@@ -367,7 +367,7 @@ export async function runDestroy(options: DestroyOptions): Promise<void> {
       console.warn(
         `    WARNING: could not delete the internal-dispatch Secrets: ` +
           `${sanitizeForTerminal(res.stderr.trim()) || `exit ${res.exitCode}`}. Delete them ` +
-          `manually (kubectl delete secret -n ${K8S_NAMESPACE} -l ` +
+          `manually (kubectl delete secret -n ${namespace} -l ` +
           `app.kubernetes.io/name=${releaseName},` +
           `app.kubernetes.io/component=${INTERNAL_SECRET_COMPONENT}); they are retained by ` +
           `resource-policy and helm uninstall will not remove them.`,

--- a/src/cli/destroy.ts
+++ b/src/cli/destroy.ts
@@ -1,5 +1,4 @@
 // src/cli/destroy.ts
-import path from "node:path";
 import { existsSync, readFileSync } from "node:fs";
 import readline from "node:readline";
 import { execCapture } from "./exec.js";

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -5,17 +5,12 @@ import path from "node:path";
 import { execCapture } from "./exec.js";
 import { sanitizeForTerminal } from "./terminal.js";
 import { checkContainerRuntime } from "./container-runtime.js";
-import { sanitizeK8sName } from "../emit/templates/utils.js";
+import { resolveK8sNamespace, sanitizeK8sName } from "../emit/templates/utils.js";
 import {
   assertSafeInfrastructure,
   infrastructurePath,
   outputDirName,
 } from "./infrastructure-validation.js";
-
-// The release lives in the literal "default" namespace (init binds Workload Identity
-// there; deploy/rollback/state/destroy all pin it). Pin every kubectl read here too —
-// a kubeconfig namespace override otherwise makes every check report "not found".
-const K8S_NAMESPACE = "default";
 
 // Name the file in parse errors — a bare SyntaxError from JSON.parse gives no clue
 // WHICH file is corrupt.
@@ -190,13 +185,17 @@ export async function runDoctor(options: {
 }): Promise<void> {
   const { projectDir, releaseName } = options;
   const results: CheckResult[] = [];
+  let namespace = resolveK8sNamespace();
 
   // Ensure kubectl is pointing at the right cluster
   const infraPathForCtx = infrastructurePath(projectDir);
   if (existsSync(infraPathForCtx)) {
-    const infraCtx = readJsonFile<{ projectId?: string; region?: string }>(infraPathForCtx);
+    const infraCtx = readJsonFile<{ projectId?: string; region?: string; namespace?: string }>(
+      infraPathForCtx,
+    );
     // S13: validate before these reach a gcloud/kubectl argv.
     assertSafeInfrastructure(infraCtx);
+    namespace = resolveK8sNamespace(infraCtx.namespace);
     if (infraCtx.projectId && infraCtx.region) {
       const clusterName = `${releaseName}-cluster`;
       const credResult = await execCapture("gcloud", [
@@ -270,7 +269,7 @@ export async function runDoctor(options: {
   let state: Awaited<ReturnType<typeof readState>> = null;
   let stateError: string | null = null;
   try {
-    state = await readState(projectDir, releaseName);
+    state = await readState(projectDir, releaseName, { namespace });
   } catch (err) {
     if (!(err instanceof StateUnavailableError)) throw err;
     stateError = err.message;
@@ -417,7 +416,7 @@ export async function runDoctor(options: {
       "gateway",
       `${releaseName}-gateway`,
       "-n",
-      K8S_NAMESPACE,
+      namespace,
       "-o",
       "jsonpath={.status.conditions[?(@.type=='Accepted')].status}",
     ]);
@@ -432,7 +431,7 @@ export async function runDoctor(options: {
           "gateway",
           `${releaseName}-gateway`,
           "-n",
-          K8S_NAMESPACE,
+          namespace,
           "-o",
           "jsonpath={.status.conditions[?(@.type=='Accepted')].message}",
         ]);
@@ -442,7 +441,7 @@ export async function runDoctor(options: {
           // L14: condition messages are cluster-sourced — strip terminal control chars.
           message:
             sanitizeForTerminal(reasonResult.stdout.trim()) || `Status: ${accepted || "Unknown"}`,
-          fix: `kubectl describe gateway ${releaseName}-gateway`,
+          fix: `kubectl describe gateway ${releaseName}-gateway -n ${namespace}`,
         });
       }
     } else {
@@ -460,7 +459,7 @@ export async function runDoctor(options: {
       "gateway",
       `${releaseName}-gateway`,
       "-n",
-      K8S_NAMESPACE,
+      namespace,
       "-o",
       "jsonpath={.status.addresses[0].value}",
     ]);
@@ -499,7 +498,7 @@ export async function runDoctor(options: {
       "httproute",
       `${releaseName}-routes`,
       "-n",
-      K8S_NAMESPACE,
+      namespace,
       "-o",
       "jsonpath={.status.parents[0].conditions[?(@.type=='Accepted')].status}",
     ]);
@@ -512,7 +511,7 @@ export async function runDoctor(options: {
               name: "HTTPRoute",
               status: "fail",
               message: `Status: ${accepted || "Unknown"}`,
-              fix: `kubectl describe httproute ${releaseName}-routes`,
+              fix: `kubectl describe httproute ${releaseName}-routes -n ${namespace}`,
             },
       );
     } else {
@@ -524,7 +523,7 @@ export async function runDoctor(options: {
       "get",
       "deployments",
       "-n",
-      K8S_NAMESPACE,
+      namespace,
       "-l",
       `app.kubernetes.io/name=${releaseName}`,
       "-o",
@@ -594,7 +593,7 @@ export async function runDoctor(options: {
             name: `${label}${roleTag}`,
             status: "fail",
             message: `${ready}/${total} ready`,
-            fix: `kubectl describe deployment/${name}`,
+            fix: `kubectl describe deployment/${name} -n ${namespace}`,
           });
         } else if (ready < total) {
           results.push({
@@ -607,7 +606,7 @@ export async function runDoctor(options: {
             name: `${label}${roleTag}`,
             status: "fail",
             message: `${ready}/${total} ready`,
-            fix: `kubectl describe deployment/${name}`,
+            fix: `kubectl describe deployment/${name} -n ${namespace}`,
           });
         }
       }
@@ -651,7 +650,7 @@ export async function runDoctor(options: {
       "get",
       "svc",
       "-n",
-      K8S_NAMESPACE,
+      namespace,
       "-l",
       `app.kubernetes.io/name=${releaseName}`,
       "-o",
@@ -704,7 +703,7 @@ export async function runDoctor(options: {
         "get",
         "endpointslice",
         "-n",
-        K8S_NAMESPACE,
+        namespace,
         "-l",
         `kubernetes.io/service-name=${svc}`,
         "-o",
@@ -728,7 +727,7 @@ export async function runDoctor(options: {
           name: `Active Service endpoints: ${svc}`,
           status: "fail",
           message: "0 ready endpoints — selector matches no ready pods (origin will 503)",
-          fix: `kubectl get svc ${svc} -o jsonpath='{.spec.selector}' — verify app.kubernetes.io/version matches a running pod's label`,
+          fix: `kubectl get svc ${svc} -n ${namespace} -o jsonpath='{.spec.selector}' — verify app.kubernetes.io/version matches a running pod's label`,
         });
       }
       // readyEndpoints === -1 (kubectl error) is left unreported — cluster-connectivity
@@ -779,7 +778,7 @@ export async function runDoctor(options: {
       "get",
       "pods",
       "-n",
-      K8S_NAMESPACE,
+      namespace,
       "-l",
       `app.kubernetes.io/name=${releaseName}`,
       "-o",
@@ -796,7 +795,7 @@ export async function runDoctor(options: {
           "logs",
           pod,
           "-n",
-          K8S_NAMESPACE,
+          namespace,
           "--tail=50",
         ]);
         if (logsResult.exitCode !== 0) continue;
@@ -812,14 +811,14 @@ export async function runDoctor(options: {
           name: "Pod logs",
           status: "fail",
           message: `Fatal error in ${fatalHit.pod}: ${firstFatal}`,
-          fix: `kubectl logs ${fatalHit.pod} --tail=50`,
+          fix: `kubectl logs ${fatalHit.pod} -n ${namespace} --tail=50`,
         });
       } else if (errorPods.length > 0) {
         results.push({
           name: "Pod logs",
           status: "warn",
           message: `error-level lines in ${errorPods.length}/${podsToCheck.length} pod(s) — likely transient app errors`,
-          fix: `kubectl logs ${errorPods[0]} --tail=50`,
+          fix: `kubectl logs ${errorPods[0]} -n ${namespace} --tail=50`,
         });
       } else if (podsToCheck.length > 0) {
         results.push({
@@ -940,7 +939,7 @@ export async function runDoctor(options: {
         "get",
         "svcneg",
         "-n",
-        K8S_NAMESPACE,
+        namespace,
         "-o",
         "jsonpath={range .items[*]}{.metadata.name}|{.status.conditions[?(@.type=='Initialized')].status}{\"\\n\"}{end}",
       ]);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,6 +1,6 @@
 // src/cli/index.ts
 import path from "node:path";
-import { infrastructurePath } from "./infrastructure-validation.js";
+import { infrastructurePath, infrastructureWritePath } from "./infrastructure-validation.js";
 import { sanitizeForTerminal } from "./terminal.js";
 import { existsSync, readFileSync } from "node:fs";
 import { runInit } from "./init.js";
@@ -40,6 +40,7 @@ const VALUE_FLAGS = new Set([
   "bucket",
   "registry",
   "release-name",
+  "namespace",
   "port",
 ]);
 
@@ -143,6 +144,7 @@ Options:
   --bucket <name>          GCS bucket name for static assets (init)
   --registry <url>         Container registry URL (init)
   --release-name <name>    Helm release name (default: current directory name)
+  --namespace <name>       Kubernetes namespace (init; default: persisted value or default)
   --standard               Provision a GKE Standard cluster instead of Autopilot (init)
   --skip-build             Skip next build (deploy, emulate)
   --skip-push              Skip docker build + push (deploy)
@@ -188,12 +190,17 @@ async function main(): Promise<void> {
       .slice(0, 40)
       .replace(/-+$/, "") || "app";
   let persistedReleaseName: string | undefined;
-  const infraPath = infrastructurePath(projectDir);
+  let persistedNamespace: string | undefined;
+  const infraPath =
+    command === "init" ? infrastructureWritePath(projectDir) : infrastructurePath(projectDir);
   if (existsSync(infraPath)) {
     try {
       const infra = JSON.parse(readFileSync(infraPath, "utf-8"));
       if (typeof infra.releaseName === "string" && infra.releaseName) {
         persistedReleaseName = infra.releaseName;
+      }
+      if (typeof infra.namespace === "string" && infra.namespace) {
+        persistedNamespace = infra.namespace;
       }
     } catch (err) {
       // Malformed infrastructure.json — fall back to the directory default, but name
@@ -229,6 +236,7 @@ async function main(): Promise<void> {
       const registry =
         (flags["registry"] as string) ??
         (projectId && region ? `${region}-docker.pkg.dev/${projectId}/nextjs` : undefined);
+      const initNamespace = (flags["namespace"] as string | undefined) ?? persistedNamespace;
 
       if (!projectId || hosts.length === 0) {
         console.error("Error: --project-id and --host are required for init");
@@ -248,6 +256,7 @@ async function main(): Promise<void> {
         bucket: bucket!,
         registry: registry!,
         releaseName,
+        ...(initNamespace ? { namespace: initNamespace } : {}),
         projectDir,
         dryRun,
         // --standard opts out of the Autopilot default (Standard clusters get

--- a/src/cli/infrastructure-validation.ts
+++ b/src/cli/infrastructure-validation.ts
@@ -12,7 +12,7 @@ import {
 export interface InfrastructureArgvFields {
   projectId?: string | undefined;
   region?: string | undefined;
-  namespace?: string | undefined;
+  namespace?: unknown;
   containerRegistry?: string | undefined;
   gcsBucket?: string | undefined;
   cacheRegion?: string | undefined;
@@ -40,7 +40,7 @@ export function assertSafeInfrastructure(infra: InfrastructureArgvFields | null 
   if (!infra) return;
   if (infra.projectId) assertSafeProjectId(infra.projectId);
   if (infra.region) assertSafeRegion(infra.region);
-  if (infra.namespace) assertSafeNamespace(infra.namespace);
+  if (infra.namespace !== undefined) assertSafeNamespace(infra.namespace);
   if (infra.containerRegistry) assertSafeImageRegistry(infra.containerRegistry);
   // A region-shaped value; same charset as `region` (lowercase alnum + hyphen).
   if (infra.cacheRegion) assertSafeRegion(infra.cacheRegion);
@@ -74,16 +74,9 @@ export function assertSafeInfrastructure(infra: InfrastructureArgvFields | null 
  * existing single-target project is unaffected.
  */
 export function infrastructurePath(projectDir: string): string {
+  const scoped = infrastructureWritePath(projectDir);
   const variant = process.env.ADAPTER_K8S_CONFIG?.trim();
-  const base = path.join(projectDir, ".k8s-adapter");
-  if (!variant) return path.join(base, "infrastructure.json");
-  if (!/^[a-z0-9][-a-z0-9_]*$/i.test(variant)) {
-    throw new Error(
-      `ADAPTER_K8S_CONFIG=${JSON.stringify(variant)} is not a valid variant name. Use a bare ` +
-        `name like "scaleway"; it is interpolated into a filename, so a path is refused.`,
-    );
-  }
-  const scoped = path.join(base, `infrastructure.${variant}.json`);
+  if (!variant) return scoped;
   // NO FALLBACK. Falling back was a cross-wiring hazard: the adapter loads
   // adapter.config.<variant>.mjs while this returned the DEFAULT infrastructure.json, so a
   // half-present variant built config A against infrastructure B — a deploy aimed at one
@@ -98,6 +91,23 @@ export function infrastructurePath(projectDir: string): string {
     );
   }
   return scoped;
+}
+
+/**
+ * Path where init writes infrastructure state. Unlike infrastructurePath(), this permits a
+ * selected variant not to exist yet because creating it is init's job.
+ */
+export function infrastructureWritePath(projectDir: string): string {
+  const variant = process.env.ADAPTER_K8S_CONFIG?.trim();
+  const base = path.join(projectDir, ".k8s-adapter");
+  if (!variant) return path.join(base, "infrastructure.json");
+  if (!/^[a-z0-9][-a-z0-9_]*$/i.test(variant)) {
+    throw new Error(
+      `ADAPTER_K8S_CONFIG=${JSON.stringify(variant)} is not a valid variant name. Use a bare ` +
+        `name like "scaleway"; it is interpolated into a filename, so a path is refused.`,
+    );
+  }
+  return path.join(base, `infrastructure.${variant}.json`);
 }
 
 /**

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -5,12 +5,14 @@ import { execCapture } from "./exec.js";
 import { generateAdapterConfig, generateInfrastructureJson } from "./scaffold.js";
 import { gkeVersionAtLeast, MIN_GKE_VERSION_FOR_CDN } from "./gke-version.js";
 import { sanitizeForTerminal } from "./terminal.js";
+import { infrastructureWritePath } from "./infrastructure-validation.js";
 import {
   assertSafeBucketName,
   assertSafeHostname,
   assertSafeImageRegistry,
   assertSafeProjectId,
   assertSafeRegion,
+  resolveK8sNamespace,
 } from "../emit/templates/utils.js";
 
 export interface InitOptions {
@@ -20,6 +22,7 @@ export interface InitOptions {
   bucket: string;
   registry: string;
   releaseName: string;
+  namespace?: string;
   projectDir: string;
   dryRun?: boolean;
   /** Backoff between IAM-binding retries (ms). Defaults to 5000; tests override to run fast. */
@@ -94,10 +97,12 @@ export function buildInitGcloudCommands(options: {
   region: string;
   bucket: string;
   releaseName: string;
+  namespace?: string;
   hosts?: string[];
   autopilot?: boolean;
 }): GcloudCommand[] {
   const { projectId, region, bucket, releaseName, hosts = [], autopilot = true } = options;
+  const namespace = resolveK8sNamespace(options.namespace);
   const commands: GcloudCommand[] = [];
   // S6: the impersonable Job identity and the CLI-only one. See the doc comments above —
   // every grant below is deliberate about WHICH of the two it lands on.
@@ -390,7 +395,7 @@ export function buildInitGcloudCommands(options: {
       "--role",
       "roles/iam.workloadIdentityUser",
       "--member",
-      `serviceAccount:${projectId}.svc.id.goog[default/${releaseName}-deploy-sa]`,
+      `serviceAccount:${projectId}.svc.id.goog[${namespace}/${releaseName}-deploy-sa]`,
       "--condition=None",
       "--project",
       projectId,
@@ -609,11 +614,34 @@ export async function runInit(options: InitOptions): Promise<void> {
     bucket,
     registry,
     releaseName,
+    namespace: configuredNamespace,
     projectDir,
     dryRun,
     iamRetryDelayMs = 5000,
     autopilot = true,
   } = options;
+  const namespace = resolveK8sNamespace(configuredNamespace);
+
+  const infraPath = infrastructureWritePath(projectDir);
+  if (existsSync(infraPath)) {
+    let existing: { namespace?: unknown };
+    try {
+      existing = JSON.parse(readFileSync(infraPath, "utf-8"));
+    } catch (err) {
+      throw new Error(
+        `Failed to parse ${infraPath}: ${err instanceof Error ? err.message : String(err)}. ` +
+          `Fix the file before re-running init.`,
+      );
+    }
+    const existingNamespace = resolveK8sNamespace(existing.namespace);
+    if (existingNamespace !== namespace) {
+      throw new Error(
+        `Cannot change the namespace of an existing release from "${existingNamespace}" to ` +
+          `"${namespace}". The old namespace still contains release state and Workload ` +
+          `Identity bindings. Destroy that release first, or use a new release/config variant.`,
+      );
+    }
+  }
 
   // Validate every operator-supplied value BEFORE it reaches a gcloud arg array or the
   // scaffolded adapter.config.mjs — a `'` in a host/bucket name would otherwise be raw
@@ -682,6 +710,7 @@ export async function runInit(options: InitOptions): Promise<void> {
     region,
     bucket,
     releaseName,
+    namespace,
     hosts,
     autopilot,
   });
@@ -914,9 +943,8 @@ export async function runInit(options: InitOptions): Promise<void> {
   }
 
   // 4. Write infrastructure.json
-  const infraDir = path.join(projectDir, ".k8s-adapter");
-  const infraPath = path.join(infraDir, "infrastructure.json");
-  console.log("  → Writing .k8s-adapter/infrastructure.json");
+  const infraDir = path.dirname(infraPath);
+  console.log(`  → Writing ${path.relative(projectDir, infraPath)}`);
   if (!dryRun) {
     mkdirSync(infraDir, { recursive: true });
     writeFileSync(
@@ -930,6 +958,7 @@ export async function runInit(options: InitOptions): Promise<void> {
         gatewayName: `${releaseName}-gateway`,
         routeExtensionName: `${releaseName}-route-ext`,
         releaseName,
+        namespace,
       }),
     );
   }
@@ -992,7 +1021,7 @@ export async function runInit(options: InitOptions): Promise<void> {
   console.log(`  3. Configure your DNS A records for your hosts:`);
   console.log("     - Wait 5-10 minutes for the GCP Load Balancer to initialize.");
   console.log(
-    `     - Run \`kubectl get gateway ${releaseName}-gateway\` to find your external IP address.`,
+    `     - Run \`kubectl get gateway ${releaseName}-gateway -n ${namespace}\` to find your external IP address.`,
   );
   for (const h of hosts) {
     console.log(`     - Create a DNS A record for ${h} pointing to that IP.`);

--- a/src/cli/rollback.ts
+++ b/src/cli/rollback.ts
@@ -9,10 +9,7 @@ import {
   assertSafeImageRegistry,
   poolResourceNames,
   sanitizeK8sName,
-  // init binds Workload Identity to [default/<release>-deploy-sa]; the release lives
-  // in the literal "default" namespace. Pin it on every kubectl call instead of
-  // trusting whatever namespace the operator's context happens to have.
-  K8S_NAMESPACE,
+  resolveK8sNamespace,
 } from "../emit/templates/utils.js";
 import {
   ROUTING_MANIFEST_VOLUME_NAME,
@@ -89,14 +86,18 @@ type RoutingServingRead =
  * it from the image reference broke once images became digest-pinned (see the NEXT_BUILD_ID note
  * inside).
  */
-export async function readRoutingServingConfig(releaseName: string): Promise<RoutingServingRead> {
+export async function readRoutingServingConfig(
+  releaseName: string,
+  configuredNamespace?: string,
+): Promise<RoutingServingRead> {
+  const namespace = resolveK8sNamespace(configuredNamespace);
   const deployName = routingServiceDeploymentName(releaseName);
   const res = await execCapture("kubectl", [
     "get",
     "deployment",
     deployName,
     "-n",
-    K8S_NAMESPACE,
+    namespace,
     "--ignore-not-found",
     "-o",
     "json",
@@ -223,9 +224,11 @@ export type RetainManifestResult =
 // by deploy (pre-helm-upgrade) to retain the outgoing build.
 export async function retainLiveRoutingManifest(
   releaseName: string,
+  configuredNamespace?: string,
   log: (msg: string) => void = (m) => console.log(m),
 ): Promise<RetainManifestResult> {
-  const read = await readRoutingServingConfig(releaseName);
+  const namespace = resolveK8sNamespace(configuredNamespace);
+  const read = await readRoutingServingConfig(releaseName, namespace);
   // N68: absence (proven by --ignore-not-found) is the ONLY outcome that means "nothing to
   // retain". A read failure is a retention failure, which deploy treats as fatal unless
   // --allow-unretained-manifest — otherwise helm overwrites the stable ConfigMap and the
@@ -253,7 +256,7 @@ export async function retainLiveRoutingManifest(
     "configmap",
     snapshotName,
     "-n",
-    K8S_NAMESPACE,
+    namespace,
     "--ignore-not-found",
     "-o",
     "json",
@@ -283,7 +286,7 @@ export async function retainLiveRoutingManifest(
     "configmap",
     serving.manifestConfigMap,
     "-n",
-    K8S_NAMESPACE,
+    namespace,
     "-o",
     "json",
   ]);
@@ -328,7 +331,7 @@ export async function retainLiveRoutingManifest(
   // argv length, and secrets never go on argv.
   const applied = await execCaptureStdin(
     "kubectl",
-    ["apply", "-n", K8S_NAMESPACE, "-f", "-"],
+    ["apply", "-n", namespace, "-f", "-"],
     JSON.stringify(snapshot),
   );
   if (applied.exitCode !== 0) {
@@ -366,6 +369,7 @@ export async function retainLiveRoutingManifest(
 // still serving traffic. No cutover performed."
 export async function revertRoutingServiceToBuild(opts: {
   releaseName: string;
+  namespace?: string;
   targetBuildId: string;
   registry: string | undefined;
   /**
@@ -376,13 +380,14 @@ export async function revertRoutingServiceToBuild(opts: {
   targetImageDigest?: string | undefined;
 }): Promise<void> {
   const { releaseName, targetBuildId, registry, targetImageDigest } = opts;
+  const namespace = resolveK8sNamespace(opts.namespace);
   const deployName = routingServiceDeploymentName(releaseName);
   // N68: same distinction as retention — a read failure here used to return silently, i.e.
   // report "this release has no routing tier" and let the caller believe the edge was
   // reverted (deploy's abort path prints "the routing edge was reverted") while the edge
   // kept serving the other build's middleware. Absence is exit 0 + empty stdout; anything
   // else throws so the caller can say what it does not know.
-  const exists = await readRoutingServingConfig(releaseName);
+  const exists = await readRoutingServingConfig(releaseName, namespace);
   if (exists.status === "failed") {
     throw new Error(
       `Could not determine what the routing tier (${deployName}) is serving: ${exists.reason}. ` +
@@ -412,7 +417,7 @@ export async function revertRoutingServiceToBuild(opts: {
 
   // Retain the manifest we are about to roll AWAY from, so the symmetric roll-forward
   // can restore it (its stable-ConfigMap content is otherwise lost on the next deploy).
-  await retainLiveRoutingManifest(releaseName);
+  await retainLiveRoutingManifest(releaseName, namespace);
 
   const targetSnapshot = routingManifestSnapshotName(releaseName, targetBuildId);
   const snap = await execCapture("kubectl", [
@@ -420,7 +425,7 @@ export async function revertRoutingServiceToBuild(opts: {
     "configmap",
     targetSnapshot,
     "-n",
-    K8S_NAMESPACE,
+    namespace,
     "--ignore-not-found",
     "-o",
     "name",
@@ -466,7 +471,7 @@ export async function revertRoutingServiceToBuild(opts: {
       "secret",
       candidate,
       "-n",
-      K8S_NAMESPACE,
+      namespace,
       "--ignore-not-found",
       "-o",
       "name",
@@ -547,7 +552,7 @@ export async function revertRoutingServiceToBuild(opts: {
     "deployment",
     deployName,
     "-n",
-    K8S_NAMESPACE,
+    namespace,
     "--type=strategic",
     // Same field-manager rationale as the Service selector patches below: helm owns this
     // Deployment, so the next `helm upgrade` must not conflict on the fields we flip here.
@@ -577,12 +582,12 @@ export async function revertRoutingServiceToBuild(opts: {
     "status",
     `deployment/${deployName}`,
     "-n",
-    K8S_NAMESPACE,
+    namespace,
     `--timeout=${ROUTING_ROLLOUT_TIMEOUT_SECONDS}s`,
   ]);
   if (rollout.exitCode !== 0) {
     const detail = rollout.stderr.trim() || rollout.stdout.trim() || `exit ${rollout.exitCode}`;
-    const restored = await restoreRoutingSpec(deployName, priorSpec);
+    const restored = await restoreRoutingSpec(deployName, priorSpec, namespace);
     throw new Error(
       `The routing service did not roll out to build ${targetBuildId} within ` +
         `${ROUTING_ROLLOUT_TIMEOUT_SECONDS}s: ${detail}\n` +
@@ -590,7 +595,7 @@ export async function revertRoutingServiceToBuild(opts: {
           ? `  The edge was restored to what it was serving before (${priorSpec.buildId ?? "unknown build"}), ` +
             `so the pools and the edge still agree. Traffic was NOT switched.`
           : `  !! The edge could NOT be restored, so the pools and the edge may now be on ` +
-            `DIFFERENT builds. Check \`kubectl -n ${K8S_NAMESPACE} describe deployment ` +
+            `DIFFERENT builds. Check \`kubectl -n ${namespace} describe deployment ` +
             `${deployName}\` and the routing pod logs — a manifest that does not match the ` +
             `image makes the pod refuse to start on purpose.`) +
         `\n  Traffic was NOT switched.`,
@@ -623,6 +628,7 @@ interface RoutingSpecSnapshot {
 async function restoreRoutingSpec(
   deployName: string,
   prior: RoutingSpecSnapshot,
+  namespace: string,
 ): Promise<boolean> {
   if (!prior.image) return false;
   const patch = {
@@ -677,7 +683,7 @@ async function restoreRoutingSpec(
     "deployment",
     deployName,
     "-n",
-    K8S_NAMESPACE,
+    namespace,
     "--type=strategic",
     "--field-manager=helm",
     "-p",
@@ -735,6 +741,7 @@ async function readLiveCapacity(
   releaseName: string,
   pool: string,
   currentBuildId: string,
+  namespace: string,
 ): Promise<{ observed: LiveCapacity; unreadable: string[] }> {
   const { deployment, hpa } = poolResourceNames(releaseName, pool, currentBuildId);
   const unreadable: string[] = [];
@@ -750,7 +757,7 @@ async function readLiveCapacity(
     "deployment",
     deployment,
     "-n",
-    K8S_NAMESPACE,
+    namespace,
     "--ignore-not-found",
     "-o",
     "jsonpath={.metadata.name}|{.spec.replicas}|{.status.readyReplicas}",
@@ -771,7 +778,7 @@ async function readLiveCapacity(
     "hpa",
     hpa,
     "-n",
-    K8S_NAMESPACE,
+    namespace,
     "--ignore-not-found",
     "-o",
     "jsonpath={.metadata.name}|{.status.desiredReplicas}|{.spec.maxReplicas}",
@@ -801,6 +808,7 @@ export async function runRollback(options: {
   const infra = existsSync(infraPath) ? JSON.parse(readFileSync(infraPath, "utf-8")) : undefined;
   // S13: validate before these reach a gcloud/kubectl argv.
   assertSafeInfrastructure(infra);
+  const namespace = resolveK8sNamespace(infra?.namespace);
 
   // Pin kubectl at THIS release's cluster BEFORE any cluster read — the state ConfigMap
   // read below previously ran against whatever context happened to be current, so a
@@ -824,7 +832,10 @@ export async function runRollback(options: {
     }
   }
 
-  const state = await readState(projectDir, releaseName, dryRun ? { localOnly: true } : undefined);
+  const state = await readState(projectDir, releaseName, {
+    ...(dryRun ? { localOnly: true } : {}),
+    namespace,
+  });
   if (!state?.previousBuildId) {
     // Dry-run deliberately reads the LOCAL state file only (L13 — no cluster access),
     // so "no previous build" may just mean the local file is missing/stale while the
@@ -904,7 +915,7 @@ export async function runRollback(options: {
     "get",
     "deployments",
     "-n",
-    K8S_NAMESPACE,
+    namespace,
     "-l",
     `app.kubernetes.io/name=${releaseName}`,
     "-o",
@@ -987,6 +998,7 @@ export async function runRollback(options: {
       releaseName,
       previousDeploy.pool,
       currentBuildId,
+      namespace,
     );
     if (unreadable.length > 0) {
       console.warn(
@@ -1010,7 +1022,7 @@ export async function runRollback(options: {
       "scale",
       `deployment/${previousDeploy.name}`,
       "-n",
-      K8S_NAMESPACE,
+      namespace,
       `--replicas=${plan.replicas}`,
     ]);
   }
@@ -1035,7 +1047,7 @@ export async function runRollback(options: {
       "hpa",
       hpaName,
       "-n",
-      K8S_NAMESPACE,
+      namespace,
       "--ignore-not-found",
       "-o",
       "name",
@@ -1046,7 +1058,7 @@ export async function runRollback(options: {
         "deployment",
         previousDeploy.name,
         "-n",
-        K8S_NAMESPACE,
+        namespace,
         `--name=${hpaName}`,
         `--min=${plan.min}`,
         `--max=${plan.max}`,
@@ -1058,7 +1070,7 @@ export async function runRollback(options: {
         "hpa",
         hpaName,
         "-n",
-        K8S_NAMESPACE,
+        namespace,
         "--type=merge",
         // Same field-manager rationale as the Service/Deployment patches: helm owns the
         // chart-rendered HPA, so the next `helm upgrade` must not conflict here.
@@ -1084,7 +1096,7 @@ export async function runRollback(options: {
       "status",
       `deployment/${previousDeploy.name}`,
       "-n",
-      K8S_NAMESPACE,
+      namespace,
       "--timeout=120s",
     ]);
   }
@@ -1108,7 +1120,7 @@ export async function runRollback(options: {
       "get",
       "pods",
       "-n",
-      K8S_NAMESPACE,
+      namespace,
       "-l",
       `app.kubernetes.io/name=${releaseName},app.kubernetes.io/version=${safePreviousBuild},app.kubernetes.io/component!=routing-service`,
       "-o",
@@ -1129,7 +1141,7 @@ export async function runRollback(options: {
           "exec",
           pod,
           "-n",
-          K8S_NAMESPACE,
+          namespace,
           "--",
           "node",
           "-e",
@@ -1153,7 +1165,8 @@ export async function runRollback(options: {
     throw new Error(
       `Previous build ${previousBuildId} did not pass /healthz within 2 minutes. Traffic ` +
         `was NOT switched — the current build is still serving. Both builds were left scaled ` +
-        `up; investigate (kubectl logs -l app.kubernetes.io/version=${safePreviousBuild}) and ` +
+        `up; investigate (kubectl logs -n ${namespace} -l ` +
+        `app.kubernetes.io/version=${safePreviousBuild}) and ` +
         `re-run the rollback.`,
     );
   }
@@ -1165,6 +1178,7 @@ export async function runRollback(options: {
   if (infra?.containerRegistry) assertSafeImageRegistry(infra.containerRegistry);
   await revertRoutingServiceToBuild({
     releaseName,
+    namespace,
     targetBuildId: previousBuildId,
     registry: infra?.containerRegistry,
     targetImageDigest: state.routingImageDigests?.[previousBuildId],
@@ -1192,7 +1206,7 @@ export async function runRollback(options: {
       "service",
       svcName,
       "-n",
-      K8S_NAMESPACE,
+      namespace,
       "--type=json",
       // --force-conflicts is NOT a valid `kubectl patch` flag (only `apply
       // --server-side` accepts it); a JSON patch needs no conflict override.
@@ -1225,7 +1239,7 @@ export async function runRollback(options: {
         "service",
         serviceName,
         "-n",
-        K8S_NAMESPACE,
+        namespace,
         "--type=json",
         "--field-manager=helm",
         "-p",
@@ -1252,6 +1266,7 @@ export async function runRollback(options: {
       assertSafeBuildId(currentBuildId);
       await revertRoutingServiceToBuild({
         releaseName,
+        namespace,
         targetBuildId: currentBuildId,
         registry: infra?.containerRegistry,
         targetImageDigest: state.routingImageDigests?.[currentBuildId],
@@ -1287,7 +1302,7 @@ export async function runRollback(options: {
       );
       console.error(`  Recover by re-running the rollback, or restore the edge manually:`);
       console.error(
-        `    kubectl -n ${K8S_NAMESPACE} set image deployment/` +
+        `    kubectl -n ${namespace} set image deployment/` +
           `${routingServiceDeploymentName(releaseName)} routing-service=` +
           `${infra?.containerRegistry ?? "<registry>"}/routing-service:${currentBuildId}`,
       );
@@ -1331,6 +1346,7 @@ export async function runRollback(options: {
         basedOnGeneration: state.generation ?? null,
       },
       releaseName,
+      namespace,
     );
   } catch (err) {
     console.error(`\n  Rollback traffic switch succeeded, but persisting state failed:`);
@@ -1380,14 +1396,14 @@ export async function runRollback(options: {
       "hpa",
       currentDeploy.hpa,
       "-n",
-      K8S_NAMESPACE,
+      namespace,
       "--ignore-not-found",
     ]);
     await execOrThrow("kubectl", [
       "scale",
       `deployment/${currentDeploy.name}`,
       "-n",
-      K8S_NAMESPACE,
+      namespace,
       "--replicas=0",
     ]);
   }

--- a/src/cli/scaffold.ts
+++ b/src/cli/scaffold.ts
@@ -1,4 +1,5 @@
 // src/cli/scaffold.ts
+import { K8S_NAMESPACE } from "../emit/templates/utils.js";
 
 export interface ScaffoldOptions {
   projectId: string;
@@ -57,6 +58,7 @@ export interface InfrastructureConfig {
   gatewayName: string;
   routeExtensionName: string;
   releaseName: string;
+  namespace?: string;
 }
 
 export function generateInfrastructureJson(config: InfrastructureConfig): string {
@@ -70,6 +72,7 @@ export function generateInfrastructureJson(config: InfrastructureConfig): string
       gatewayName: config.gatewayName,
       routeExtensionName: config.routeExtensionName,
       releaseName: config.releaseName,
+      namespace: config.namespace ?? K8S_NAMESPACE,
     },
     null,
     2,

--- a/src/cli/state.ts
+++ b/src/cli/state.ts
@@ -3,6 +3,7 @@ import { existsSync, readFileSync, writeFileSync, renameSync, mkdirSync } from "
 import path from "node:path";
 import { stateFileName } from "./infrastructure-validation.js";
 import { execCapture, execCaptureStdin } from "./exec.js";
+import { resolveK8sNamespace } from "../emit/templates/utils.js";
 
 const STATE_DIR = ".k8s-adapter";
 // Variant-scoped: see stateFileName(). Sharing one state file across deploy targets lets a
@@ -10,11 +11,6 @@ const STATE_DIR = ".k8s-adapter";
 // cluster's Services at a build that only ever existed on the other one.
 const STATE_FILE = (): string => stateFileName();
 const CONFIGMAP_NAME_SUFFIX = "-adapter-state";
-// init binds Workload Identity to [<namespace>/${releaseName}-deploy-sa] with the literal
-// namespace "default" — the release (and therefore this ConfigMap) lives there. Pin it:
-// reading/writing via whatever namespace the operator's context happens to have can
-// silently target the wrong namespace.
-const STATE_NAMESPACE = "default";
 // N22: every shell-out goes through exec.ts (AGENTS.md) — this file used to call
 // `spawn("kubectl", …)` directly, which meant no `stdin.on("error")` handler (the
 // ERR_STREAM_DESTROYED crash exec.ts:231-236 documents, hit immediately AFTER cutover,
@@ -228,7 +224,7 @@ export function chooseNewerState(local: AdapterState, cluster: AdapterState): Ad
       `selector onto a build that may be scaled to zero. Confirm which build is serving ` +
       `(\`npx adapter-k8s doctor\`), then delete the stale copy — ` +
       `\`rm ${path.join(STATE_DIR, STATE_FILE())}\` to accept the cluster's, or re-run the ` +
-      `deploy after \`kubectl delete configmap <release>${CONFIGMAP_NAME_SUFFIX} -n ${STATE_NAMESPACE}\` ` +
+      `deploy after \`kubectl delete configmap <release>${CONFIGMAP_NAME_SUFFIX} -n <namespace>\` ` +
       `to accept the local one.`,
   );
 }
@@ -241,12 +237,15 @@ export function chooseNewerState(local: AdapterState, cluster: AdapterState): Ad
 export async function readState(
   projectDir: string,
   releaseName?: string,
-  opts?: { localOnly?: boolean },
+  opts?: { localOnly?: boolean; namespace?: string },
 ): Promise<AdapterState | null> {
   const local = readLocalState(projectDir);
   if (!releaseName || opts?.localOnly) return local;
 
-  const { state: cluster } = await readClusterState(releaseName);
+  const { state: cluster } = await readClusterState(
+    releaseName,
+    resolveK8sNamespace(opts?.namespace),
+  );
   if (!cluster) return local;
   if (!local) return cluster;
   return chooseNewerState(local, cluster);
@@ -288,7 +287,9 @@ export async function writeState(
   projectDir: string,
   state: StateWrite,
   releaseName?: string,
+  configuredNamespace?: string,
 ): Promise<void> {
+  const namespace = resolveK8sNamespace(configuredNamespace);
   const { basedOnGeneration, ...body } = state;
   const localExisting = readLocalStateQuiet(projectDir);
 
@@ -304,7 +305,7 @@ export async function writeState(
   let clusterReadError: ClusterStateWriteError | null = null;
   if (releaseName) {
     try {
-      const existing = await readClusterStateForWrite(releaseName);
+      const existing = await readClusterStateForWrite(releaseName, namespace);
       clusterGeneration = existing.generation;
       resourceVersion = existing.resourceVersion;
     } catch (err) {
@@ -378,7 +379,7 @@ export async function writeState(
 
   // Write to cluster ConfigMap (throws ClusterStateWriteError on failure)
   if (releaseName) {
-    await writeClusterState(releaseName, stamped, resourceVersion);
+    await writeClusterState(releaseName, stamped, resourceVersion, namespace);
   }
 }
 
@@ -386,12 +387,12 @@ function configMapName(releaseName: string): string {
   return `${releaseName}${CONFIGMAP_NAME_SUFFIX}`;
 }
 
-const STATE_GET_ARGS = (cmName: string): string[] => [
+const STATE_GET_ARGS = (cmName: string, namespace: string): string[] => [
   "get",
   "configmap",
   cmName,
   "-n",
-  STATE_NAMESPACE,
+  namespace,
   // N20: THE machine-readable absence signal. With --ignore-not-found a genuinely absent
   // ConfigMap is exit 0 + empty stdout, so any non-zero exit is a real failure
   // (connectivity, RBAC, expired credentials) and must never read as "no state yet".
@@ -460,19 +461,19 @@ function parseStateConfigMap(
   return { state, resourceVersion };
 }
 
-async function readClusterState(releaseName: string): Promise<ClusterStateRead> {
+async function readClusterState(releaseName: string, namespace: string): Promise<ClusterStateRead> {
   const cmName = configMapName(releaseName);
-  const result = await execCapture("kubectl", STATE_GET_ARGS(cmName), {
+  const result = await execCapture("kubectl", STATE_GET_ARGS(cmName, namespace), {
     timeoutMs: KUBECTL_TIMEOUT_MS,
   }).catch((err: unknown) => {
     throw new ClusterStateReadError(
-      `Could not read the deploy-state ConfigMap ${cmName} in namespace ${STATE_NAMESPACE}: ` +
+      `Could not read the deploy-state ConfigMap ${cmName} in namespace ${namespace}: ` +
         `${err instanceof Error ? err.message : String(err)}`,
     );
   });
   if (result.exitCode !== 0) {
     throw new ClusterStateReadError(
-      `Could not read the deploy-state ConfigMap ${cmName} in namespace ${STATE_NAMESPACE} ` +
+      `Could not read the deploy-state ConfigMap ${cmName} in namespace ${namespace} ` +
         `(kubectl exited ${result.exitCode}${result.timedOut ? ", timed out" : ""}). ` +
         `--ignore-not-found makes a genuinely absent ConfigMap exit 0, so this is a ` +
         `connectivity/RBAC failure, NOT "no deploys yet".` +
@@ -488,9 +489,10 @@ async function readClusterState(releaseName: string): Promise<ClusterStateRead> 
 // while an unreadable cluster IS (see writeState).
 async function readClusterStateForWrite(
   releaseName: string,
+  namespace: string,
 ): Promise<{ generation: number; resourceVersion: string | null }> {
   const cmName = configMapName(releaseName);
-  const result = await execCapture("kubectl", STATE_GET_ARGS(cmName), {
+  const result = await execCapture("kubectl", STATE_GET_ARGS(cmName, namespace), {
     timeoutMs: KUBECTL_TIMEOUT_MS,
   }).catch((err: unknown) => {
     throw new ClusterStateWriteError(
@@ -513,10 +515,17 @@ async function readClusterStateForWrite(
   };
 }
 
-async function currentResourceVersion(releaseName: string): Promise<string | null> {
-  const result = await execCapture("kubectl", STATE_GET_ARGS(configMapName(releaseName)), {
-    timeoutMs: KUBECTL_TIMEOUT_MS,
-  });
+async function currentResourceVersion(
+  releaseName: string,
+  namespace: string,
+): Promise<string | null> {
+  const result = await execCapture(
+    "kubectl",
+    STATE_GET_ARGS(configMapName(releaseName), namespace),
+    {
+      timeoutMs: KUBECTL_TIMEOUT_MS,
+    },
+  );
   if (result.exitCode !== 0) return null;
   return parseStateConfigMap(configMapName(releaseName), result.stdout).resourceVersion;
 }
@@ -525,6 +534,7 @@ async function writeClusterState(
   releaseName: string,
   state: AdapterState,
   resourceVersion: string | null,
+  namespace: string,
 ): Promise<void> {
   const cmName = configMapName(releaseName);
   // JSON, not hand-built YAML: the old writer embedded the state in a single-quoted YAML
@@ -551,8 +561,8 @@ async function writeClusterState(
   // replace (update, precondition) when it exists; create (fails AlreadyExists if a
   // racing writer got there first) when it does not.
   const args = resourceVersion
-    ? ["replace", "-n", STATE_NAMESPACE, "-f", "-"]
-    : ["create", "-n", STATE_NAMESPACE, "-f", "-"];
+    ? ["replace", "-n", namespace, "-f", "-"]
+    : ["create", "-n", namespace, "-f", "-"];
 
   // N22: via execCaptureStdin — the stdin 'error' handler, timeout, and Windows shim
   // handling all live in exec.ts. The payload never goes on argv (size + secrets rule).
@@ -570,7 +580,7 @@ async function writeClusterState(
   // N23: classify the failure on the machine-readable signal — did the object move? —
   // never on stderr text. A moved (or newly created) resourceVersion means a concurrent
   // deploy/rollback committed state while we were writing.
-  const observed = await currentResourceVersion(releaseName).catch(() => null);
+  const observed = await currentResourceVersion(releaseName, namespace).catch(() => null);
   const concurrent = observed !== null && observed !== resourceVersion;
   const detail = result.stderr.trim() || `kubectl ${args[0]} exited ${result.exitCode}`;
   throw new ClusterStateWriteError(

--- a/src/cli/tail.ts
+++ b/src/cli/tail.ts
@@ -1,7 +1,6 @@
 // src/cli/tail.ts
 import { spawn, type ChildProcess } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
-import path from "node:path";
 import { execCapture } from "./exec.js";
 import { sanitizeForTerminal } from "./terminal.js";
 import { assertSafeInfrastructure, infrastructurePath } from "./infrastructure-validation.js";

--- a/src/cli/tail.ts
+++ b/src/cli/tail.ts
@@ -4,6 +4,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { execCapture } from "./exec.js";
 import { sanitizeForTerminal } from "./terminal.js";
 import { assertSafeInfrastructure, infrastructurePath } from "./infrastructure-validation.js";
+import { resolveK8sNamespace } from "../emit/templates/utils.js";
 
 const COLORS = [
   "\x1b[36m", // cyan
@@ -23,18 +24,21 @@ const RED = "\x1b[31m";
 
 export async function runTail(options: { projectDir: string; releaseName: string }): Promise<void> {
   const { projectDir, releaseName } = options;
+  let namespace = resolveK8sNamespace();
 
   // Connect to the right cluster
   const infraPath = infrastructurePath(projectDir);
   if (existsSync(infraPath)) {
-    let infra: { projectId?: string; region?: string };
+    let infra: { projectId?: string; region?: string; namespace?: string };
     try {
       infra = JSON.parse(readFileSync(infraPath, "utf-8"));
       // S13: validate before these reach a gcloud/kubectl argv.
       assertSafeInfrastructure(infra);
+      namespace = resolveK8sNamespace(infra.namespace);
     } catch (err) {
-      // Name the file — a bare SyntaxError gives no clue WHICH file is corrupt.
-      throw new Error(`Failed to parse ${infraPath}: ${(err as Error).message}`);
+      // Name the file — this covers both malformed JSON and a parsed value that fails
+      // infrastructure validation (for example, an invalid namespace).
+      throw new Error(`Invalid ${infraPath}: ${(err as Error).message}`);
     }
     if (infra.projectId && infra.region) {
       const credResult = await execCapture("gcloud", [
@@ -77,7 +81,7 @@ export async function runTail(options: { projectDir: string; releaseName: string
     const shortId = podName.split("-").pop()!.slice(0, 5);
     const badge = `${component}/${shortId}`;
 
-    const child = spawn("kubectl", ["logs", "-f", "--tail=10", podName], {
+    const child = spawn("kubectl", ["logs", "-f", "--tail=10", "-n", namespace, podName], {
       stdio: ["ignore", "pipe", "pipe"],
     });
 
@@ -121,6 +125,8 @@ export async function runTail(options: { projectDir: string; releaseName: string
     const podsResult = await execCapture("kubectl", [
       "get",
       "pods",
+      "-n",
+      namespace,
       "-l",
       `app.kubernetes.io/name=${releaseName}`,
       "-o",

--- a/src/emit/dockerfiles.ts
+++ b/src/emit/dockerfiles.ts
@@ -75,7 +75,7 @@ RUN npm install --no-save --no-audit --no-fund sharp@${installSharpVersion} \\
 }
 
 export function generateDockerfile({
-  containerStrategy,
+  containerStrategy: _containerStrategy,
   nodeVersion = DEFAULT_EMITTED_NODE_VERSION,
   buildId,
   installSharpVersion,

--- a/src/emit/dockerfiles.ts
+++ b/src/emit/dockerfiles.ts
@@ -65,11 +65,15 @@ function assertSafeSharpVersion(version: string): void {
 }
 
 // The in-image sharp install, shared by both emitted app Dockerfiles.
+// Keep it outside /app: npm would otherwise prune traced packages that are deliberately
+// absent from the minimal staged package.json before the container ever starts.
 function sharpInstallStep(installSharpVersion: string): string {
   assertSafeSharpVersion(installSharpVersion);
   return `# Build host had no linux-x64 sharp binding to stage — install it in-image so
 # /_next/image works (pool-server.cjs requires @img/sharp-linux-x64 at runtime).
-RUN npm install --no-save --no-audit --no-fund sharp@${installSharpVersion} \\
+RUN npm install --prefix /tmp/adapter-k8s-sharp --no-save --no-audit --no-fund sharp@${installSharpVersion} \\
+ && cp -R /tmp/adapter-k8s-sharp/node_modules/. /app/node_modules/ \\
+ && rm -rf /tmp/adapter-k8s-sharp \\
  && npm cache clean --force
 `;
 }

--- a/src/emit/helm.ts
+++ b/src/emit/helm.ts
@@ -12,14 +12,10 @@ import {
   renderRoutingManifestConfigMap,
   renderRoutingManifestSnapshotConfigMap,
 } from "./templates/routing-manifest-configmap.js";
-import { sanitizeK8sName } from "./templates/utils.js";
 import { renderRoutingServiceDeployment } from "./templates/routing-service-deployment.js";
 import { renderRoutingServiceService } from "./templates/routing-service-service.js";
 import { renderRoutingServiceHPA } from "./templates/routing-service-hpa.js";
-import {
-  renderRouteExtConfigMap,
-  routeExtDocumentDigest,
-} from "./templates/route-ext-configmap.js";
+import { routeExtDocumentDigest } from "./templates/route-ext-configmap.js";
 import { renderNetworkPolicies } from "./templates/network-policy.js";
 import { resolveProvider } from "../providers/index.js";
 
@@ -234,7 +230,7 @@ export function generateHelmChart({
     // shared sources — both match Kubernetes' own "last one wins" semantics, so a pool
     // override behaves the way someone reading the rendered pod spec would predict.
     const poolConfig = config.pools?.[poolName];
-    const mergedEnv = { ...(config.env ?? {}), ...(poolConfig?.env ?? {}) };
+    const mergedEnv = { ...config.env, ...poolConfig?.env };
     const mergedEnvFrom = [...(config.envFrom ?? []), ...(poolConfig?.envFrom ?? [])];
     files[`templates/${poolName}-deployment.yaml`] = renderDeployment({
       poolName,

--- a/src/emit/metadata.ts
+++ b/src/emit/metadata.ts
@@ -20,6 +20,7 @@ export function generateBuildMetadata({
   poolNames,
   generatedAt,
   provider,
+  namespace,
   containerRegistry,
   nodeCidrs,
   containerStrategy,
@@ -72,6 +73,8 @@ export function generateBuildMetadata({
    * discover NetworkPolicy ranges through gcloud.
    */
   provider: string;
+  /** Namespace qualified into the ext_proc authority at build time. */
+  namespace: string;
   /**
    * Registry the emitted chart's image references were built against. The routing tier's image
    * is baked into its Deployment template at BUILD time, so a chart is only valid for the
@@ -86,6 +89,7 @@ export function generateBuildMetadata({
       buildId,
       nextVersion,
       provider,
+      namespace,
       ...(containerRegistry ? { containerRegistry } : {}),
       ...(nodeCidrs && nodeCidrs.length > 0 ? { nodeCidrs } : {}),
       pools: poolNames,

--- a/src/emit/templates/generic-gateway.ts
+++ b/src/emit/templates/generic-gateway.ts
@@ -71,8 +71,10 @@ export function renderGenericGateway({
   // listener (a listener carries at most one hostname) and therefore cannot share a merged
   // data plane — acceptable: lanes are single-host by construction.
   const singleHostname =
-    hosts.length === 1 ? `
-      hostname: "${hosts[0]!.hostname}"` : "";
+    hosts.length === 1
+      ? `
+      hostname: "${hosts[0]!.hostname}"`
+      : "";
   let listeners = `    - name: http${singleHostname}
       protocol: HTTP
       port: 80

--- a/src/emit/templates/route-ext-update-job.ts
+++ b/src/emit/templates/route-ext-update-job.ts
@@ -4,7 +4,6 @@ import {
   assertSafeProjectId,
   assertSafeRegion,
   assertSafeBuildId,
-  K8S_NAMESPACE,
 } from "./utils.js";
 
 // Single source of truth for the traffic-ext registration Job name. deploy.ts's
@@ -178,10 +177,10 @@ spec:
               # A rewritten \`service\`/\`authority\` would point this LB's callout at a
               # DIFFERENT backend — i.e. insert a middleware tier that sees and rewrites
               # every request. Both values are fully determined by the release name,
-              # project, and the single supported namespace, so verify them against the
+              # project, and the Helm release namespace, so verify them against the
               # values this Job was RENDERED with instead of trusting the mount. (The
               # residual IAM exposure — the binding is project-wide, so any principal who
-              # can create a pod in "${K8S_NAMESPACE}" can set
+              # can create a pod in this release namespace can set
               # serviceAccountName: ${releaseName}-deploy-sa and inherit it — needs a
               # resource condition on the binding in cli/init.ts; that is tracked
               # separately.)
@@ -216,7 +215,7 @@ spec:
                 echo "route-extension.yaml matches the rendered chart (sha256) ✓"
               fi
               EXPECT_SERVICE="projects/${projectId}/global/backendServices/${releaseName}-routing-service"
-              EXPECT_AUTHORITY="${releaseName}-routing-service.${K8S_NAMESPACE}.svc.cluster.local"
+              EXPECT_AUTHORITY="${releaseName}-routing-service.{{ .Release.Namespace }}.svc.cluster.local"
               GOT_SERVICE=$(sed -n 's/^ *service: *"\\(.*\\)" *$/\\1/p' /tmp/ext.yaml)
               GOT_AUTHORITY=$(sed -n 's/^ *authority: *"\\(.*\\)" *$/\\1/p' /tmp/ext.yaml)
               if [ "$GOT_SERVICE" != "$EXPECT_SERVICE" ]; then

--- a/src/emit/templates/routing-manifest-configmap.ts
+++ b/src/emit/templates/routing-manifest-configmap.ts
@@ -1,5 +1,8 @@
 // src/emit/templates/routing-manifest-configmap.ts
-import { sanitizeK8sName, routingManifestSnapshotName as routingManifestSnapshotNameLocal } from "./utils.js";
+import {
+  sanitizeK8sName,
+  routingManifestSnapshotName as routingManifestSnapshotNameLocal,
+} from "./utils.js";
 import { renderConfigMap } from "./configmap.js";
 
 /**

--- a/src/emit/templates/utils.ts
+++ b/src/emit/templates/utils.ts
@@ -1,16 +1,15 @@
 // src/emit/templates/utils.ts
 import { createHash } from "node:crypto";
 
-/**
- * The ONLY namespace this adapter deploys to. init binds Workload Identity to
- * `default/<release>-deploy-sa`, and every kubectl/helm call in the CLI pins this
- * literal instead of trusting the operator's current context. Build time
- * (adapter.ts) and deploy time (deploy.ts) both REJECT an infrastructure.json
- * `namespace` other than this: honoring it only in the ext_proc extension-chain
- * authority (extension-chain.ts) while workloads land in "default" skewed the
- * GXLB callout target and failed every edge callout.
- */
+/** Default release namespace when infrastructure.json does not declare one. */
 export const K8S_NAMESPACE = "default";
+
+/** Resolve and validate the release namespace at each cluster/YAML consumption boundary. */
+export function resolveK8sNamespace(namespace?: unknown): string {
+  const resolved = namespace ?? K8S_NAMESPACE;
+  assertSafeNamespace(resolved);
+  return resolved;
+}
 
 export function sanitizeK8sName(name: string, suffix = ""): string {
   // Lowercase, replace non-alphanumeric with hyphens
@@ -233,7 +232,7 @@ const IMAGE_REGISTRY_RE =
 // Next.js build ids (default or from `generateBuildId()` — commonly a git ref in CI).
 // Excludes helm `--set` metacharacters (`,` `\`) and YAML/template breakouts (`"` `'` `{`).
 const BUILD_ID_RE = /^[A-Za-z0-9._-]{1,128}$/;
-const NAMESPACE_RE = /^[a-z0-9-]{1,63}$/;
+const NAMESPACE_RE = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
 // GCS bucket naming rules (https://cloud.google.com/storage/docs/buckets#naming).
 const BUCKET_RE = /^[a-z0-9][a-z0-9._-]{1,61}[a-z0-9]$/;
 
@@ -301,11 +300,12 @@ export function assertSafeBuildId(buildId: string): void {
   }
 }
 
-export function assertSafeNamespace(namespace: string): void {
-  if (!NAMESPACE_RE.test(namespace)) {
+export function assertSafeNamespace(namespace: unknown): asserts namespace is string {
+  if (typeof namespace !== "string" || !NAMESPACE_RE.test(namespace)) {
     throw new Error(
-      `Invalid namespace "${namespace}": must match ${NAMESPACE_RE} ` +
-        `(lowercase letters, digits, and hyphens only, max 63 chars).`,
+      `Invalid namespace ${JSON.stringify(namespace)}: must be a DNS-1123 label ` +
+        `(lowercase letters, digits, and hyphens only, max 63 chars, and must start ` +
+        `and end with a letter or digit).`,
     );
   }
 }

--- a/src/pool-server/cache-policy.ts
+++ b/src/pool-server/cache-policy.ts
@@ -75,6 +75,8 @@ export function createPprRouteMatcher(
       pathnameOrOutputId,
       ...rscParentCandidates(pathnameOrOutputId, rscConfig),
     ]);
+    // Snapshot the initial seeds: the loop adds derived forms that must not recursively expand.
+    // oxlint-disable-next-line unicorn/no-useless-spread
     for (const seed of [...seeds]) {
       const withoutBase = stripBasePath(seed, basePath);
       seeds.add(withoutBase);

--- a/src/pool-server/dispatch.ts
+++ b/src/pool-server/dispatch.ts
@@ -312,7 +312,7 @@ function deleteHeaderCaseInsensitive(
 function sanitizeStoredEntryHeaders(
   headers: Record<string, string> | undefined,
 ): Record<string, string> {
-  const out: Record<string, string> = { ...(headers ?? {}) };
+  const out: Record<string, string> = { ...headers };
   deleteHeaderCaseInsensitive(out, "x-next-cache-tags");
   return out;
 }
@@ -536,7 +536,7 @@ function captureResponseForStore(res: ServerResponse, maxBytes: number) {
       | undefined {
       if (over) return undefined;
       const merged: Record<string, string | string[]> = {
-        ...((res.getHeaders?.() as Record<string, string | string[]>) ?? {}),
+        ...(res.getHeaders?.() as Record<string, string | string[]> | undefined),
         ...headHeaders,
       };
       // The stored copy replays under its own verdict; drop the first serve's.
@@ -881,6 +881,9 @@ async function invokeLocalHandlerOverHttp({
       // has already been streamed to the client; this only keeps the invocation/server lifecycle
       // alive until Next's cache writes, revalidations, and after() work have completed.
       while (pendingWaitUntil.size > 0) {
+        // Snapshot the Set: callbacks may delete themselves and enqueue more work while this
+        // batch settles; the outer loop deliberately picks up the next fixed-point batch.
+        // oxlint-disable-next-line unicorn/no-useless-spread
         await Promise.all([...pendingWaitUntil]);
       }
     };
@@ -1240,6 +1243,9 @@ export function extractRouteParams(
     const name = match[1] ?? match[2];
     if (!name) continue;
     const value = routeMatches?.[name] ?? routeMatches?.[`nxtP${name}`];
+    // RegExp.test intentionally preserves the legacy coercion behaviour for a malformed
+    // secret-gated route-matches value; startsWith would throw before the existing shape path.
+    // oxlint-disable-next-line unicorn/prefer-string-starts-ends-with
     if (value === undefined || /^\$nxtP/.test(value)) continue;
     if (match[1]) {
       const segments = value.split("/");

--- a/src/pool-server/dispatch.ts
+++ b/src/pool-server/dispatch.ts
@@ -2357,7 +2357,9 @@ export function createDispatcher(options: DispatcherOptions) {
             "http://localhost",
           ).pathname;
           const storedKey = storedConcrete === "/" ? "/index" : storedConcrete;
-          const stored = await platformCache.readStored(storedKey, { kind: "APP_PAGE" }).catch(() => null);
+          const stored = await platformCache
+            .readStored(storedKey, { kind: "APP_PAGE" })
+            .catch(() => null);
           const sv = stored?.value as
             | { kind?: string; html?: unknown; headers?: Record<string, string>; status?: number }
             | undefined;
@@ -2749,7 +2751,7 @@ export function createDispatcher(options: DispatcherOptions) {
             res,
             bufferedBody,
             basePath,
-              notFoundIsPrerendered,
+            notFoundIsPrerendered,
           );
           return;
         }
@@ -2808,7 +2810,7 @@ export function createDispatcher(options: DispatcherOptions) {
                 res,
                 undefined,
                 basePath,
-              notFoundIsPrerendered,
+                notFoundIsPrerendered,
               );
               return;
             }
@@ -3383,7 +3385,10 @@ export function createDispatcher(options: DispatcherOptions) {
             // A STORED entry's postponed token injects even when the SEED is stale — the
             // stored entry passed the handler's own tag check. The disk-shell path keeps
             // the shellUsable gate.
-            if (!isDynamicRsc && (entryPostponed !== undefined || (shellUsable && shellAvailable))) {
+            if (
+              !isDynamicRsc &&
+              (entryPostponed !== undefined || (shellUsable && shellAvailable))
+            ) {
               const meta = ((req as any)[NEXT_REQUEST_META] as Record<string, unknown>) ?? {};
               // The materialized entry's token wins over the build token — it carries the
               // regenerated Resume Data Cache.
@@ -3573,19 +3578,19 @@ export function createDispatcher(options: DispatcherOptions) {
               // (no Suspense boundary above the params access) is rendered dynamically by
               // upstream, and running it non-minimal made Next resume a fallback shell upstream
               // deliberately skips (app-dir/fallback-shells).
+              // Shell-bearing templates (handlerPprInfo) go non-minimal ONLY in emulate
+              // mode, where the entrypoint's own filesystem cache holds the build shells
+              // and Next resumes internally. Under a SHARED cache the entrypoints are
+              // per-request render modules with no route-shell orchestration (measured:
+              // k3d sub-shell-generation served "(runtime)" layouts), so those routes now
+              // take the same minimal+inject path as the no-classic-handler case below.
+              // Shell-LESS root-param templates still need non-minimal in both modes (N16).
+              // A VERIFIED preview / on-demand-revalidate request always runs NON-minimal:
+              // next start serves these through the full server, so getStaticProps sees
+              // revalidateReason 'on-demand' and the fresh entry persists through the
+              // registered cache handler. The minimal rungs exist for platform-cache
+              // emulation, which must never intercept an authenticated revalidation.
               (
-                // Shell-bearing templates (handlerPprInfo) go non-minimal ONLY in emulate
-                // mode, where the entrypoint's own filesystem cache holds the build shells
-                // and Next resumes internally. Under a SHARED cache the entrypoints are
-                // per-request render modules with no route-shell orchestration (measured:
-                // k3d sub-shell-generation served "(runtime)" layouts), so those routes now
-                // take the same minimal+inject path as the no-classic-handler case below.
-                // Shell-LESS root-param templates still need non-minimal in both modes (N16).
-                // A VERIFIED preview / on-demand-revalidate request always runs NON-minimal:
-                // next start serves these through the full server, so getStaticProps sees
-                // revalidateReason 'on-demand' and the fresh entry persists through the
-                // registered cache handler. The minimal rungs exist for platform-cache
-                // emulation, which must never intercept an authenticated revalidation.
                 isVerifiedPreviewRequest(req) ||
                 ((entrypointOwnsPprShell ||
                   // partialPrefetching builds get NO injection (the partialFallback serving

--- a/src/pool-server/index.ts
+++ b/src/pool-server/index.ts
@@ -21,7 +21,6 @@ import {
   templateOutputCandidates,
   trailingSlashVariants,
   type MiddlewareMatcher,
-  type RscConfig,
 } from "../routing-common.js";
 import { createHandlerLoader } from "./handler-loader.js";
 import { collectPublicPathnames } from "./public-files.js";
@@ -2750,7 +2749,7 @@ export async function startPoolServer(): Promise<ReturnType<typeof createPoolSer
           "content-type": getContentType(staticPathname),
           "cache-control": cacheControl,
           etag,
-          ...(headers ?? {}),
+          ...headers,
         };
         if (ifNoneMatchMatches(req.headers["if-none-match"], etag)) {
           res.writeHead(304, responseHeaders);

--- a/src/pool-server/valkey-cache/build-seed-index.ts
+++ b/src/pool-server/valkey-cache/build-seed-index.ts
@@ -22,8 +22,6 @@
 // (same rule as the Valkey client; see cache-handler-entry.ts).
 import type { SeedEntry } from "./incremental-cache-handler.js";
 
-declare const require: (id: string) => any;
-
 interface StaticAssetRecord {
   pathname: string;
   filePath: string;
@@ -177,7 +175,7 @@ function fetchCacheSeed(appRoot: string, cacheKey: string): SeedEntry | null {
  * `<key>.segments/`. Returns null (miss) when the html is absent or the entry would be
  * half-usable.
  */
-function fsMirrorSeed(appRoot: string, cacheKey: string, ctx?: SeedLookupCtx): SeedEntry | null {
+function fsMirrorSeed(appRoot: string, cacheKey: string, _ctx?: SeedLookupCtx): SeedEntry | null {
   const fs = builtin<typeof import("node:fs")>("node:fs");
   const path = builtin<typeof import("node:path")>("node:path");
   const base = path.join(appRoot, ".next", "server", "app", ...cacheKey.split("/").filter(Boolean));

--- a/src/pool-server/valkey-cache/build-seed-index.ts
+++ b/src/pool-server/valkey-cache/build-seed-index.ts
@@ -104,9 +104,8 @@ export function buildSeedSources(assets: StaticAssetRecord[]): Map<string, SeedS
 // bundled into next.config.cacheHandler which the edge middleware graph pulls in. The seed
 // lookup only ever RUNS in the Node pool; in the edge bundle this is dead code that parses.
 function builtin<T>(id: string): T {
-  const getBuiltin = (
-    globalThis as { process?: { getBuiltinModule?: (id: string) => unknown } }
-  ).process?.getBuiltinModule;
+  const getBuiltin = (globalThis as { process?: { getBuiltinModule?: (id: string) => unknown } })
+    .process?.getBuiltinModule;
   if (!getBuiltin) {
     throw new Error(`[valkey-cache] process.getBuiltinModule unavailable loading ${id}`);
   }
@@ -179,7 +178,8 @@ function fsMirrorSeed(appRoot: string, cacheKey: string, _ctx?: SeedLookupCtx): 
   const fs = builtin<typeof import("node:fs")>("node:fs");
   const path = builtin<typeof import("node:path")>("node:path");
   const base = path.join(appRoot, ".next", "server", "app", ...cacheKey.split("/").filter(Boolean));
-  const htmlAbs = cacheKey === "/" ? path.join(appRoot, ".next", "server", "app", "index.html") : `${base}.html`;
+  const htmlAbs =
+    cacheKey === "/" ? path.join(appRoot, ".next", "server", "app", "index.html") : `${base}.html`;
   if (!fs.existsSync(htmlAbs)) return null;
   const stat = fs.statSync(htmlAbs);
   const html = fs.readFileSync(htmlAbs, "utf8");

--- a/src/pool-server/valkey-cache/incremental-cache-handler.ts
+++ b/src/pool-server/valkey-cache/incremental-cache-handler.ts
@@ -496,7 +496,9 @@ export class ValkeyIncrementalCacheHandler {
       const seed = await this.seedLookup(cacheKey, {
         ...(ctx.kind !== undefined ? { kind: ctx.kind } : {}),
         ...(ctx.isFallback !== undefined ? { isFallback: ctx.isFallback } : {}),
-        ...(ctx.isRoutePPREnabled !== undefined ? { isRoutePPREnabled: ctx.isRoutePPREnabled } : {}),
+        ...(ctx.isRoutePPREnabled !== undefined
+          ? { isRoutePPREnabled: ctx.isRoutePPREnabled }
+          : {}),
       });
       if (!seed) return null;
       const softTags = ctx.softTags ?? ctx.tags ?? [];

--- a/src/providers/generic.ts
+++ b/src/providers/generic.ts
@@ -156,8 +156,7 @@ export const genericProvider: ProviderAdapter = {
           namespace: generic?.gatewayNamespace ?? "envoy-gateway-system",
           labels: {
             "app.kubernetes.io/name": "envoy",
-            "gateway.envoyproxy.io/owning-gatewayclass":
-              generic?.gateway?.className ?? "eg",
+            "gateway.envoyproxy.io/owning-gatewayclass": generic?.gateway?.className ?? "eg",
           },
         },
       ],

--- a/src/routing-common.ts
+++ b/src/routing-common.ts
@@ -804,6 +804,8 @@ export function prepareRequest(
   // NextResponse.next()'s x-middleware-override-headers and materialized as a cookie the
   // client never set (app-middleware-proxy). The pool's server.ts does the same strip for
   // Phase 1; doing it here too is idempotent. The public prefetch hint is protocol, kept.
+  // Snapshot before deleting so iteration never depends on Map mutation semantics.
+  // oxlint-disable-next-line unicorn/no-useless-spread
   for (const name of [...headers.keys()]) {
     if (name.startsWith("x-middleware-") && name !== "x-middleware-prefetch") {
       headers.delete(name);
@@ -1241,6 +1243,7 @@ export function filterInternalQuery(
   for (const [k, v] of Object.entries(query)) {
     if (k.startsWith("nxtP") || k === "_rsc") continue;
     const values = Array.isArray(v) ? v : [v];
+    // oxlint-disable-next-line unicorn/prefer-string-starts-ends-with
     if (values.some((value) => /^\$nxtP/.test(value))) continue;
     out[k] = v;
   }
@@ -1273,7 +1276,11 @@ export function sanitizeRouteMatches(
   matches: Record<string, string> | null | undefined,
 ): Record<string, string> | null {
   if (!matches) return null;
-  const unresolvedValues = new Set(Object.values(matches).filter((value) => /^\$nxtP/.test(value)));
+  const unresolvedValues = new Set(
+    // RegExp.test retains the previous coercion behaviour at this trust boundary.
+    // oxlint-disable-next-line unicorn/prefer-string-starts-ends-with
+    Object.values(matches).filter((value) => /^\$nxtP/.test(value)),
+  );
   if (unresolvedValues.size === 0) return matches;
   const sanitized = Object.fromEntries(
     Object.entries(matches).filter(([, value]) => !unresolvedValues.has(value)),

--- a/test/deploy-tests-manifest.adapter-k8s.json
+++ b/test/deploy-tests-manifest.adapter-k8s.json
@@ -22,16 +22,12 @@
         "Deploy and build both succeed here — only the assertion diverges — so this is a",
         "case-level exclusion rather than a file exclusion."
       ],
-      "failed": [
-        "expire-time should do a blocking revalidation when the cache entry has expired"
-      ]
+      "failed": ["expire-time should do a blocking revalidation when the cache entry has expired"]
     }
   },
   "rules": {
     "include": [],
-    "exclude": [
-      "test/e2e/app-dir/next-dist-client-esm-import/next-dist-client-esm-import.test.ts"
-    ]
+    "exclude": ["test/e2e/app-dir/next-dist-client-esm-import/next-dist-client-esm-import.test.ts"]
   },
   "_excludeReasons": {
     "test/e2e/app-dir/next-dist-client-esm-import/next-dist-client-esm-import.test.ts": [

--- a/tests/adapter-config-variant.test.ts
+++ b/tests/adapter-config-variant.test.ts
@@ -9,6 +9,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import {
   infrastructurePath,
+  infrastructureWritePath,
   outputDirName,
   stateFileName,
 } from "../src/cli/infrastructure-validation.js";
@@ -54,6 +55,14 @@ describe("infrastructurePath — config variants", () => {
     const dir = project({ ".k8s-adapter/infrastructure.json": "{}" });
     process.env.ADAPTER_K8S_CONFIG = "nosuch";
     expect(() => infrastructurePath(dir)).toThrow(/nosuch/);
+  });
+
+  it("lets init select the missing variant path without falling back", () => {
+    const dir = project({ ".k8s-adapter/infrastructure.json": "{}" });
+    process.env.ADAPTER_K8S_CONFIG = "scaleway";
+    expect(infrastructureWritePath(dir)).toBe(
+      path.join(dir, ".k8s-adapter", "infrastructure.scaleway.json"),
+    );
   });
 
   it("rejects a variant that is a PATH rather than a name", () => {

--- a/tests/adapter-config.test.ts
+++ b/tests/adapter-config.test.ts
@@ -380,17 +380,26 @@ describe("onBuildComplete build-time guards", () => {
     await expect(adapter.onBuildComplete!(ctx("b12345"))).resolves.toBeUndefined();
   });
 
-  it("rejects a non-default namespace from infrastructure.json (fail-fast, actionable)", async () => {
-    // The namespace feeds ONLY the ext_proc extension-chain authority; every
-    // kubectl/helm call pins the literal "default" (init binds Workload Identity
-    // there). Honoring "prod" here shipped workloads to default while the GXLB
-    // callout targeted prod — every edge callout failed. The build must refuse.
+  it("records a custom namespace in the build handoff", async () => {
     writeInfra({ namespace: "prod" });
     const adapter = createK8sAdapter(validConfig);
     await adapter.modifyConfig!({} as any, {} as any);
-    await expect(adapter.onBuildComplete!(ctx("b12345"))).rejects.toThrow(
-      /Unsupported namespace "prod".*deploys only to the "default" namespace.*Remove "namespace"/s,
-    );
+    await expect(adapter.onBuildComplete!(ctx("b12345"))).resolves.toBeUndefined();
+    expect(
+      JSON.parse(
+        readFileSync(path.join(projectDir, ".k8s-adapter/output/build-metadata.json"), "utf-8"),
+      ).namespace,
+    ).toBe("prod");
+  });
+
+  it("qualifies the GKE extension-chain authority with the custom namespace", async () => {
+    writeInfra({ namespace: "prod", projectId: "my-project-1", region: "us-central1" });
+    const adapter = createK8sAdapter(validConfig);
+    await adapter.modifyConfig!({} as any, {} as any);
+    await expect(adapter.onBuildComplete!(ctx("b12345"))).resolves.toBeUndefined();
+    expect(
+      readFileSync(path.join(projectDir, ".k8s-adapter/output/extension-chains.json"), "utf-8"),
+    ).toContain("-routing-service.prod.svc.cluster.local");
   });
 
   it('accepts an explicit namespace of "default" (and none at all)', async () => {

--- a/tests/adapter-config.test.ts
+++ b/tests/adapter-config.test.ts
@@ -227,6 +227,7 @@ describe("onBuildComplete build-time guards", () => {
 
   beforeEach(() => {
     projectDir = mkdtempSync(path.join(os.tmpdir(), "adapter-build-"));
+    vi.spyOn(process, "cwd").mockReturnValue(projectDir);
     savedSkip = process.env.ADAPTER_K8S_SKIP_STAGING;
     process.env.ADAPTER_K8S_SKIP_STAGING = "1";
   });
@@ -234,6 +235,7 @@ describe("onBuildComplete build-time guards", () => {
   afterEach(() => {
     if (savedSkip === undefined) delete process.env.ADAPTER_K8S_SKIP_STAGING;
     else process.env.ADAPTER_K8S_SKIP_STAGING = savedSkip;
+    vi.restoreAllMocks();
     rmSync(projectDir, { recursive: true, force: true });
   });
 
@@ -296,21 +298,21 @@ describe("onBuildComplete build-time guards", () => {
   });
 
   it("fails when release+pool truncation collapses distinct build ids (composed-name guard)", async () => {
-    // 20-char release + 38-char pool = a 60-char `release-pool-` prefix: only 3
-    // build-id chars survive the 63-char truncation, so "abc12345xyz" and
-    // "abc99999xyz" produce IDENTICAL composed resource names even though
+    // 20-char release + 29-char pool = a 51-char `release-pool-` prefix: exactly 8
+    // build-id chars survive the 59-char HPA-name budget, so "abcdefgh123" and
+    // "abcdefgh999" produce IDENTICAL composed resource names even though
     // sanitizeK8sName(buildId) alone (the old guard's comparison) differs.
     writeInfra({ releaseName: "r".repeat(20) });
     writeFileSync(
       path.join(projectDir, ".k8s-adapter", "state.json"),
-      JSON.stringify({ buildId: "abc12345xyz", previousBuildId: null }),
+      JSON.stringify({ buildId: "abcdefgh123", previousBuildId: null }),
     );
     const adapter = createK8sAdapter({
       ...validConfig,
-      pools: { ["p".repeat(38)]: { routes: ["appPages"] } },
+      pools: { ["p".repeat(29)]: { routes: ["appPages"] } },
     });
     await adapter.modifyConfig!({} as any, {} as any);
-    await expect(adapter.onBuildComplete!(ctx("abc99999xyz"))).rejects.toThrow(
+    await expect(adapter.onBuildComplete!(ctx("abcdefgh999"))).rejects.toThrow(
       /sanitizes to the same K8s name as the previous build/,
     );
   });

--- a/tests/adapter-externals-deps.test.ts
+++ b/tests/adapter-externals-deps.test.ts
@@ -79,6 +79,35 @@ describe("stageExternalsDependencies", () => {
     expect(staged("node_modules/left-pad/package.json")).toBe(true);
   });
 
+  it("stages dependencies whose exports hide package.json", async () => {
+    const externals = path.join(projectDir, ".next", "node_modules");
+    writePkg(path.join(externals, "external-123"), {
+      name: "external",
+      dependencies: { locked: "1.0.0" },
+    });
+    const nm = path.join(projectDir, "node_modules");
+    writePkg(
+      path.join(nm, "locked"),
+      {
+        name: "locked",
+        exports: { ".": "./dist/index.js" },
+        dependencies: { "locked-child": "1.0.0" },
+      },
+      { "dist/index.js": "module.exports = {};" },
+    );
+    writePkg(
+      path.join(nm, "locked-child"),
+      { name: "locked-child", exports: { ".": "./index.js" } },
+      { "index.js": "module.exports = {};" },
+    );
+
+    const result = await stageExternalsDependencies(projectDir, externals, "ssr", false);
+
+    expect(result.unresolved).toEqual([]);
+    expect(staged("node_modules/locked/package.json")).toBe(true);
+    expect(staged("node_modules/locked-child/package.json")).toBe(true);
+  });
+
   it("reports (not throws) an unresolvable dependency and continues", async () => {
     const externals = path.join(projectDir, ".next", "node_modules");
     writePkg(path.join(externals, "thing-123"), {

--- a/tests/adapter-next-runtime-deps.test.ts
+++ b/tests/adapter-next-runtime-deps.test.ts
@@ -81,15 +81,25 @@ describe("staging next's runtime dependency closure", () => {
     seedApp();
     const routingContext = path.join(projectDir, ".k8s-adapter", "routing-service", "context");
 
-    const result = await stageNextRuntimeDependencies(projectDir, "routing-service", false, undefined, {
-      stageDir: routingContext,
-    });
+    const result = await stageNextRuntimeDependencies(
+      projectDir,
+      "routing-service",
+      false,
+      undefined,
+      {
+        stageDir: routingContext,
+      },
+    );
 
     expect(result.staged).toContain("@swc/helpers");
     expect(
-      existsSync(path.join(routingContext, "node_modules/@swc/helpers/_/_interop_require_default.js")),
+      existsSync(
+        path.join(routingContext, "node_modules/@swc/helpers/_/_interop_require_default.js"),
+      ),
     ).toBe(true);
-    expect(existsSync(path.join(routingContext, "node_modules/styled-jsx/package.json"))).toBe(true);
+    expect(existsSync(path.join(routingContext, "node_modules/styled-jsx/package.json"))).toBe(
+      true,
+    );
   });
 
   it("stages @swc/helpers so the edge sandbox can load in the container", async () => {
@@ -126,9 +136,13 @@ describe("staging next's runtime dependency closure", () => {
       { name: "react-dom", version: "19.2.0", dependencies: { scheduler: "^0.27.0" } },
       { "client.js": "module.exports = {};" },
     );
-    writePkg(path.join(nm, "scheduler"), { name: "scheduler", version: "0.27.0" }, {
-      "index.js": "module.exports = {};",
-    });
+    writePkg(
+      path.join(nm, "scheduler"),
+      { name: "scheduler", version: "0.27.0" },
+      {
+        "index.js": "module.exports = {};",
+      },
+    );
     writePkg(path.join(nm, "react"), { name: "react", version: "19.2.0" });
 
     await stageNextRuntimeDependencies(projectDir, "ssr");

--- a/tests/adapter-next-runtime-deps.test.ts
+++ b/tests/adapter-next-runtime-deps.test.ts
@@ -163,6 +163,21 @@ describe("staging next's runtime dependency closure", () => {
     expect(staged("node_modules/@swc/helpers/package.json")).toBe(false);
   });
 
+  it("stages a Next dependency whose exports hide package.json", async () => {
+    seedApp({ "locked-runtime": "1.0.0" });
+    writePkg(
+      path.join(projectDir, "node_modules", "locked-runtime"),
+      { name: "locked-runtime", exports: { ".": "./dist/index.js" } },
+      { "dist/index.js": "module.exports = {};" },
+    );
+
+    const result = await stageNextRuntimeDependencies(projectDir, "ssr");
+
+    expect(result.staged).toContain("locked-runtime");
+    expect(result.unresolved).not.toContain("locked-runtime");
+    expect(staged("node_modules/locked-runtime/package.json")).toBe(true);
+  });
+
   it("warns and continues when a declared dependency is unresolvable", async () => {
     // A pnpm/monorepo layout can hide one. Refusing to build the image over a package the app
     // may never load would be worse than the CrashLoop it prevents.

--- a/tests/adapter-sharp-staging.test.ts
+++ b/tests/adapter-sharp-staging.test.ts
@@ -7,7 +7,15 @@
 // Additionally sharp@0.35 gained an exports map WITHOUT a "./package" subpath, which the
 // old `${dep}/package` resolution choked on.
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, readFileSync } from "node:fs";
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  rmSync,
+  existsSync,
+  readFileSync,
+  realpathSync,
+} from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { resolveSharpDepDir, stageSharpRuntimePackages } from "../src/adapter.js";
@@ -78,7 +86,7 @@ afterAll(() => {
 describe("sharp staging survives the 0.35 package shape (survey: canary.97 image cluster)", () => {
   it("resolveSharpDepDir resolves a sharp whose exports map has no ./package subpath", () => {
     const dir = resolveSharpDepDir("sharp", projectDir);
-    expect(dir).toBe(path.join(projectDir, "node_modules", "sharp"));
+    expect(dir).toBe(realpathSync(path.join(projectDir, "node_modules", "sharp")));
   });
 
   it("stages the app's sharp JS package AND its runtime dep tree alongside the @img binaries", async () => {

--- a/tests/adapter-staging.test.ts
+++ b/tests/adapter-staging.test.ts
@@ -13,6 +13,7 @@ import {
   readFileSync,
   existsSync,
   lstatSync,
+  realpathSync,
 } from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -587,7 +588,7 @@ describe("resolveSharpDepDir", () => {
         exports: { "./sharp.node": "./sharp.node", "./package": "./package.json" },
       }),
     );
-    expect(resolveSharpDepDir("@img/sharp-testonly-linux-x64", tmpDir)).toBe(dir);
+    expect(resolveSharpDepDir("@img/sharp-testonly-linux-x64", tmpDir)).toBe(realpathSync(dir));
   });
 
   it("falls back to the sibling of a resolvable sharp copy when exports block resolution entirely", () => {
@@ -609,7 +610,7 @@ describe("resolveSharpDepDir", () => {
         exports: { "./sharp.node": "./sharp.node" },
       }),
     );
-    expect(resolveSharpDepDir("@img/sharp-testonly-sibling", tmpDir)).toBe(dir);
+    expect(resolveSharpDepDir("@img/sharp-testonly-sibling", tmpDir)).toBe(realpathSync(dir));
   });
 
   it("returns undefined for an unresolvable package", () => {

--- a/tests/cel.test.ts
+++ b/tests/cel.test.ts
@@ -1,17 +1,11 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   generateCelExpression,
   extractStaticPrefix,
   escapeCelString,
   CEL_EXPRESSION_WARN_LENGTH,
 } from "../src/cel.js";
-import {
-  mockOutputs,
-  mockStaticFile,
-  mockPrerender,
-  mockAppPage,
-  mockAppRoute,
-} from "./helpers/mock-outputs.js";
+import { mockOutputs, mockStaticFile } from "./helpers/mock-outputs.js";
 
 describe("extractStaticPrefix", () => {
   it("extracts prefix from dynamic route regex", () => {
@@ -136,18 +130,6 @@ describe("generateCelExpression", () => {
 });
 
 describe("generateCelExpression with basePath", () => {
-  const mwOutputs = (staticFiles: { pathname: string }[]) =>
-    mockOutputs({
-      staticFiles: staticFiles.map((f) => mockStaticFile(f)),
-      middleware: {
-        id: "middleware",
-        filePath: "/dist/server/middleware.js",
-        pathname: "/middleware",
-        type: 8 as any,
-        config: { matchers: [] },
-      } as any,
-    });
-
   it("probes middleware coverage with the basePath-prefixed pathname", () => {
     // Next bakes the basePath into matcher sourceRegexes, so the coverage probe
     // must test the wire path — a basePath-less probe would wrongly exclude
@@ -166,4 +148,3 @@ describe("generateCelExpression with basePath", () => {
     expect(cel).not.toContain("api-docs");
   });
 });
-

--- a/tests/cli/deploy-orchestration.test.ts
+++ b/tests/cli/deploy-orchestration.test.ts
@@ -458,6 +458,7 @@ describe("runDeploy — orchestration", () => {
         basedOnGeneration: null,
       },
       RELEASE,
+      "default",
     );
     // CDN invalidated for the OUTGOING build. Prior state (legacy) recorded no tag for
     // it, so no recordedTag is passed — cdn-invalidate falls back to the full purge (M13).
@@ -681,6 +682,7 @@ describe("runDeploy — guards and teardown", () => {
         basedOnGeneration: null,
       },
       RELEASE,
+      "default",
     );
     // A loud warning named the missing deployment...
     expect(
@@ -792,21 +794,66 @@ describe("runDeploy — guards and teardown", () => {
     expect(events).not.toContain("helm");
   });
 
-  it("rejects a non-default namespace in infrastructure.json before touching anything", async () => {
-    // The chart/extension chain were built for the ext_proc authority in
-    // infra.namespace, but every kubectl/helm call pins "default" — deploying would
-    // skew the GXLB callout target away from the workloads. Fail fast instead.
-    setupFs({ infra: { ...BASE_INFRA, namespace: "prod" } });
+  it("uses a custom namespace for Helm, cluster state, and routing retention", async () => {
+    setupFs({
+      infra: { ...BASE_INFRA, namespace: "prod" },
+      metadata: { buildId: "buildn", pools: ["ssr"], cacheEnabled: false, namespace: "prod" },
+    });
     vi.mocked(execCapture).mockImplementation(happyCluster(events) as never);
+
+    await runDeploy({ projectDir: PROJECT, releaseName: RELEASE, skipBuild: true });
+
+    const helmCall = vi.mocked(execOrThrow).mock.calls.find(([cmd]) => cmd === "helm");
+    expect(helmCall?.[1].join(" ")).toContain("--namespace prod --create-namespace");
+    expect(vi.mocked(readState)).toHaveBeenCalledWith(PROJECT, RELEASE, { namespace: "prod" });
+    expect(vi.mocked(retainLiveRoutingManifest)).toHaveBeenCalledWith(RELEASE, "prod");
+    expect(vi.mocked(writeState)).toHaveBeenCalledWith(
+      PROJECT,
+      expect.objectContaining({ buildId: "buildn", previousBuildId: "buildm" }),
+      RELEASE,
+      "prod",
+    );
+  });
+
+  it("refuses build output emitted for a different namespace", async () => {
+    setupFs({
+      infra: { ...BASE_INFRA, namespace: "prod" },
+      metadata: {
+        buildId: "buildn",
+        pools: ["ssr"],
+        cacheEnabled: false,
+        namespace: "staging",
+      },
+    });
 
     await expect(
       runDeploy({ projectDir: PROJECT, releaseName: RELEASE, skipBuild: true }),
-    ).rejects.toThrow(
-      /Unsupported namespace "prod".*deploys only to the "default" namespace.*Remove "namespace"/s,
-    );
+    ).rejects.toThrow(/emitted for namespace "staging".*targets "prod"/s);
     expect(events).not.toContain("helm");
-    expect(events).not.toContain("get-credentials");
-    expect(vi.mocked(writeState)).not.toHaveBeenCalled();
+  });
+
+  it("treats legacy build output with no namespace as default", async () => {
+    setupFs({
+      infra: { ...BASE_INFRA, namespace: "prod" },
+      metadata: { buildId: "buildn", pools: ["ssr"], cacheEnabled: false },
+    });
+
+    await expect(
+      runDeploy({ projectDir: PROJECT, releaseName: RELEASE, skipBuild: true }),
+    ).rejects.toThrow(/emitted for namespace "default".*targets "prod"/s);
+    expect(events).not.toContain("helm");
+  });
+
+  it("rejects malformed namespace metadata instead of bypassing the fingerprint", async () => {
+    setupFs({
+      infra: { ...BASE_INFRA, namespace: "prod" },
+      metadata: { buildId: "buildn", pools: ["ssr"], cacheEnabled: false, namespace: 123 },
+    });
+
+    await expect(
+      runDeploy({ projectDir: PROJECT, releaseName: RELEASE, skipBuild: true }),
+    ).rejects.toThrow(/Invalid namespace/);
+    expect(events).not.toContain("helm");
   });
 
   it('accepts an explicit namespace of "default" in infrastructure.json', async () => {
@@ -831,6 +878,7 @@ describe("runDeploy — guards and teardown", () => {
         basedOnGeneration: null,
       },
       RELEASE,
+      "default",
     );
   });
 
@@ -866,6 +914,7 @@ describe("runDeploy — guards and teardown", () => {
         basedOnGeneration: null,
       },
       RELEASE,
+      "default",
     );
   });
 
@@ -1189,8 +1238,10 @@ describe("runDeploy — N25: every post-helm abort puts the ext_proc edge back",
 
     expect(vi.mocked(revertRoutingServiceToBuild)).toHaveBeenCalledWith({
       releaseName: RELEASE,
+      namespace: "default",
       targetBuildId: "buildm",
       registry: REGISTRY,
+      targetImageDigest: undefined,
     });
     expect(printedErrors()).toContain("reverted to build buildm");
     expect(vi.mocked(writeState)).not.toHaveBeenCalled();
@@ -1484,6 +1535,7 @@ describe("runDeploy — N30: routing-manifest retention failure is fatal by defa
       PROJECT,
       expect.objectContaining({ unretainedManifestBuilds: ["buildm"] }),
       RELEASE,
+      "default",
     );
     expect(printedWarnings()).toContain("revert the routing IMAGE only");
   });
@@ -1512,6 +1564,7 @@ describe("runDeploy — N30: routing-manifest retention failure is fatal by defa
         basedOnGeneration: null,
       },
       RELEASE,
+      "default",
     );
   });
 });

--- a/tests/cli/deploy-orchestration.test.ts
+++ b/tests/cli/deploy-orchestration.test.ts
@@ -89,18 +89,36 @@ function setupFs({
   infra = BASE_INFRA,
   metadata = { buildId: "buildn", pools: ["ssr"], cacheEnabled: false },
   cdn = true,
+  outputName = "output",
+  infrastructureName = "infrastructure.json",
 }: {
   infra?: InfraFixture;
   metadata?: Record<string, unknown>;
   cdn?: boolean;
+  outputName?: string;
+  infrastructureName?: string;
 } = {}) {
   fixturePools = Array.isArray(metadata.pools) ? (metadata.pools as string[]) : ["ssr"];
+  const fixtureInfraPath = path.join(PROJECT, ".k8s-adapter", infrastructureName);
+  const fixtureOutput = path.join(PROJECT, ".k8s-adapter", outputName);
+  const fixtureMetaPath = path.join(fixtureOutput, "build-metadata.json");
+  const fixtureCdnFilter = path.join(fixtureOutput, "chart", "templates", "cdn-http-filter.yaml");
+  const fixtureRouteExtJobYaml = path.join(
+    fixtureOutput,
+    "chart",
+    "templates",
+    "route-ext-update-job.yaml",
+  );
   vi.mocked(existsSync).mockImplementation(
-    (p) => p === infraPath || p === metaPath || (cdn && p === cdnFilter) || p === routeExtJobYaml,
+    (p) =>
+      p === fixtureInfraPath ||
+      p === fixtureMetaPath ||
+      (cdn && p === fixtureCdnFilter) ||
+      p === fixtureRouteExtJobYaml,
   );
   vi.mocked(readFileSync).mockImplementation((p) => {
-    if (p === infraPath) return JSON.stringify(infra);
-    if (p === metaPath) return JSON.stringify(metadata);
+    if (p === fixtureInfraPath) return JSON.stringify(infra);
+    if (p === fixtureMetaPath) return JSON.stringify(metadata);
     return "";
   });
 }
@@ -499,6 +517,31 @@ describe("runDeploy — orchestration", () => {
       projectDir: PROJECT,
       releaseName: RELEASE,
     });
+  });
+
+  it("builds every container from the selected variant output", async () => {
+    process.env.ADAPTER_K8S_CONFIG = "staging";
+    try {
+      setupFs({
+        outputName: "output.staging",
+        infrastructureName: "infrastructure.staging.json",
+      });
+      vi.mocked(execCapture).mockImplementation(happyCluster(events) as never);
+
+      await runDeploy({ projectDir: PROJECT, releaseName: RELEASE, skipBuild: true });
+
+      const dockerBuilds = vi
+        .mocked(execOrThrow)
+        .mock.calls.filter(([cmd, args]) => cmd === "docker" && args.includes("build"))
+        .map(([, args]) => args.join(" "));
+      expect(dockerBuilds).toHaveLength(2);
+      expect(dockerBuilds).toEqual([
+        expect.stringContaining(".k8s-adapter/output.staging/pools/ssr"),
+        expect.stringContaining(".k8s-adapter/output.staging/routing-service"),
+      ]);
+    } finally {
+      delete process.env.ADAPTER_K8S_CONFIG;
+    }
   });
 
   it("new build never healthy: no selector patch, no state commit, non-zero exit, previous keeps serving", async () => {

--- a/tests/cli/deploy.test.ts
+++ b/tests/cli/deploy.test.ts
@@ -94,7 +94,10 @@ describe("refreshFetchCacheStaging", () => {
     });
     expect(
       existsSync(
-        path.join(projectDir, ".k8s-adapter/output/pools/ssr/context/.k8s-adapter/fetch-cache-seed"),
+        path.join(
+          projectDir,
+          ".k8s-adapter/output/pools/ssr/context/.k8s-adapter/fetch-cache-seed",
+        ),
       ),
     ).toBe(false);
   });
@@ -113,11 +116,7 @@ describe("refreshFetchCacheStaging", () => {
           containerStrategy: "traced-assets",
         }),
       ).toThrow(/distDir/);
-      expect(
-        existsSync(
-          path.join(projectDir, ".k8s-adapter/output/pools/ssr/context"),
-        ),
-      ).toBe(true);
+      expect(existsSync(path.join(projectDir, ".k8s-adapter/output/pools/ssr/context"))).toBe(true);
     } finally {
       rmSync(victim, { recursive: true, force: true });
     }

--- a/tests/cli/deploy.test.ts
+++ b/tests/cli/deploy.test.ts
@@ -254,6 +254,19 @@ describe("buildHelmUpgradeArgs", () => {
     expect(args.join(" ")).toContain("activeBuildId=abc123");
   });
 
+  it("pins Helm to the configured namespace", () => {
+    const args = buildHelmUpgradeArgs({
+      releaseName: "my-app",
+      chartPath: ".k8s-adapter/output/chart",
+      buildId: "abc123",
+      registry: "us-central1-docker.pkg.dev/my-project/nextjs",
+      previousBuildId: null,
+      namespace: "apps",
+    });
+
+    expect(args.join(" ")).toContain("--namespace apps --create-namespace");
+  });
+
   it("sanitizes the serving build selector used during the upgrade", () => {
     const args = buildHelmUpgradeArgs({
       releaseName: "my-app",

--- a/tests/cli/describe.test.ts
+++ b/tests/cli/describe.test.ts
@@ -63,6 +63,26 @@ describe("runDescribe", () => {
     expect(depCall![1].join(" ")).toContain("-n default");
   });
 
+  it("uses the configured namespace for state and deployment reads", async () => {
+    writeFileSync(
+      path.join(tmpDir, ".k8s-adapter", "infrastructure.json"),
+      JSON.stringify({
+        projectId: "proj-12345",
+        region: "us-central1",
+        hosts: [],
+        namespace: "apps",
+      }),
+    );
+
+    await runDescribe({ projectDir: tmpDir, releaseName: RELEASE });
+
+    expect(readState).toHaveBeenCalledWith(tmpDir, RELEASE, { namespace: "apps" });
+    const depCall = vi
+      .mocked(execCapture)
+      .mock.calls.find(([cmd, args]) => cmd === "kubectl" && args.includes("deployments"));
+    expect(depCall?.[1].join(" ")).toContain("-n apps");
+  });
+
   it("classifies builds by EXACT version label, not prefix matching", async () => {
     // Two build ids sharing a 12-char normalized prefix must not both classify as
     // "current" (the prefix-substring technique caused a production 503 — see deploy.ts).

--- a/tests/cli/destroy.test.ts
+++ b/tests/cli/destroy.test.ts
@@ -219,6 +219,20 @@ describe("runDestroy — confirmation gate (L12)", () => {
     expect(out).toContain(`[dry-run] gcloud iam roles delete ${deployExtRoleId("my-app")}`);
   });
 
+  it("targets the configured namespace for release-scoped Kubernetes resources", async () => {
+    writeFileSync(
+      path.join(tmpDir, ".k8s-adapter", "infrastructure.json"),
+      JSON.stringify({ ...INFRA, namespace: "apps" }),
+    );
+
+    await runDestroy({ projectDir: tmpDir, releaseName: "my-app", dryRun: true });
+
+    const out = printedOutput();
+    expect(out).toContain("helm uninstall my-app --namespace apps");
+    expect(out).toContain("kubectl delete configmap -n apps");
+    expect(out).toContain("kubectl delete secret -n apps");
+  });
+
   it("deletes BOTH service accounts for real (not only the deploy one)", async () => {
     await runDestroy({ projectDir: tmpDir, releaseName: "my-app", yes: true });
     const deleted = vi

--- a/tests/cli/doctor.test.ts
+++ b/tests/cli/doctor.test.ts
@@ -98,7 +98,7 @@ describe("runDoctor", () => {
   let tmpDir: string;
   const infraDir = () => path.join(tmpDir, ".k8s-adapter");
 
-  function writeInfra(hosts: string[] = []): void {
+  function writeInfra(hosts: string[] = [], namespace?: string): void {
     mkdirSync(infraDir(), { recursive: true });
     writeFileSync(
       path.join(infraDir(), "infrastructure.json"),
@@ -109,6 +109,7 @@ describe("runDoctor", () => {
         gcsBucket: "proj-nextjs-static",
         containerRegistry: "us-central1-docker.pkg.dev/proj/nextjs",
         releaseName: RELEASE,
+        ...(namespace ? { namespace } : {}),
       }),
     );
   }
@@ -398,5 +399,26 @@ describe("runDoctor", () => {
       expect(call, `kubectl ${resource} call`).toBeDefined();
       expect(call!.join(" "), `kubectl ${resource} pinned to -n default`).toContain("-n default");
     }
+  });
+
+  it("includes the configured namespace in kubectl remediation commands", async () => {
+    writeInfra([], "apps");
+    vi.mocked(readState).mockResolvedValue({ buildId: "buildn", previousBuildId: null } as never);
+    stubCluster({
+      deployments: "rel-ssr-buildn|0/1|buildn",
+      services: "rel-ssr|ssr",
+      endpoints: "false",
+      pods: "rel-ssr-buildn-a",
+      logs: "FATAL startup failed",
+    });
+
+    await expect(runDoctor({ projectDir: tmpDir, releaseName: RELEASE })).rejects.toThrow(
+      /process\.exit:1/,
+    );
+
+    const out = printed();
+    expect(out).toContain("kubectl describe deployment/rel-ssr-buildn -n apps");
+    expect(out).toContain("kubectl get svc rel-ssr -n apps");
+    expect(out).toContain("kubectl logs rel-ssr-buildn-a -n apps --tail=50");
   });
 });

--- a/tests/cli/init.test.ts
+++ b/tests/cli/init.test.ts
@@ -10,7 +10,7 @@ import {
 } from "../../src/cli/init.js";
 import * as exec from "../../src/cli/exec.js";
 import * as scaffold from "../../src/cli/scaffold.js";
-import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import path from "node:path";
 import os from "node:os";
 
@@ -62,6 +62,30 @@ describe("buildInitGcloudCommands", () => {
 
     const saCmd = commands.find((c) => c.description.includes("service account"));
     expect(saCmd).toBeDefined();
+  });
+
+  it("binds Workload Identity to the configured namespace", () => {
+    const commands = buildInitGcloudCommands({
+      projectId: "my-project",
+      region: "us-central1",
+      bucket: "my-project-nextjs-static",
+      releaseName: "my-app",
+      namespace: "apps",
+    });
+    const binding = commands.find((c) => c.args.includes("roles/iam.workloadIdentityUser"));
+    expect(binding?.args).toContain("serviceAccount:my-project.svc.id.goog[apps/my-app-deploy-sa]");
+  });
+
+  it("rejects an unsafe namespace before building command arguments", () => {
+    expect(() =>
+      buildInitGcloudCommands({
+        projectId: "my-project",
+        region: "us-central1",
+        bucket: "my-project-nextjs-static",
+        releaseName: "my-app",
+        namespace: 'bad";inject',
+      }),
+    ).toThrow(/Invalid namespace/);
   });
 
   it("includes routing service backend provisioning commands", () => {
@@ -269,8 +293,59 @@ describe("runInit", () => {
 
   function mockScaffold(): void {
     vi.spyOn(scaffold, "generateAdapterConfig").mockReturnValue("config");
-    vi.spyOn(scaffold, "generateInfrastructureJson").mockReturnValue("infra");
+    vi.spyOn(scaffold, "generateInfrastructureJson").mockImplementation((config) =>
+      JSON.stringify(config),
+    );
   }
+
+  it("writes the selected config variant instead of the default infrastructure file", async () => {
+    const execCapture = vi.spyOn(exec, "execCapture");
+    mockScaffold();
+    execCapture.mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+    process.env.ADAPTER_K8S_CONFIG = "staging";
+
+    try {
+      await runInit({ ...VALID, namespace: "apps", projectDir: tmpDir, iamRetryDelayMs: 0 });
+    } finally {
+      delete process.env.ADAPTER_K8S_CONFIG;
+    }
+
+    const variantPath = path.join(tmpDir, ".k8s-adapter", "infrastructure.staging.json");
+    expect(existsSync(variantPath)).toBe(true);
+    expect(existsSync(path.join(tmpDir, ".k8s-adapter", "infrastructure.json"))).toBe(false);
+    expect(JSON.parse(readFileSync(variantPath, "utf-8")).namespace).toBe("apps");
+  });
+
+  it("prints a namespace-pinned Gateway lookup after init", async () => {
+    const execCapture = vi.spyOn(exec, "execCapture");
+    mockScaffold();
+    execCapture.mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+
+    await runInit({
+      ...VALID,
+      namespace: "apps",
+      projectDir: tmpDir,
+      iamRetryDelayMs: 0,
+    });
+
+    expect(console.log).toHaveBeenCalledWith(
+      expect.stringContaining("kubectl get gateway my-app-gateway -n apps"),
+    );
+  });
+
+  it("refuses to move an existing release to another namespace", async () => {
+    mkdirSync(path.join(tmpDir, ".k8s-adapter"), { recursive: true });
+    writeFileSync(
+      path.join(tmpDir, ".k8s-adapter", "infrastructure.json"),
+      JSON.stringify({ namespace: "default" }),
+    );
+    const execCapture = vi.spyOn(exec, "execCapture");
+
+    await expect(
+      runInit({ ...VALID, namespace: "apps", projectDir: tmpDir, iamRetryDelayMs: 0 }),
+    ).rejects.toThrow(/Cannot change the namespace.*default.*apps/s);
+    expect(execCapture).not.toHaveBeenCalled();
+  });
 
   it("retries on IAM binding failure and handles already exists", async () => {
     const execCapture = vi.spyOn(exec, "execCapture");

--- a/tests/cli/parse-args.test.ts
+++ b/tests/cli/parse-args.test.ts
@@ -35,8 +35,9 @@ describe("parseArgs", () => {
   });
 
   it("supports the --flag value form", () => {
-    const { flags } = parseArgs(argv("init", "--project-id", "my-proj"));
+    const { flags } = parseArgs(argv("init", "--project-id", "my-proj", "--namespace", "apps"));
     expect(flags["project-id"]).toBe("my-proj");
+    expect(flags["namespace"]).toBe("apps");
   });
 
   it("value flags hard-error when the value is missing", () => {

--- a/tests/cli/rollback.test.ts
+++ b/tests/cli/rollback.test.ts
@@ -124,6 +124,7 @@ describe("runRollback — CDN invalidation", () => {
       // N69: rollback passes the generation it READ as writeState's floor.
       { buildId: "buildm", previousBuildId: "buildn", cdnTags, basedOnGeneration: null },
       RELEASE,
+      "default",
     );
   });
 
@@ -140,6 +141,7 @@ describe("runRollback — CDN invalidation", () => {
       PROJECT,
       { buildId: "buildm", previousBuildId: "buildn", basedOnGeneration: null },
       RELEASE,
+      "default",
     );
   });
 
@@ -163,7 +165,10 @@ describe("runRollback — CDN invalidation", () => {
     expect(vi.mocked(execCapture)).not.toHaveBeenCalled();
     expect(vi.mocked(execCaptureStdin)).not.toHaveBeenCalled();
     // State came from the LOCAL file only.
-    expect(vi.mocked(readState)).toHaveBeenCalledWith(PROJECT, RELEASE, { localOnly: true });
+    expect(vi.mocked(readState)).toHaveBeenCalledWith(PROJECT, RELEASE, {
+      localOnly: true,
+      namespace: "default",
+    });
     // No mutations of any kind.
     expect(vi.mocked(execOrThrow)).not.toHaveBeenCalled();
     expect(vi.mocked(writeState)).not.toHaveBeenCalled();
@@ -284,6 +289,7 @@ describe("runRollback — HPA names past the 59-char truncation boundary", () =>
       PROJECT,
       { buildId: PREV, previousBuildId: CURR, basedOnGeneration: null },
       LONG_RELEASE,
+      "default",
     );
   });
 });
@@ -319,7 +325,9 @@ describe("runRollback — state read ordering", () => {
     expect(vi.mocked(execCapture).mock.calls[0]![1]).toContain("get-credentials");
     expect(stateOrder).toBeGreaterThan(credOrder);
     // Non-dry-run reads may hit the cluster ConfigMap (no localOnly flag).
-    expect(vi.mocked(readState)).toHaveBeenCalledWith(PROJECT, RELEASE, undefined);
+    expect(vi.mocked(readState)).toHaveBeenCalledWith(PROJECT, RELEASE, {
+      namespace: "default",
+    });
   });
 });
 
@@ -476,6 +484,7 @@ describe("runRollback — routing service revert", () => {
       PROJECT,
       { buildId: "buildm", previousBuildId: "buildn", basedOnGeneration: null },
       RELEASE,
+      "default",
     );
   });
 

--- a/tests/cli/state.test.ts
+++ b/tests/cli/state.test.ts
@@ -30,6 +30,7 @@ describe("state", () => {
   let tmpDir: string;
 
   beforeEach(() => {
+    vi.clearAllMocks();
     tmpDir = mkdtempSync(path.join(os.tmpdir(), "adapter-k8s-test-"));
   });
 
@@ -60,6 +61,23 @@ describe("state", () => {
     // N21: every write stamps a monotonic generation + updatedAt on top of the payload.
     expect(read).toMatchObject(state);
     expect(read!.generation).toBe(1);
+  });
+
+  it("pins cluster state reads and writes to the configured namespace", async () => {
+    vi.clearAllMocks();
+    vi.mocked(execCapture).mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+    vi.mocked(execCaptureStdin).mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+
+    await readState(tmpDir, "rel", { namespace: "apps" });
+    expect(vi.mocked(execCapture).mock.calls[0]![1]).toContain("apps");
+
+    await writeState(
+      tmpDir,
+      { buildId: "b1", previousBuildId: null, basedOnGeneration: null },
+      "rel",
+      "apps",
+    );
+    expect(vi.mocked(execCaptureStdin).mock.calls[0]![1]).toContain("apps");
   });
 
   it("overwrites existing state", async () => {

--- a/tests/cli/tail.test.ts
+++ b/tests/cli/tail.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { runTail } from "../../src/cli/tail.js";
+
+describe("runTail", () => {
+  let projectDir: string | undefined;
+
+  afterEach(() => {
+    if (projectDir) rmSync(projectDir, { recursive: true, force: true });
+    projectDir = undefined;
+  });
+
+  it("reports invalid infrastructure values without mislabeling them as JSON parse failures", async () => {
+    projectDir = mkdtempSync(path.join(os.tmpdir(), "adapter-k8s-tail-test-"));
+    const adapterDir = path.join(projectDir, ".k8s-adapter");
+    mkdirSync(adapterDir);
+    const infraPath = path.join(adapterDir, "infrastructure.json");
+    writeFileSync(infraPath, JSON.stringify({ namespace: "Invalid" }));
+
+    await expect(runTail({ projectDir, releaseName: "my-app" })).rejects.toThrow(
+      new RegExp(`Invalid ${infraPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}: Invalid namespace`),
+    );
+  });
+});

--- a/tests/e2e/apphosting-standalone-baseline.test.ts
+++ b/tests/e2e/apphosting-standalone-baseline.test.ts
@@ -7,7 +7,7 @@ import { spawnSync } from "node:child_process";
 const runBaseline = process.env.RUN_APPHOSTING_BASELINE_E2E === "1";
 const describeIf = runBaseline ? describe : describe.skip;
 
-const nextVersion = process.env.APPHOSTING_BASELINE_NEXT_VERSION ?? "16.2.1";
+const nextVersion = process.env.APPHOSTING_BASELINE_NEXT_VERSION ?? "16.3.0";
 const reactVersion = process.env.APPHOSTING_BASELINE_REACT_VERSION ?? "19.2.4";
 const adapterVersion = process.env.APPHOSTING_BASELINE_ADAPTER_VERSION ?? "latest";
 

--- a/tests/e2e/live/pages.test.ts
+++ b/tests/e2e/live/pages.test.ts
@@ -3,6 +3,31 @@ import { describe, expect, it } from "vitest";
 const BASE = process.env.E2E_PAGES_BASE_URL?.replace(/\/$/, "");
 
 describe.skipIf(!BASE)("deployed Pages entrypoint fixture", () => {
+  it("keeps static, SSR, ISR, and API outputs distinct", async () => {
+    const staticResponse = await fetch(`${BASE}/static-vary`);
+    expect(staticResponse.status).toBe(200);
+    expect(await staticResponse.text()).toContain("Pages static RSC vary probe");
+
+    const ssrResponse = await fetch(`${BASE}/ssr-probe`);
+    expect(ssrResponse.status).toBe(200);
+    const ssrDocument = await ssrResponse.text();
+    expect(ssrDocument).toContain('id="optional-catchall-slug"');
+    expect(ssrDocument).toContain("ssr-probe");
+
+    const slug = `live-${crypto.randomUUID()}`;
+    const isrResponse = await fetch(`${BASE}/isr/${slug}`);
+    expect(isrResponse.status).toBe(200);
+    expect(await isrResponse.text()).toContain(slug);
+
+    const apiResponse = await fetch(`${BASE}/api/probe?value=pages`);
+    expect(apiResponse.status).toBe(200);
+    expect(await apiResponse.json()).toEqual({
+      router: "pages-api",
+      method: "GET",
+      query: { value: "pages" },
+    });
+  });
+
   it("keeps the Pages data protocol out of root optional catch-all params", async () => {
     const documentResponse = await fetch(`${BASE}/`);
     expect(documentResponse.status).toBe(200);

--- a/tests/emit/dockerfiles.test.ts
+++ b/tests/emit/dockerfiles.test.ts
@@ -67,7 +67,11 @@ describe("generateDockerfile", () => {
       buildId: "abc123",
       installSharpVersion: "0.34.5",
     });
-    expect(result).toContain("RUN npm install --no-save --no-audit --no-fund sharp@0.34.5");
+    expect(result).toContain(
+      "RUN npm install --prefix /tmp/adapter-k8s-sharp --no-save --no-audit --no-fund sharp@0.34.5",
+    );
+    expect(result).toContain("cp -R /tmp/adapter-k8s-sharp/node_modules/. /app/node_modules/");
+    expect(result).not.toContain("RUN npm install --no-save");
     expect(result.indexOf("COPY --chown=node:node . .")).toBeLessThan(
       result.indexOf("RUN npm install"),
     );
@@ -121,7 +125,11 @@ describe("generatePoolDockerfile", () => {
       buildId: "abc123",
       installSharpVersion: "0.34.5",
     });
-    expect(result).toContain("RUN npm install --no-save --no-audit --no-fund sharp@0.34.5");
+    expect(result).toContain(
+      "RUN npm install --prefix /tmp/adapter-k8s-sharp --no-save --no-audit --no-fund sharp@0.34.5",
+    );
+    expect(result).toContain("cp -R /tmp/adapter-k8s-sharp/node_modules/. /app/node_modules/");
+    expect(result).not.toContain("RUN npm install --no-save");
     // Must run after the context is copied (needs /app) and before dropping to the
     // non-root user (npm writes node_modules as root at build time).
     expect(result.indexOf("COPY --chown=node:node context/ .")).toBeLessThan(

--- a/tests/emit/metadata.test.ts
+++ b/tests/emit/metadata.test.ts
@@ -5,6 +5,8 @@ import { generateBuildMetadata } from "../../src/emit/metadata.js";
 const base = {
   buildId: "b12345",
   nextVersion: "16.2.0",
+  provider: "generic",
+  namespace: "apps",
   poolNames: ["ssr"],
   generatedAt: "2026-01-01T00:00:00.000Z",
   containerStrategy: "traced-assets" as const,
@@ -20,6 +22,8 @@ describe("generateBuildMetadata", () => {
     expect(JSON.parse(generateBuildMetadata(base))).toEqual({
       buildId: "b12345",
       nextVersion: "16.2.0",
+      provider: "generic",
+      namespace: "apps",
       pools: ["ssr"],
       generatedAt: "2026-01-01T00:00:00.000Z",
       containerStrategy: "traced-assets",

--- a/tests/emit/per-build-routing-manifest.test.ts
+++ b/tests/emit/per-build-routing-manifest.test.ts
@@ -56,8 +56,7 @@ describe("per-build routing manifest ConfigMap", () => {
       buildId: "bms7bbb",
       imageRegistry: "r/x",
     });
-    const name = (y: string) =>
-      y.match(/configMap:\s*\n(?:\s*#[^\n]*\n)*\s*name: (\S+)/)?.[1];
+    const name = (y: string) => y.match(/configMap:\s*\n(?:\s*#[^\n]*\n)*\s*name: (\S+)/)?.[1];
     expect(name(a)).toBeTruthy();
     expect(name(a)).not.toBe(name(b));
   });

--- a/tests/emit/templates/route-ext-job.test.ts
+++ b/tests/emit/templates/route-ext-job.test.ts
@@ -412,12 +412,14 @@ describe("N73: route-ext Job verifies the mounted route-extension.yaml", () => {
 
   it("pins the expected service and authority to the values it was RENDERED with", () => {
     const yaml = job();
-    // Both are fully determined by release name + project + the single supported namespace
-    // (K8S_NAMESPACE), so they can be re-derived rather than trusted from /config.
+    // Both are fully determined by release name + project + the Helm release namespace,
+    // so they can be re-derived rather than trusted from /config.
     expect(yaml).toContain(
       'EXPECT_SERVICE="projects/my-project/global/backendServices/my-app-routing-service"',
     );
-    expect(yaml).toContain('EXPECT_AUTHORITY="my-app-routing-service.default.svc.cluster.local"');
+    expect(yaml).toContain(
+      'EXPECT_AUTHORITY="my-app-routing-service.{{ .Release.Namespace }}.svc.cluster.local"',
+    );
   });
 
   it("aborts before the privileged import when either value mismatches", () => {

--- a/tests/emit/templates/utils.test.ts
+++ b/tests/emit/templates/utils.test.ts
@@ -38,7 +38,7 @@ describe("sanitizeK8sName", () => {
   it("strips trailing hyphens introduced by the 63-char boundary", () => {
     const result = sanitizeK8sName("valid-name-" + "x".repeat(60) + "-suffix");
     expect(result.length).toBeLessThanOrEqual(63);
-    expect(result.endsWith('-')).toBe(false);
+    expect(result.endsWith("-")).toBe(false);
   });
 
   it("handles all-special-character input", () => {

--- a/tests/emit/templates/utils.test.ts
+++ b/tests/emit/templates/utils.test.ts
@@ -38,7 +38,7 @@ describe("sanitizeK8sName", () => {
   it("strips trailing hyphens introduced by the 63-char boundary", () => {
     const result = sanitizeK8sName("valid-name-" + "x".repeat(60) + "-suffix");
     expect(result.length).toBeLessThanOrEqual(63);
-    expect(/-$/.test(result)).toBe(false);
+    expect(result.endsWith('-')).toBe(false);
   });
 
   it("handles all-special-character input", () => {

--- a/tests/emit/templates/utils.test.ts
+++ b/tests/emit/templates/utils.test.ts
@@ -16,6 +16,8 @@ import {
   assertSafePoolName,
   assertSafeYamlScalar,
   assertSafeImageReference,
+  assertSafeNamespace,
+  resolveK8sNamespace,
   K8S_NAMESPACE,
 } from "../../../src/emit/templates/utils.js";
 // The snapshot name must be importable from its historical home too — deploy.ts and
@@ -88,6 +90,21 @@ describe("sanitizeK8sName", () => {
     // Short names are untouched apart from the suffix.
     expect(sanitizeK8sName("nextjs-ssr", "-hcp")).toBe("nextjs-ssr-hcp");
   });
+});
+
+describe("Kubernetes namespace validation", () => {
+  it("accepts DNS-1123 labels and defaults only absent values", () => {
+    expect(resolveK8sNamespace()).toBe(K8S_NAMESPACE);
+    expect(resolveK8sNamespace("apps-3")).toBe("apps-3");
+    expect(() => assertSafeNamespace("a".repeat(63))).not.toThrow();
+  });
+
+  it.each(["-prod", "prod-", "---", "Prod", "", "a".repeat(64), 123, null])(
+    "rejects an invalid namespace value: %j",
+    (namespace) => {
+      expect(() => assertSafeNamespace(namespace)).toThrow(/Invalid namespace/);
+    },
+  );
 });
 
 describe("routingManifestSnapshotName", () => {

--- a/tests/pool-server/dispatch-materialization.test.ts
+++ b/tests/pool-server/dispatch-materialization.test.ts
@@ -94,7 +94,12 @@ function baseOptions(over: Record<string, unknown> = {}) {
   } as any;
 }
 
-const route = { kind: "route", pool: "ssr", matchedPathname: "/ppr-page", routeMatches: null } as any;
+const route = {
+  kind: "route",
+  pool: "ssr",
+  matchedPathname: "/ppr-page",
+  routeMatches: null,
+} as any;
 
 describe("PPR serve ladder reads the platform cache", () => {
   it("serves a materialized POSTPONED entry's html and injects ITS postponed token", async () => {

--- a/tests/pool-server/dispatch-not-found-prerender.test.ts
+++ b/tests/pool-server/dispatch-not-found-prerender.test.ts
@@ -142,11 +142,9 @@ describe("deploy-mode 404: prerendered /_not-found preferred over handler invoca
         await a.handler(a.req, { writeHead: () => {}, end: () => {} });
       }) as any,
     } as any);
-    await dispatcher.dispatch(
-      mockReq("/missing.png", { "sec-fetch-dest": "image" }),
-      mockRes(),
-      { kind: "not-found" } as any,
-    );
+    await dispatcher.dispatch(mockReq("/missing.png", { "sec-fetch-dest": "image" }), mockRes(), {
+      kind: "not-found",
+    } as any);
     expect(seenHeaders).toEqual(["image"]);
   });
 

--- a/tests/pool-server/dispatch-root-shell-injection.test.ts
+++ b/tests/pool-server/dispatch-root-shell-injection.test.ts
@@ -16,9 +16,17 @@ function mockReq(url: string): any {
 }
 function mockRes(): any {
   return {
-    headersSent: false, writableEnded: false,
-    setHeader: vi.fn(), getHeaderNames: () => [], removeHeader: vi.fn(),
-    writeHead: vi.fn(), write: vi.fn(), end: vi.fn(), on: vi.fn(), once: vi.fn(), emit: vi.fn(),
+    headersSent: false,
+    writableEnded: false,
+    setHeader: vi.fn(),
+    getHeaderNames: () => [],
+    removeHeader: vi.fn(),
+    writeHead: vi.fn(),
+    write: vi.fn(),
+    end: vi.fn(),
+    on: vi.fn(),
+    once: vi.fn(),
+    emit: vi.fn(),
   };
 }
 const handlerLoader = {
@@ -34,16 +42,19 @@ for (const mp of ["/", "/index"]) {
       handlerLoader,
       poolName: "ssr",
       buildId: "b1",
-      staticAssets: [
-        { pathname: "/", filePath: shellFile, prerender: true, ppr: true },
-      ] as any,
+      staticAssets: [{ pathname: "/", filePath: shellFile, prerender: true, ppr: true }] as any,
       pprRoutes: { "/": { postponedState: "tok", fallbackFilePath: shellFile } } as any,
       incrementalCacheShared: true,
-      localHandlerInvoker: (async (a: any) => { calls.push(a); }) as any,
+      localHandlerInvoker: (async (a: any) => {
+        calls.push(a);
+      }) as any,
     } as any);
     const req = mockReq("/");
     await dispatcher.dispatch(req, mockRes(), {
-      kind: "route", matchedPathname: mp, pool: "ssr", routeMatches: null,
+      kind: "route",
+      matchedPathname: mp,
+      pool: "ssr",
+      routeMatches: null,
     } as any);
     expect(calls).toHaveLength(1);
     const meta = (req as any)[Symbol.for("NextInternalRequestMeta")];

--- a/tests/pool-server/dispatch.test.ts
+++ b/tests/pool-server/dispatch.test.ts
@@ -578,7 +578,11 @@ describe("createDispatcher", () => {
       // invokeStatus tells the RENDER it is a 404 (Next then emits the default not-found
       // metadata — robots noindex; metadata-navigation "root not-found with default
       // metadata"); forceStatus alone only rewrites the status after the fact.
-      expect.objectContaining({ matchedPathname: "/docs/404", forceStatus: 404, invokeStatus: 404 }),
+      expect.objectContaining({
+        matchedPathname: "/docs/404",
+        forceStatus: 404,
+        invokeStatus: 404,
+      }),
     );
   });
 

--- a/tests/pool-server/index.draft-bypass.test.ts
+++ b/tests/pool-server/index.draft-bypass.test.ts
@@ -16,7 +16,7 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import path from "node:path";
-import net, { type AddressInfo } from "node:net";
+import { type AddressInfo } from "node:net";
 import { createServer } from "node:http";
 
 const REPO_ROOT = process.cwd();

--- a/tests/pool-server/route-matches-sanitization.test.ts
+++ b/tests/pool-server/route-matches-sanitization.test.ts
@@ -37,7 +37,7 @@ describe("extractRouteParams sentinel filtering (the Phase-2 compensation)", () 
     // removed is therefore also removed here, which is why an UNSANITIZED Phase-2 header
     // cannot produce params Phase 1 would not have produced.
     const phase1Drops = (value: string) => /^\$nxtP[^/]*$/.test(value);
-    const consumerDrops = (value: string) => /^\$nxtP/.test(value);
+    const consumerDrops = (value: string) => value.startsWith('$nxtP');
     for (const value of [
       "$nxtPid",
       "$nxtPslug",

--- a/tests/pool-server/route-matches-sanitization.test.ts
+++ b/tests/pool-server/route-matches-sanitization.test.ts
@@ -37,7 +37,7 @@ describe("extractRouteParams sentinel filtering (the Phase-2 compensation)", () 
     // removed is therefore also removed here, which is why an UNSANITIZED Phase-2 header
     // cannot produce params Phase 1 would not have produced.
     const phase1Drops = (value: string) => /^\$nxtP[^/]*$/.test(value);
-    const consumerDrops = (value: string) => value.startsWith('$nxtP');
+    const consumerDrops = (value: string) => value.startsWith("$nxtP");
     for (const value of [
       "$nxtPid",
       "$nxtPslug",

--- a/tests/pool-server/valkey-cache/build-seed-index.test.ts
+++ b/tests/pool-server/valkey-cache/build-seed-index.test.ts
@@ -101,9 +101,7 @@ describe("createBuildSeedLookup", () => {
   });
 
   it("declines a prerender with no .rsc sibling rather than emit a half-usable entry", async () => {
-    writeManifest([
-      asset({ pathname: "/no-rsc", filePath: ".next/server/app/no-rsc.html" }),
-    ]);
+    writeManifest([asset({ pathname: "/no-rsc", filePath: ".next/server/app/no-rsc.html" })]);
     stage(".next/server/app/no-rsc.html", "<html>x</html>");
     const lookup = createBuildSeedLookup({ appRoot });
     expect(await lookup("/no-rsc")).toBeNull();
@@ -285,7 +283,10 @@ describe("filesystem-mirror seeds (PPR shells, segments — sub-shell-generation
     ]);
     stage(".next/server/app/covered.html", "<html>covered</html>");
     stage(".next/server/app/covered.rsc", "rsc");
-    stage(".next/server/app/covered.meta", JSON.stringify({ headers: { "x-next-cache-tags": "disk-tag" } }));
+    stage(
+      ".next/server/app/covered.meta",
+      JSON.stringify({ headers: { "x-next-cache-tags": "disk-tag" } }),
+    );
     const lookup = createBuildSeedLookup({ appRoot });
 
     const entry = await lookup("/covered", { kind: "APP_PAGE" });

--- a/tests/pool-server/valkey-cache/incremental-cache-handler.test.ts
+++ b/tests/pool-server/valkey-cache/incremental-cache-handler.test.ts
@@ -917,7 +917,11 @@ describe("build-seed fallback: an empty Valkey behaves like next start's warm fi
     const h = new ValkeyIncrementalCacheHandler({ client, buildId: "tagmerge1", now: () => 1000 });
     await h.set(
       "sharedfetchkey",
-      { kind: "FETCH", data: { body: "x", headers: {}, status: 200 }, revalidate: 31536000 } as never,
+      {
+        kind: "FETCH",
+        data: { body: "x", headers: {}, status: 200 },
+        revalidate: 31536000,
+      } as never,
       { tags: ["other-page-tag"] },
     );
 

--- a/tests/pool-server/valkey-cache/resp-client-tls.integration.test.ts
+++ b/tests/pool-server/valkey-cache/resp-client-tls.integration.test.ts
@@ -371,12 +371,13 @@ describe("readClientHelloSni (guards the L18 wire assertion from going vacuous)"
     const port = await new Promise<number>((r) => {
       server.listen(0, "127.0.0.1", () => r((server.address() as net.AddressInfo).port));
     });
-    const socket = tls.connect({ host: "127.0.0.1", port, rejectUnauthorized: false, ...options });
-    socket.on("error", () => undefined);
+    let socket: tls.TLSSocket | undefined;
     try {
+      socket = tls.connect({ host: "127.0.0.1", port, rejectUnauthorized: false, ...options });
+      socket.on("error", () => undefined);
       return await seen;
     } finally {
-      socket.destroy();
+      socket?.destroy();
       await new Promise<void>((r) => server.close(() => r()));
     }
   }
@@ -385,8 +386,17 @@ describe("readClientHelloSni (guards the L18 wire assertion from going vacuous)"
     expect(await sniOf({ servername: "valkey.example.internal" })).toBe("valkey.example.internal");
   });
 
-  it("reports an IP servername (Node sends it; this is what L18 must avoid)", async () => {
-    expect(await sniOf({ servername: "10.1.2.3" })).toBe("10.1.2.3");
+  it("reports an IP servername when the Node runtime permits sending one", async () => {
+    try {
+      expect(await sniOf({ servername: "10.1.2.3" })).toBe("10.1.2.3");
+    } catch (error) {
+      // Node 26 upgraded DEP0123 from a warning to a TypeError. That is a stronger runtime
+      // guarantee than L18 needs; Node 20/22/24 still exercise the ClientHello parser above.
+      expect(error).toBeInstanceOf(TypeError);
+      expect(String(error)).toContain(
+        "Setting the TLS ServerName to an IP address is not permitted",
+      );
+    }
   });
 
   it("reports null when no servername is set (the L18 shape)", async () => {

--- a/tests/pool-server/valkey-cache/resp-client-tls.integration.test.ts
+++ b/tests/pool-server/valkey-cache/resp-client-tls.integration.test.ts
@@ -21,6 +21,8 @@ import {
 import type { CacheEntry } from "../../../src/pool-server/valkey-cache/types.js";
 import { ValkeyCacheHandler } from "../../../src/pool-server/valkey-cache/use-cache-handler.js";
 
+const SERVER_CLOCK_TOLERANCE_MS = 100;
+
 // The `rediss://` (TLS) variant of the plaintext integration suites: the SAME paths those cover —
 // RESP round-trips, the tag-manifest `updateTags` EVAL, cross-replica revalidation through both
 // handlers — but over a real TLS handshake to a real Valkey configured with `--tls-port`. The unit
@@ -525,8 +527,8 @@ describe.skipIf(!dockerAvailable || !opensslAvailable)(
       const after = Date.now();
       expect(Number(clamped)).toBe(1);
       const stored = JSON.parse((await c.hmget(key, "t"))[0]!);
-      expect(stored.expired).toBeGreaterThanOrEqual(before - 5);
-      expect(stored.expired).toBeLessThanOrEqual(after + 5);
+      expect(stored.expired).toBeGreaterThanOrEqual(before - SERVER_CLOCK_TOLERANCE_MS);
+      expect(stored.expired).toBeLessThanOrEqual(after + SERVER_CLOCK_TOLERANCE_MS);
       expect(stored.expired).toBeLessThan(clientNow - MAX_CLOCK_SKEW_MS);
       expect(await c.ttl(key)).toBeGreaterThan(29 * 24 * 60 * 60); // M11 TTL applied over TLS too
     });

--- a/tests/pool-server/valkey-cache/use-cache-handler.integration.test.ts
+++ b/tests/pool-server/valkey-cache/use-cache-handler.integration.test.ts
@@ -30,6 +30,9 @@ try {
 }
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+// Docker Desktop and virtualized CI clocks can differ from the host wall clock by more than
+// 5 ms. This remains tiny beside the 60-second production skew clamp the assertions protect.
+const SERVER_CLOCK_TOLERANCE_MS = 100;
 
 function makeEntry(
   text: string,
@@ -356,11 +359,11 @@ describe.skipIf(!dockerAvailable)("ValkeyCacheHandler (integration)", () => {
     // The script reports the skew to the caller (feeds warnOnClockSkewClamp).
     expect(Number(clamped)).toBe(1);
     const stored = JSON.parse((await raw.hget(key, "t"))!);
-    expect(stored.expired).toBeGreaterThanOrEqual(before - 5);
-    expect(stored.expired).toBeLessThanOrEqual(after + 5);
+    expect(stored.expired).toBeGreaterThanOrEqual(before - SERVER_CLOCK_TOLERANCE_MS);
+    expect(stored.expired).toBeLessThanOrEqual(after + SERVER_CLOCK_TOLERANCE_MS);
     expect(stored.expired).toBeLessThan(clientNow - MAX_CLOCK_SKEW_MS);
     // `at` was rewritten to the SERVER clock, not the skewed client clock.
-    expect(stored.at).toBeLessThanOrEqual(after + 5);
+    expect(stored.at).toBeLessThanOrEqual(after + SERVER_CLOCK_TOLERANCE_MS);
   });
 
   it("N78 hard expire, clock 5min BEHIND: the watermark is dragged FORWARD to the server's now", async () => {
@@ -383,8 +386,8 @@ describe.skipIf(!dockerAvailable)("ValkeyCacheHandler (integration)", () => {
     const after = Date.now();
     expect(Number(clamped)).toBe(1);
     const stored = JSON.parse((await raw.hget(key, "t"))!);
-    expect(stored.expired).toBeGreaterThanOrEqual(before - 5);
-    expect(stored.expired).toBeLessThanOrEqual(after + 5);
+    expect(stored.expired).toBeGreaterThanOrEqual(before - SERVER_CLOCK_TOLERANCE_MS);
+    expect(stored.expired).toBeLessThanOrEqual(after + SERVER_CLOCK_TOLERANCE_MS);
     expect(stored.expired).toBeGreaterThan(clientNow + MAX_CLOCK_SKEW_MS);
   });
 
@@ -407,8 +410,8 @@ describe.skipIf(!dockerAvailable)("ValkeyCacheHandler (integration)", () => {
     const after = Date.now();
     expect(Number(clamped)).toBe(1);
     const stored = JSON.parse((await raw.hget(key, "t"))!);
-    expect(stored.stale).toBeGreaterThanOrEqual(before - 5);
-    expect(stored.stale).toBeLessThanOrEqual(after + 5);
+    expect(stored.stale).toBeGreaterThanOrEqual(before - SERVER_CLOCK_TOLERANCE_MS);
+    expect(stored.stale).toBeLessThanOrEqual(after + SERVER_CLOCK_TOLERANCE_MS);
     expect(stored.expired - stored.stale).toBe(300_000);
   });
 
@@ -456,8 +459,8 @@ describe.skipIf(!dockerAvailable)("ValkeyCacheHandler (integration)", () => {
       const after = Date.now();
       expect(warn.mock.calls.some((c) => /clock/i.test(String(c[0])))).toBe(true);
       const stored = JSON.parse((await raw.hget("k8s:skew-handler:tags", "t"))!);
-      expect(stored.expired).toBeGreaterThanOrEqual(before - 5);
-      expect(stored.expired).toBeLessThanOrEqual(after + 5);
+      expect(stored.expired).toBeGreaterThanOrEqual(before - SERVER_CLOCK_TOLERANCE_MS);
+      expect(stored.expired).toBeLessThanOrEqual(after + SERVER_CLOCK_TOLERANCE_MS);
       // The whole point: a correctly-clocked replica drops the entry NOW.
       expect(await reader.get("k", [])).toBeUndefined();
     } finally {

--- a/tests/providers/review-fixes.test.ts
+++ b/tests/providers/review-fixes.test.ts
@@ -1,6 +1,6 @@
 // Fixes from the second external review of the multi-provider work. Each case is the failure the
 // review described, written so it fails if the fix regresses.
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { resolveProvider } from "../../src/providers/index.js";
 import { renderNetworkPolicies } from "../../src/emit/templates/network-policy.js";
 import { buildDockerCommands } from "../../src/cli/deploy.js";

--- a/tests/routing-common.tier-parity.test.ts
+++ b/tests/routing-common.tier-parity.test.ts
@@ -1078,7 +1078,7 @@ describe("Phase 1 / Phase 2 client rewrite-signal parity", () => {
    * `isRSCRequest` / `isRSCRequestHeader` guards at both upstream emission sites). */
   const rscTiers = (args: Parameters<typeof bothTiers>[0]) => {
     const rscHeader = args.manifest.routeGraph.rsc?.header ?? "rsc";
-    return bothTiers({ ...args, headers: { [rscHeader]: "1", ...(args.headers ?? {}) } });
+    return bothTiers({ ...args, headers: { [rscHeader]: "1", ...args.headers } });
   };
 
   it("emits the rewrite signal for a next.config rewrite on BOTH tiers (repeated query keys)", async () => {


### PR DESCRIPTION
## Summary

- pin the adapter and integration fixtures to stable Next.js 16.3
- make variant outputs, package resolution, and native dependency staging portable
- add lint, typecheck, formatting, namespace, and cross-platform regression coverage

## Motivation

The build path depended on local package layout, host-platform behavior, and one shared output directory. That made the same project produce different artifacts across developer machines, CI runners, and deployment variants.

## Changes

- update Next.js and every integration fixture to the stable 16.3 release
- exercise Pages static output, SSR, fallback-blocking ISR, and API dispatch through the deployed fixture
- run formatting, lint, typecheck, build, and unit tests for every pull request, including stacked branches
- persist and apply a configurable Kubernetes namespace instead of assuming `default`
- resolve runtime packages through exports maps and preserve traced dependencies while staging Sharp
- scope emitted output to the selected config variant and use that output in generated container builds
- cover Node IP/SNI behavior, native artifact diagnostics, path normalization, and deterministic clock assertions

## Testing

- `npm run build`
- `npm test`
- `npm run typecheck`
- `npm run lint`
- `npm run fmt:check`
- `npm ci && npm run build` in each integration fixture
