### PR TITLE
Add lint and typecheck gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Lint
+        run: npm run lint
+
+      - name: Typecheck
+        run: npm run typecheck
+
       - name: Build
         run: npm run build
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "esbuild": "^0.27.4",
         "ioredis": "^5.11.1",
         "oxfmt": "^0.42.0",
-        "oxlint": "^1.57.0",
+        "oxlint": "1.73.0",
         "typescript": "^6.0.2",
         "vitest": "^4.1.1"
       },

--- a/package.json
+++ b/package.json
@@ -53,8 +53,9 @@
     "build": "npm run build:clean && npm run build:types && npm run build:adapter && npm run build:pool-server && npm run build:cache-handler && npm run build:protos && npm run build:routing-service && npm run build:cli",
     "fmt": "oxfmt",
     "fmt:check": "oxfmt --check",
-    "lint": "oxlint",
-    "lint:fix": "oxlint --fix"
+    "lint": "oxlint --deny-warnings",
+    "lint:fix": "oxlint --fix",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@bufbuild/protobuf": "^2.12.1",
@@ -72,7 +73,7 @@
     "esbuild": "^0.27.4",
     "ioredis": "^5.11.1",
     "oxfmt": "^0.42.0",
-    "oxlint": "^1.57.0",
+    "oxlint": "1.73.0",
     "typescript": "^6.0.2",
     "vitest": "^4.1.1"
   },

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -1244,7 +1244,7 @@ export function createK8sAdapter(userConfig?: K8sAdapterConfig): NextAdapter {
   const adapter: NextAdapter = {
     name: "k8s",
 
-    async modifyConfig(nextConfig, ctx) {
+    async modifyConfig(nextConfig, _ctx) {
       // The stable adapter API ctx has { phase, nextVersion } — no projectDir.
       // Use process.cwd() which is the project root during build.
       const cfg = await ensureConfig(process.cwd());
@@ -1341,7 +1341,7 @@ export function createK8sAdapter(userConfig?: K8sAdapterConfig): NextAdapter {
         // asset split regresses client bootstrap (asset URLs move under /_next/static/immutable/).
         const disabled = process.env.ADAPTER_K8S_DISABLE_IMMUTABLE_ASSETS === "1";
         modified.experimental = {
-          ...((modified.experimental as Record<string, unknown>) ?? {}),
+          ...(modified.experimental as Record<string, unknown> | undefined),
           supportsImmutableAssets: disabled ? false : (userImmutable ?? true),
         };
       }
@@ -1351,7 +1351,7 @@ export function createK8sAdapter(userConfig?: K8sAdapterConfig): NextAdapter {
       const buildCpus = parseInt(process.env.ADAPTER_K8S_BUILD_CPUS ?? "", 10);
       if (buildCpus > 0) {
         modified.experimental = {
-          ...((modified.experimental as Record<string, unknown>) ?? {}),
+          ...(modified.experimental as Record<string, unknown> | undefined),
           cpus: buildCpus,
           memoryBasedWorkersCount: false,
           parallelServerCompiles: false,
@@ -1392,7 +1392,7 @@ export function createK8sAdapter(userConfig?: K8sAdapterConfig): NextAdapter {
         // 3,342/0 without it (2026-07-28). Absent a measured need, a build-wide define stays
         // out; if it is ever reconsidered, land it alone and re-run the full suite.
         modified.experimental = {
-          ...((modified.experimental as Record<string, unknown>) ?? {}),
+          ...(modified.experimental as Record<string, unknown> | undefined),
           ...(allowedOrigins.size > 0
             ? {
                 serverActions: {
@@ -1400,7 +1400,7 @@ export function createK8sAdapter(userConfig?: K8sAdapterConfig): NextAdapter {
                   allowedOrigins: [...allowedOrigins],
                 },
               }
-            : {}),
+            : undefined),
         };
       }
 

--- a/src/cli/container-runtime.ts
+++ b/src/cli/container-runtime.ts
@@ -71,9 +71,7 @@ async function canBuild(candidate: ContainerCli): Promise<boolean> {
         "",
       ];
   for (const host of hosts) {
-    const res = await execCapture("buildctl", ["debug", "workers"], {
-      ...(host ? { env: { BUILDKIT_HOST: host } } : {}),
-    }).catch(() => null);
+    const res = await execCapture("buildctl", ["debug", "workers"], (host ? { env: { BUILDKIT_HOST: host } } : {})).catch(() => null);
     if (res && res.exitCode === 0) return true;
   }
   return false;

--- a/src/cli/destroy.ts
+++ b/src/cli/destroy.ts
@@ -1,5 +1,4 @@
 // src/cli/destroy.ts
-import path from "node:path";
 import { existsSync, readFileSync } from "node:fs";
 import readline from "node:readline";
 import { execCapture } from "./exec.js";

--- a/src/cli/tail.ts
+++ b/src/cli/tail.ts
@@ -1,7 +1,6 @@
 // src/cli/tail.ts
 import { spawn, type ChildProcess } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
-import path from "node:path";
 import { execCapture } from "./exec.js";
 import { sanitizeForTerminal } from "./terminal.js";
 import { assertSafeInfrastructure, infrastructurePath } from "./infrastructure-validation.js";

--- a/src/emit/dockerfiles.ts
+++ b/src/emit/dockerfiles.ts
@@ -75,7 +75,7 @@ RUN npm install --no-save --no-audit --no-fund sharp@${installSharpVersion} \\
 }
 
 export function generateDockerfile({
-  containerStrategy,
+  containerStrategy: _containerStrategy,
   nodeVersion = DEFAULT_EMITTED_NODE_VERSION,
   buildId,
   installSharpVersion,

--- a/src/emit/helm.ts
+++ b/src/emit/helm.ts
@@ -12,14 +12,10 @@ import {
   renderRoutingManifestConfigMap,
   renderRoutingManifestSnapshotConfigMap,
 } from "./templates/routing-manifest-configmap.js";
-import { sanitizeK8sName } from "./templates/utils.js";
 import { renderRoutingServiceDeployment } from "./templates/routing-service-deployment.js";
 import { renderRoutingServiceService } from "./templates/routing-service-service.js";
 import { renderRoutingServiceHPA } from "./templates/routing-service-hpa.js";
-import {
-  renderRouteExtConfigMap,
-  routeExtDocumentDigest,
-} from "./templates/route-ext-configmap.js";
+import { routeExtDocumentDigest } from "./templates/route-ext-configmap.js";
 import { renderNetworkPolicies } from "./templates/network-policy.js";
 import { resolveProvider } from "../providers/index.js";
 
@@ -234,7 +230,7 @@ export function generateHelmChart({
     // shared sources — both match Kubernetes' own "last one wins" semantics, so a pool
     // override behaves the way someone reading the rendered pod spec would predict.
     const poolConfig = config.pools?.[poolName];
-    const mergedEnv = { ...(config.env ?? {}), ...(poolConfig?.env ?? {}) };
+    const mergedEnv = { ...config.env, ...poolConfig?.env };
     const mergedEnvFrom = [...(config.envFrom ?? []), ...(poolConfig?.envFrom ?? [])];
     files[`templates/${poolName}-deployment.yaml`] = renderDeployment({
       poolName,

--- a/src/pool-server/cache-policy.ts
+++ b/src/pool-server/cache-policy.ts
@@ -75,6 +75,8 @@ export function createPprRouteMatcher(
       pathnameOrOutputId,
       ...rscParentCandidates(pathnameOrOutputId, rscConfig),
     ]);
+    // Snapshot the initial seeds: the loop adds derived forms that must not recursively expand.
+    // oxlint-disable-next-line unicorn/no-useless-spread
     for (const seed of [...seeds]) {
       const withoutBase = stripBasePath(seed, basePath);
       seeds.add(withoutBase);

--- a/src/pool-server/dispatch.ts
+++ b/src/pool-server/dispatch.ts
@@ -312,7 +312,7 @@ function deleteHeaderCaseInsensitive(
 function sanitizeStoredEntryHeaders(
   headers: Record<string, string> | undefined,
 ): Record<string, string> {
-  const out: Record<string, string> = { ...(headers ?? {}) };
+  const out: Record<string, string> = { ...headers };
   deleteHeaderCaseInsensitive(out, "x-next-cache-tags");
   return out;
 }
@@ -536,7 +536,7 @@ function captureResponseForStore(res: ServerResponse, maxBytes: number) {
       | undefined {
       if (over) return undefined;
       const merged: Record<string, string | string[]> = {
-        ...((res.getHeaders?.() as Record<string, string | string[]>) ?? {}),
+        ...(res.getHeaders?.() as Record<string, string | string[]> | undefined),
         ...headHeaders,
       };
       // The stored copy replays under its own verdict; drop the first serve's.
@@ -881,6 +881,9 @@ async function invokeLocalHandlerOverHttp({
       // has already been streamed to the client; this only keeps the invocation/server lifecycle
       // alive until Next's cache writes, revalidations, and after() work have completed.
       while (pendingWaitUntil.size > 0) {
+        // Snapshot the Set: callbacks may delete themselves and enqueue more work while this
+        // batch settles; the outer loop deliberately picks up the next fixed-point batch.
+        // oxlint-disable-next-line unicorn/no-useless-spread
         await Promise.all([...pendingWaitUntil]);
       }
     };
@@ -1240,6 +1243,9 @@ export function extractRouteParams(
     const name = match[1] ?? match[2];
     if (!name) continue;
     const value = routeMatches?.[name] ?? routeMatches?.[`nxtP${name}`];
+    // RegExp.test intentionally preserves the legacy coercion behaviour for a malformed
+    // secret-gated route-matches value; startsWith would throw before the existing shape path.
+    // oxlint-disable-next-line unicorn/prefer-string-starts-ends-with
     if (value === undefined || /^\$nxtP/.test(value)) continue;
     if (match[1]) {
       const segments = value.split("/");

--- a/src/pool-server/index.ts
+++ b/src/pool-server/index.ts
@@ -21,7 +21,6 @@ import {
   templateOutputCandidates,
   trailingSlashVariants,
   type MiddlewareMatcher,
-  type RscConfig,
 } from "../routing-common.js";
 import { createHandlerLoader } from "./handler-loader.js";
 import { collectPublicPathnames } from "./public-files.js";
@@ -2750,7 +2749,7 @@ export async function startPoolServer(): Promise<ReturnType<typeof createPoolSer
           "content-type": getContentType(staticPathname),
           "cache-control": cacheControl,
           etag,
-          ...(headers ?? {}),
+          ...headers,
         };
         if (ifNoneMatchMatches(req.headers["if-none-match"], etag)) {
           res.writeHead(304, responseHeaders);

--- a/src/pool-server/valkey-cache/build-seed-index.ts
+++ b/src/pool-server/valkey-cache/build-seed-index.ts
@@ -22,8 +22,6 @@
 // (same rule as the Valkey client; see cache-handler-entry.ts).
 import type { SeedEntry } from "./incremental-cache-handler.js";
 
-declare const require: (id: string) => any;
-
 interface StaticAssetRecord {
   pathname: string;
   filePath: string;
@@ -177,7 +175,7 @@ function fetchCacheSeed(appRoot: string, cacheKey: string): SeedEntry | null {
  * `<key>.segments/`. Returns null (miss) when the html is absent or the entry would be
  * half-usable.
  */
-function fsMirrorSeed(appRoot: string, cacheKey: string, ctx?: SeedLookupCtx): SeedEntry | null {
+function fsMirrorSeed(appRoot: string, cacheKey: string, _ctx?: SeedLookupCtx): SeedEntry | null {
   const fs = builtin<typeof import("node:fs")>("node:fs");
   const path = builtin<typeof import("node:path")>("node:path");
   const base = path.join(appRoot, ".next", "server", "app", ...cacheKey.split("/").filter(Boolean));

--- a/src/routing-common.ts
+++ b/src/routing-common.ts
@@ -804,6 +804,8 @@ export function prepareRequest(
   // NextResponse.next()'s x-middleware-override-headers and materialized as a cookie the
   // client never set (app-middleware-proxy). The pool's server.ts does the same strip for
   // Phase 1; doing it here too is idempotent. The public prefetch hint is protocol, kept.
+  // Snapshot before deleting so iteration never depends on Map mutation semantics.
+  // oxlint-disable-next-line unicorn/no-useless-spread
   for (const name of [...headers.keys()]) {
     if (name.startsWith("x-middleware-") && name !== "x-middleware-prefetch") {
       headers.delete(name);
@@ -1241,6 +1243,7 @@ export function filterInternalQuery(
   for (const [k, v] of Object.entries(query)) {
     if (k.startsWith("nxtP") || k === "_rsc") continue;
     const values = Array.isArray(v) ? v : [v];
+    // oxlint-disable-next-line unicorn/prefer-string-starts-ends-with
     if (values.some((value) => /^\$nxtP/.test(value))) continue;
     out[k] = v;
   }
@@ -1273,7 +1276,11 @@ export function sanitizeRouteMatches(
   matches: Record<string, string> | null | undefined,
 ): Record<string, string> | null {
   if (!matches) return null;
-  const unresolvedValues = new Set(Object.values(matches).filter((value) => /^\$nxtP/.test(value)));
+  const unresolvedValues = new Set(
+    // RegExp.test retains the previous coercion behaviour at this trust boundary.
+    // oxlint-disable-next-line unicorn/prefer-string-starts-ends-with
+    Object.values(matches).filter((value) => /^\$nxtP/.test(value)),
+  );
   if (unresolvedValues.size === 0) return matches;
   const sanitized = Object.fromEntries(
     Object.entries(matches).filter(([, value]) => !unresolvedValues.has(value)),

--- a/tests/cel.test.ts
+++ b/tests/cel.test.ts
@@ -1,17 +1,11 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   generateCelExpression,
   extractStaticPrefix,
   escapeCelString,
   CEL_EXPRESSION_WARN_LENGTH,
 } from "../src/cel.js";
-import {
-  mockOutputs,
-  mockStaticFile,
-  mockPrerender,
-  mockAppPage,
-  mockAppRoute,
-} from "./helpers/mock-outputs.js";
+import { mockOutputs, mockStaticFile } from "./helpers/mock-outputs.js";
 
 describe("extractStaticPrefix", () => {
   it("extracts prefix from dynamic route regex", () => {
@@ -136,18 +130,6 @@ describe("generateCelExpression", () => {
 });
 
 describe("generateCelExpression with basePath", () => {
-  const mwOutputs = (staticFiles: { pathname: string }[]) =>
-    mockOutputs({
-      staticFiles: staticFiles.map((f) => mockStaticFile(f)),
-      middleware: {
-        id: "middleware",
-        filePath: "/dist/server/middleware.js",
-        pathname: "/middleware",
-        type: 8 as any,
-        config: { matchers: [] },
-      } as any,
-    });
-
   it("probes middleware coverage with the basePath-prefixed pathname", () => {
     // Next bakes the basePath into matcher sourceRegexes, so the coverage probe
     // must test the wire path — a basePath-less probe would wrongly exclude
@@ -166,4 +148,3 @@ describe("generateCelExpression with basePath", () => {
     expect(cel).not.toContain("api-docs");
   });
 });
-

--- a/tests/emit/templates/utils.test.ts
+++ b/tests/emit/templates/utils.test.ts
@@ -38,7 +38,7 @@ describe("sanitizeK8sName", () => {
   it("strips trailing hyphens introduced by the 63-char boundary", () => {
     const result = sanitizeK8sName("valid-name-" + "x".repeat(60) + "-suffix");
     expect(result.length).toBeLessThanOrEqual(63);
-    expect(/-$/.test(result)).toBe(false);
+    expect(result.endsWith('-')).toBe(false);
   });
 
   it("handles all-special-character input", () => {

--- a/tests/pool-server/index.draft-bypass.test.ts
+++ b/tests/pool-server/index.draft-bypass.test.ts
@@ -16,7 +16,7 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import path from "node:path";
-import net, { type AddressInfo } from "node:net";
+import { type AddressInfo } from "node:net";
 import { createServer } from "node:http";
 
 const REPO_ROOT = process.cwd();

--- a/tests/pool-server/route-matches-sanitization.test.ts
+++ b/tests/pool-server/route-matches-sanitization.test.ts
@@ -37,7 +37,7 @@ describe("extractRouteParams sentinel filtering (the Phase-2 compensation)", () 
     // removed is therefore also removed here, which is why an UNSANITIZED Phase-2 header
     // cannot produce params Phase 1 would not have produced.
     const phase1Drops = (value: string) => /^\$nxtP[^/]*$/.test(value);
-    const consumerDrops = (value: string) => /^\$nxtP/.test(value);
+    const consumerDrops = (value: string) => value.startsWith('$nxtP');
     for (const value of [
       "$nxtPid",
       "$nxtPslug",

--- a/tests/providers/review-fixes.test.ts
+++ b/tests/providers/review-fixes.test.ts
@@ -1,6 +1,6 @@
 // Fixes from the second external review of the multi-provider work. Each case is the failure the
 // review described, written so it fails if the fix regresses.
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { resolveProvider } from "../../src/providers/index.js";
 import { renderNetworkPolicies } from "../../src/emit/templates/network-policy.js";
 import { buildDockerCommands } from "../../src/cli/deploy.js";

--- a/tests/routing-common.tier-parity.test.ts
+++ b/tests/routing-common.tier-parity.test.ts
@@ -1078,7 +1078,7 @@ describe("Phase 1 / Phase 2 client rewrite-signal parity", () => {
    * `isRSCRequest` / `isRSCRequestHeader` guards at both upstream emission sites). */
   const rscTiers = (args: Parameters<typeof bothTiers>[0]) => {
     const rscHeader = args.manifest.routeGraph.rsc?.header ?? "rsc";
-    return bothTiers({ ...args, headers: { [rscHeader]: "1", ...(args.headers ?? {}) } });
+    return bothTiers({ ...args, headers: { [rscHeader]: "1", ...args.headers } });
   };
 
   it("emits the rewrite signal for a next.config rewrite on BOTH tiers (repeated query keys)", async () => {


### PR DESCRIPTION
- Add lint and TypeScript checks to the existing CI workflow.
- Pin `oxlint@1.73.0` so new lint rules cannot unexpectedly break CI.
- Resolve the current warnings while preserving deliberate snapshot and coercion behavior.