### PR TITLE
Enforce formatting in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Check formatting
+        run: npm run fmt:check
+
       - name: Lint
         run: npm run lint
 

--- a/README.md
+++ b/README.md
@@ -212,10 +212,7 @@ export default createK8sAdapter({
     API_KEY: { secret: "app-secrets", key: "api-key" }, // -> secretKeyRef
     FLAGS: { configMap: "app-config", key: "flags" }, // -> configMapKeyRef
   },
-  envFrom: [
-    { secret: "app-secrets" },
-    { configMap: "app-config", prefix: "CFG_" },
-  ],
+  envFrom: [{ secret: "app-secrets" }, { configMap: "app-config", prefix: "CFG_" }],
 
   pools: {
     // Merged OVER the top-level map, so a pool can override a shared default.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ Please report suspected vulnerabilities privately via GitHub's [private vulnerab
 
 ## Threat model in one paragraph
 
-The sensitive asset is the **internal dispatch secret**. The routing service resolves each request (runs middleware, classifies the route) and communicates its verdict to the pool servers via headers authenticated with this secret. Anything that holds the secret can hand a pool a forged, pre-trusted verdict—including "middleware already ran"—and have middleware skipped for arbitrary requests. The design therefore reduces to two questions: *who can reach the routing service*, and *who can obtain the secret at rest*. Everything below serves one of those two.
+The sensitive asset is the **internal dispatch secret**. The routing service resolves each request (runs middleware, classifies the route) and communicates its verdict to the pool servers via headers authenticated with this secret. Anything that holds the secret can hand a pool a forged, pre-trusted verdict—including "middleware already ran"—and have middleware skipped for arbitrary requests. The design therefore reduces to two questions: _who can reach the routing service_, and _who can obtain the secret at rest_. Everything below serves one of those two.
 
 ## Workload hardening
 
@@ -29,12 +29,12 @@ The ext_proc listener authenticates only the server (TLS with no client-certific
 
 The chart emits default-deny ingress NetworkPolicies with a positive allowlist:
 
-| source | reaches | why |
-| --- | --- | --- |
-| `35.191.0.0/16`, `130.211.0.0/22`, `2600:2d00:1:1::/64` | pools `:3000`, routing `:8443` | GFE proxy ranges for a global external Application Load Balancer with zonal `GCE_VM_IP_PORT` NEG backends—the topology this chart emits. The ext_proc callout arrives from the same ranges. |
-| `35.191.0.0/16`, `2600:2d00:1:b029::/64` | same | Health-check probers for GFE-based load balancers (the Gateway's pool checks and the routing tier's TCP check on `:8443`). |
-| node CIDRs (auto-discovered) | pools `:3000`, routing `:8081` | kubelet liveness/readiness probes originate from the **node** IP, which no Google range covers. The template fails at render time if the range is unknown, rather than leaving every pod unready at rollout. |
-| sibling pool pods (label selector) | pools `:3000` | cross-pool proxying. The routing service cannot originate pool traffic. |
+| source                                                  | reaches                        | why                                                                                                                                                                                                          |
+| ------------------------------------------------------- | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `35.191.0.0/16`, `130.211.0.0/22`, `2600:2d00:1:1::/64` | pools `:3000`, routing `:8443` | GFE proxy ranges for a global external Application Load Balancer with zonal `GCE_VM_IP_PORT` NEG backends—the topology this chart emits. The ext_proc callout arrives from the same ranges.                  |
+| `35.191.0.0/16`, `2600:2d00:1:b029::/64`                | same                           | Health-check probers for GFE-based load balancers (the Gateway's pool checks and the routing tier's TCP check on `:8443`).                                                                                   |
+| node CIDRs (auto-discovered)                            | pools `:3000`, routing `:8081` | kubelet liveness/readiness probes originate from the **node** IP, which no Google range covers. The template fails at render time if the range is unknown, rather than leaving every pod unready at rollout. |
+| sibling pool pods (label selector)                      | pools `:3000`                  | cross-pool proxying. The routing service cannot originate pool traffic.                                                                                                                                      |
 
 Both CIDR sets are discovered at deploy time (cluster subnetwork plus any node-pool subnets on Standard clusters); nothing needs setting by hand. To pin them, or to fall back to a pod-CIDR denylist:
 
@@ -42,8 +42,8 @@ Both CIDR sets are discovered at deploy time (cluster subnetwork plus any node-p
 # .k8s-adapter/helm/values.override.yaml
 global:
   networkPolicy:
-    strict: true                  # default; false = 0.0.0.0/0-except-pod-CIDR denylist
-    nodeCidrs: ["10.128.0.0/20"]  # normally discovered
+    strict: true # default; false = 0.0.0.0/0-except-pod-CIDR denylist
+    nodeCidrs: ["10.128.0.0/20"] # normally discovered
 ```
 
 The denylist exists for compatibility but is **not** a boundary for the dispatch secret: its edge is the pod CIDR, and VMs on the VPC, `hostNetwork` pods using node IPs, and pods in peered clusters all sit outside it while still being routable to `:8443`. The allowlist is the default because it is what actually closes that.
@@ -53,7 +53,7 @@ What you accept in exchange:
 1. Google publishes these ranges but guarantees nothing—new probers can appear without notification, and a future range addition would surface as unhealthy backends, not a warning.
 2. IPv6 ranges are included unconditionally (inert on single-stack clusters).
 3. The discovered node range is usually the whole cluster subnet, so any VM sharing that subnet keeps its reach—give the cluster its own subnet if that matters.
-4. The allowlist trusts the Google LB ranges wholesale; a network-level control cannot distinguish *your* load balancer's traffic from anything else sourced from those ranges.
+4. The allowlist trusts the Google LB ranges wholesale; a network-level control cannot distinguish _your_ load balancer's traffic from anything else sourced from those ranges.
 
 Neither posture governs **egress** (`policyTypes: [Ingress]`), so pool → Valkey/GCS/Artifact Registry/DNS traffic is unaffected. Standard clusters are created with `--enable-network-policy`; Autopilot always enforces it. `deploy` discovers the pod and node ranges and **aborts** if it can't—`--allow-no-network-policy` deploys without isolation, which disables everything in this section.
 
@@ -85,7 +85,7 @@ One asymmetry worth knowing: a **rolled-back** routing tier is pinned by tag rat
 
 ## Cache security
 
-Memorystore's own defaults are AUTH off and transit encryption off, and the chart's NetworkPolicies govern ingress to *pods* only—so a plaintext instance is readable **and writable** by any workload with VPC reachability. Writable matters: overwriting cached HTML/RSC is content injection into the site.
+Memorystore's own defaults are AUTH off and transit encryption off, and the chart's NetworkPolicies govern ingress to _pods_ only—so a plaintext instance is readable **and writable** by any workload with VPC reachability. Writable matters: overwriting cached HTML/RSC is content injection into the site.
 
 The adapter therefore creates instances **with AUTH + TLS** (`SERVER_AUTHENTICATION`); pods connect over `rediss://` with the AUTH string and server CA injected from the connection Secret. Because AUTH is creation-only on Memorystore, there are three config states:
 

--- a/fixtures/edge/app/edge-catchall/[[...slug]]/route.ts
+++ b/fixtures/edge/app/edge-catchall/[[...slug]]/route.ts
@@ -1,8 +1,5 @@
 export const runtime = "edge";
 
-export async function GET(
-  _request: Request,
-  { params }: { params: Promise<{ slug?: string[] }> },
-) {
+export async function GET(_request: Request, { params }: { params: Promise<{ slug?: string[] }> }) {
   return Response.json(await params);
 }

--- a/fixtures/edge/tsconfig.json
+++ b/fixtures/edge/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": false,
@@ -31,7 +27,5 @@
     "**/*.ts",
     "**/*.tsx"
   ],
-  "exclude": [
-    "node_modules"
-  ]
+  "exclude": ["node_modules"]
 }

--- a/fixtures/i18n-rewrite/package.json
+++ b/fixtures/i18n-rewrite/package.json
@@ -2,7 +2,6 @@
   "name": "adapter-k8s-i18n-rewrite-e2e-app",
   "version": "0.1.0",
   "private": true,
-  "packageManager": "npm@11.6.2",
   "scripts": {
     "build": "next build",
     "start": "next start"
@@ -18,5 +17,6 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "typescript": "^6"
-  }
+  },
+  "packageManager": "npm@11.6.2"
 }

--- a/fixtures/interception/package.json
+++ b/fixtures/interception/package.json
@@ -2,7 +2,6 @@
   "name": "adapter-k8s-interception-e2e-app",
   "version": "0.1.0",
   "private": true,
-  "packageManager": "npm@11.6.2",
   "scripts": {
     "build": "next build",
     "start": "next start"
@@ -18,5 +17,6 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "typescript": "^6"
-  }
+  },
+  "packageManager": "npm@11.6.2"
 }

--- a/fixtures/interception/tsconfig.json
+++ b/fixtures/interception/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -30,7 +26,5 @@
     "**/*.tsx",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": [
-    "node_modules"
-  ]
+  "exclude": ["node_modules"]
 }

--- a/fixtures/main/app/encoded-key/[key]/page.tsx
+++ b/fixtures/main/app/encoded-key/[key]/page.tsx
@@ -1,11 +1,7 @@
 import { connection } from "next/server";
 import { Suspense } from "react";
 
-async function EncodedKey({
-  params,
-}: {
-  params: Promise<{ key: string }>;
-}) {
+async function EncodedKey({ params }: { params: Promise<{ key: string }> }) {
   await connection();
   const { key } = await params;
   return (

--- a/fixtures/main/app/novel/[slug]/page.tsx
+++ b/fixtures/main/app/novel/[slug]/page.tsx
@@ -26,11 +26,7 @@ async function Work({ slug }: { slug: string }) {
   );
 }
 
-export default async function Page({
-  params,
-}: {
-  params: Promise<{ slug: string }>;
-}) {
+export default async function Page({ params }: { params: Promise<{ slug: string }> }) {
   const { slug } = await params;
   if (slug === "prerendered") {
     return null;

--- a/fixtures/main/next.config.ts
+++ b/fixtures/main/next.config.ts
@@ -34,9 +34,7 @@ const nextConfig: NextConfig = {
         // Service workers are mutable build artifacts: the browser must check for an update, but
         // an ETag should turn an unchanged check into a body-less 304. This local fixture locks the
         // same cache contract as Next's generated `_next/static/service-worker/*` output.
-        headers: [
-          { key: "Cache-Control", value: "public, max-age=0, must-revalidate" },
-        ],
+        headers: [{ key: "Cache-Control", value: "public, max-age=0, must-revalidate" }],
       },
     ];
   },

--- a/fixtures/pages/package.json
+++ b/fixtures/pages/package.json
@@ -2,7 +2,6 @@
   "name": "adapter-k8s-pages-e2e-app",
   "version": "0.1.0",
   "private": true,
-  "packageManager": "npm@11.6.2",
   "scripts": {
     "build": "next build",
     "start": "next start"
@@ -18,5 +17,6 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "typescript": "^6"
-  }
+  },
+  "packageManager": "npm@11.6.2"
 }

--- a/fixtures/pages/tsconfig.json
+++ b/fixtures/pages/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": false,
@@ -18,13 +14,6 @@
     "isolatedModules": true,
     "jsx": "react-jsx"
   },
-  "include": [
-    "next-env.d.ts",
-    "**/*.mts",
-    "**/*.ts",
-    "**/*.tsx"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["next-env.d.ts", "**/*.mts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
 }

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -644,7 +644,6 @@ export function assertStagedWithin(stageDir: string, absDest: string, destRelati
   }
 }
 
-
 /**
  * `config/` inside a build context is the ADAPTER'S reserved namespace — the fresh
  * routing/pool/static manifests are written there by this build, and the routing image's
@@ -667,10 +666,7 @@ function isReservedContextDest(relDest: string): boolean {
  * files and every PPR fs-mirror seed silently missed in containers (measured:
  * resume-data-cache pods) while local runs — cwd = the real build dir — worked.
  */
-export function prerenderSiblingFiles(asset: {
-  filePath: string;
-  prerender?: boolean;
-}): string[] {
+export function prerenderSiblingFiles(asset: { filePath: string; prerender?: boolean }): string[] {
   if (!asset.prerender) return [];
   if (!/(^|[/\\])server[/\\](app|pages)[/\\]/.test(asset.filePath)) return [];
   if (!asset.filePath.endsWith(".html")) return [];
@@ -2527,7 +2523,13 @@ export function createK8sAdapter(userConfig?: K8sAdapterConfig): NextAdapter {
             await resolveAndCopyExternals(nextNodeModules, nextNodeModulesDest);
             // Same externals-dependency rule as the pool contexts (node middleware may pull
             // in instrumentation-adjacent externals through its bundle).
-            await stageExternalsDependencies(projectDir, nextNodeModules, "routing-service", false, path.join(projectDir, routingServiceContextDir));
+            await stageExternalsDependencies(
+              projectDir,
+              nextNodeModules,
+              "routing-service",
+              false,
+              path.join(projectDir, routingServiceContextDir),
+            );
           }
           if (existsSync(chunksDir)) {
             // Replace the whole chunk set (not merge) so a stale prior build's chunks can't linger

--- a/src/cli/container-runtime.ts
+++ b/src/cli/container-runtime.ts
@@ -71,7 +71,11 @@ async function canBuild(candidate: ContainerCli): Promise<boolean> {
         "",
       ];
   for (const host of hosts) {
-    const res = await execCapture("buildctl", ["debug", "workers"], (host ? { env: { BUILDKIT_HOST: host } } : {})).catch(() => null);
+    const res = await execCapture(
+      "buildctl",
+      ["debug", "workers"],
+      host ? { env: { BUILDKIT_HOST: host } } : {},
+    ).catch(() => null);
     if (res && res.exitCode === 0) return true;
   }
   return false;

--- a/src/emit/templates/generic-gateway.ts
+++ b/src/emit/templates/generic-gateway.ts
@@ -71,8 +71,10 @@ export function renderGenericGateway({
   // listener (a listener carries at most one hostname) and therefore cannot share a merged
   // data plane — acceptable: lanes are single-host by construction.
   const singleHostname =
-    hosts.length === 1 ? `
-      hostname: "${hosts[0]!.hostname}"` : "";
+    hosts.length === 1
+      ? `
+      hostname: "${hosts[0]!.hostname}"`
+      : "";
   let listeners = `    - name: http${singleHostname}
       protocol: HTTP
       port: 80

--- a/src/emit/templates/routing-manifest-configmap.ts
+++ b/src/emit/templates/routing-manifest-configmap.ts
@@ -1,5 +1,8 @@
 // src/emit/templates/routing-manifest-configmap.ts
-import { sanitizeK8sName, routingManifestSnapshotName as routingManifestSnapshotNameLocal } from "./utils.js";
+import {
+  sanitizeK8sName,
+  routingManifestSnapshotName as routingManifestSnapshotNameLocal,
+} from "./utils.js";
 import { renderConfigMap } from "./configmap.js";
 
 /**

--- a/src/pool-server/dispatch.ts
+++ b/src/pool-server/dispatch.ts
@@ -2357,7 +2357,9 @@ export function createDispatcher(options: DispatcherOptions) {
             "http://localhost",
           ).pathname;
           const storedKey = storedConcrete === "/" ? "/index" : storedConcrete;
-          const stored = await platformCache.readStored(storedKey, { kind: "APP_PAGE" }).catch(() => null);
+          const stored = await platformCache
+            .readStored(storedKey, { kind: "APP_PAGE" })
+            .catch(() => null);
           const sv = stored?.value as
             | { kind?: string; html?: unknown; headers?: Record<string, string>; status?: number }
             | undefined;
@@ -2749,7 +2751,7 @@ export function createDispatcher(options: DispatcherOptions) {
             res,
             bufferedBody,
             basePath,
-              notFoundIsPrerendered,
+            notFoundIsPrerendered,
           );
           return;
         }
@@ -2808,7 +2810,7 @@ export function createDispatcher(options: DispatcherOptions) {
                 res,
                 undefined,
                 basePath,
-              notFoundIsPrerendered,
+                notFoundIsPrerendered,
               );
               return;
             }
@@ -3383,7 +3385,10 @@ export function createDispatcher(options: DispatcherOptions) {
             // A STORED entry's postponed token injects even when the SEED is stale — the
             // stored entry passed the handler's own tag check. The disk-shell path keeps
             // the shellUsable gate.
-            if (!isDynamicRsc && (entryPostponed !== undefined || (shellUsable && shellAvailable))) {
+            if (
+              !isDynamicRsc &&
+              (entryPostponed !== undefined || (shellUsable && shellAvailable))
+            ) {
               const meta = ((req as any)[NEXT_REQUEST_META] as Record<string, unknown>) ?? {};
               // The materialized entry's token wins over the build token — it carries the
               // regenerated Resume Data Cache.
@@ -3573,19 +3578,19 @@ export function createDispatcher(options: DispatcherOptions) {
               // (no Suspense boundary above the params access) is rendered dynamically by
               // upstream, and running it non-minimal made Next resume a fallback shell upstream
               // deliberately skips (app-dir/fallback-shells).
+              // Shell-bearing templates (handlerPprInfo) go non-minimal ONLY in emulate
+              // mode, where the entrypoint's own filesystem cache holds the build shells
+              // and Next resumes internally. Under a SHARED cache the entrypoints are
+              // per-request render modules with no route-shell orchestration (measured:
+              // k3d sub-shell-generation served "(runtime)" layouts), so those routes now
+              // take the same minimal+inject path as the no-classic-handler case below.
+              // Shell-LESS root-param templates still need non-minimal in both modes (N16).
+              // A VERIFIED preview / on-demand-revalidate request always runs NON-minimal:
+              // next start serves these through the full server, so getStaticProps sees
+              // revalidateReason 'on-demand' and the fresh entry persists through the
+              // registered cache handler. The minimal rungs exist for platform-cache
+              // emulation, which must never intercept an authenticated revalidation.
               (
-                // Shell-bearing templates (handlerPprInfo) go non-minimal ONLY in emulate
-                // mode, where the entrypoint's own filesystem cache holds the build shells
-                // and Next resumes internally. Under a SHARED cache the entrypoints are
-                // per-request render modules with no route-shell orchestration (measured:
-                // k3d sub-shell-generation served "(runtime)" layouts), so those routes now
-                // take the same minimal+inject path as the no-classic-handler case below.
-                // Shell-LESS root-param templates still need non-minimal in both modes (N16).
-                // A VERIFIED preview / on-demand-revalidate request always runs NON-minimal:
-                // next start serves these through the full server, so getStaticProps sees
-                // revalidateReason 'on-demand' and the fresh entry persists through the
-                // registered cache handler. The minimal rungs exist for platform-cache
-                // emulation, which must never intercept an authenticated revalidation.
                 isVerifiedPreviewRequest(req) ||
                 ((entrypointOwnsPprShell ||
                   // partialPrefetching builds get NO injection (the partialFallback serving

--- a/src/pool-server/valkey-cache/build-seed-index.ts
+++ b/src/pool-server/valkey-cache/build-seed-index.ts
@@ -104,9 +104,8 @@ export function buildSeedSources(assets: StaticAssetRecord[]): Map<string, SeedS
 // bundled into next.config.cacheHandler which the edge middleware graph pulls in. The seed
 // lookup only ever RUNS in the Node pool; in the edge bundle this is dead code that parses.
 function builtin<T>(id: string): T {
-  const getBuiltin = (
-    globalThis as { process?: { getBuiltinModule?: (id: string) => unknown } }
-  ).process?.getBuiltinModule;
+  const getBuiltin = (globalThis as { process?: { getBuiltinModule?: (id: string) => unknown } })
+    .process?.getBuiltinModule;
   if (!getBuiltin) {
     throw new Error(`[valkey-cache] process.getBuiltinModule unavailable loading ${id}`);
   }
@@ -179,7 +178,8 @@ function fsMirrorSeed(appRoot: string, cacheKey: string, _ctx?: SeedLookupCtx): 
   const fs = builtin<typeof import("node:fs")>("node:fs");
   const path = builtin<typeof import("node:path")>("node:path");
   const base = path.join(appRoot, ".next", "server", "app", ...cacheKey.split("/").filter(Boolean));
-  const htmlAbs = cacheKey === "/" ? path.join(appRoot, ".next", "server", "app", "index.html") : `${base}.html`;
+  const htmlAbs =
+    cacheKey === "/" ? path.join(appRoot, ".next", "server", "app", "index.html") : `${base}.html`;
   if (!fs.existsSync(htmlAbs)) return null;
   const stat = fs.statSync(htmlAbs);
   const html = fs.readFileSync(htmlAbs, "utf8");

--- a/src/pool-server/valkey-cache/incremental-cache-handler.ts
+++ b/src/pool-server/valkey-cache/incremental-cache-handler.ts
@@ -496,7 +496,9 @@ export class ValkeyIncrementalCacheHandler {
       const seed = await this.seedLookup(cacheKey, {
         ...(ctx.kind !== undefined ? { kind: ctx.kind } : {}),
         ...(ctx.isFallback !== undefined ? { isFallback: ctx.isFallback } : {}),
-        ...(ctx.isRoutePPREnabled !== undefined ? { isRoutePPREnabled: ctx.isRoutePPREnabled } : {}),
+        ...(ctx.isRoutePPREnabled !== undefined
+          ? { isRoutePPREnabled: ctx.isRoutePPREnabled }
+          : {}),
       });
       if (!seed) return null;
       const softTags = ctx.softTags ?? ctx.tags ?? [];

--- a/src/providers/generic.ts
+++ b/src/providers/generic.ts
@@ -156,8 +156,7 @@ export const genericProvider: ProviderAdapter = {
           namespace: generic?.gatewayNamespace ?? "envoy-gateway-system",
           labels: {
             "app.kubernetes.io/name": "envoy",
-            "gateway.envoyproxy.io/owning-gatewayclass":
-              generic?.gateway?.className ?? "eg",
+            "gateway.envoyproxy.io/owning-gatewayclass": generic?.gateway?.className ?? "eg",
           },
         },
       ],

--- a/test/deploy-tests-manifest.adapter-k8s.json
+++ b/test/deploy-tests-manifest.adapter-k8s.json
@@ -22,16 +22,12 @@
         "Deploy and build both succeed here — only the assertion diverges — so this is a",
         "case-level exclusion rather than a file exclusion."
       ],
-      "failed": [
-        "expire-time should do a blocking revalidation when the cache entry has expired"
-      ]
+      "failed": ["expire-time should do a blocking revalidation when the cache entry has expired"]
     }
   },
   "rules": {
     "include": [],
-    "exclude": [
-      "test/e2e/app-dir/next-dist-client-esm-import/next-dist-client-esm-import.test.ts"
-    ]
+    "exclude": ["test/e2e/app-dir/next-dist-client-esm-import/next-dist-client-esm-import.test.ts"]
   },
   "_excludeReasons": {
     "test/e2e/app-dir/next-dist-client-esm-import/next-dist-client-esm-import.test.ts": [

--- a/tests/adapter-next-runtime-deps.test.ts
+++ b/tests/adapter-next-runtime-deps.test.ts
@@ -81,15 +81,25 @@ describe("staging next's runtime dependency closure", () => {
     seedApp();
     const routingContext = path.join(projectDir, ".k8s-adapter", "routing-service", "context");
 
-    const result = await stageNextRuntimeDependencies(projectDir, "routing-service", false, undefined, {
-      stageDir: routingContext,
-    });
+    const result = await stageNextRuntimeDependencies(
+      projectDir,
+      "routing-service",
+      false,
+      undefined,
+      {
+        stageDir: routingContext,
+      },
+    );
 
     expect(result.staged).toContain("@swc/helpers");
     expect(
-      existsSync(path.join(routingContext, "node_modules/@swc/helpers/_/_interop_require_default.js")),
+      existsSync(
+        path.join(routingContext, "node_modules/@swc/helpers/_/_interop_require_default.js"),
+      ),
     ).toBe(true);
-    expect(existsSync(path.join(routingContext, "node_modules/styled-jsx/package.json"))).toBe(true);
+    expect(existsSync(path.join(routingContext, "node_modules/styled-jsx/package.json"))).toBe(
+      true,
+    );
   });
 
   it("stages @swc/helpers so the edge sandbox can load in the container", async () => {
@@ -126,9 +136,13 @@ describe("staging next's runtime dependency closure", () => {
       { name: "react-dom", version: "19.2.0", dependencies: { scheduler: "^0.27.0" } },
       { "client.js": "module.exports = {};" },
     );
-    writePkg(path.join(nm, "scheduler"), { name: "scheduler", version: "0.27.0" }, {
-      "index.js": "module.exports = {};",
-    });
+    writePkg(
+      path.join(nm, "scheduler"),
+      { name: "scheduler", version: "0.27.0" },
+      {
+        "index.js": "module.exports = {};",
+      },
+    );
     writePkg(path.join(nm, "react"), { name: "react", version: "19.2.0" });
 
     await stageNextRuntimeDependencies(projectDir, "ssr");

--- a/tests/cli/deploy.test.ts
+++ b/tests/cli/deploy.test.ts
@@ -94,7 +94,10 @@ describe("refreshFetchCacheStaging", () => {
     });
     expect(
       existsSync(
-        path.join(projectDir, ".k8s-adapter/output/pools/ssr/context/.k8s-adapter/fetch-cache-seed"),
+        path.join(
+          projectDir,
+          ".k8s-adapter/output/pools/ssr/context/.k8s-adapter/fetch-cache-seed",
+        ),
       ),
     ).toBe(false);
   });
@@ -113,11 +116,7 @@ describe("refreshFetchCacheStaging", () => {
           containerStrategy: "traced-assets",
         }),
       ).toThrow(/distDir/);
-      expect(
-        existsSync(
-          path.join(projectDir, ".k8s-adapter/output/pools/ssr/context"),
-        ),
-      ).toBe(true);
+      expect(existsSync(path.join(projectDir, ".k8s-adapter/output/pools/ssr/context"))).toBe(true);
     } finally {
       rmSync(victim, { recursive: true, force: true });
     }

--- a/tests/emit/per-build-routing-manifest.test.ts
+++ b/tests/emit/per-build-routing-manifest.test.ts
@@ -56,8 +56,7 @@ describe("per-build routing manifest ConfigMap", () => {
       buildId: "bms7bbb",
       imageRegistry: "r/x",
     });
-    const name = (y: string) =>
-      y.match(/configMap:\s*\n(?:\s*#[^\n]*\n)*\s*name: (\S+)/)?.[1];
+    const name = (y: string) => y.match(/configMap:\s*\n(?:\s*#[^\n]*\n)*\s*name: (\S+)/)?.[1];
     expect(name(a)).toBeTruthy();
     expect(name(a)).not.toBe(name(b));
   });

--- a/tests/emit/templates/utils.test.ts
+++ b/tests/emit/templates/utils.test.ts
@@ -38,7 +38,7 @@ describe("sanitizeK8sName", () => {
   it("strips trailing hyphens introduced by the 63-char boundary", () => {
     const result = sanitizeK8sName("valid-name-" + "x".repeat(60) + "-suffix");
     expect(result.length).toBeLessThanOrEqual(63);
-    expect(result.endsWith('-')).toBe(false);
+    expect(result.endsWith("-")).toBe(false);
   });
 
   it("handles all-special-character input", () => {

--- a/tests/pool-server/dispatch-materialization.test.ts
+++ b/tests/pool-server/dispatch-materialization.test.ts
@@ -94,7 +94,12 @@ function baseOptions(over: Record<string, unknown> = {}) {
   } as any;
 }
 
-const route = { kind: "route", pool: "ssr", matchedPathname: "/ppr-page", routeMatches: null } as any;
+const route = {
+  kind: "route",
+  pool: "ssr",
+  matchedPathname: "/ppr-page",
+  routeMatches: null,
+} as any;
 
 describe("PPR serve ladder reads the platform cache", () => {
   it("serves a materialized POSTPONED entry's html and injects ITS postponed token", async () => {

--- a/tests/pool-server/dispatch-not-found-prerender.test.ts
+++ b/tests/pool-server/dispatch-not-found-prerender.test.ts
@@ -142,11 +142,9 @@ describe("deploy-mode 404: prerendered /_not-found preferred over handler invoca
         await a.handler(a.req, { writeHead: () => {}, end: () => {} });
       }) as any,
     } as any);
-    await dispatcher.dispatch(
-      mockReq("/missing.png", { "sec-fetch-dest": "image" }),
-      mockRes(),
-      { kind: "not-found" } as any,
-    );
+    await dispatcher.dispatch(mockReq("/missing.png", { "sec-fetch-dest": "image" }), mockRes(), {
+      kind: "not-found",
+    } as any);
     expect(seenHeaders).toEqual(["image"]);
   });
 

--- a/tests/pool-server/dispatch-root-shell-injection.test.ts
+++ b/tests/pool-server/dispatch-root-shell-injection.test.ts
@@ -16,9 +16,17 @@ function mockReq(url: string): any {
 }
 function mockRes(): any {
   return {
-    headersSent: false, writableEnded: false,
-    setHeader: vi.fn(), getHeaderNames: () => [], removeHeader: vi.fn(),
-    writeHead: vi.fn(), write: vi.fn(), end: vi.fn(), on: vi.fn(), once: vi.fn(), emit: vi.fn(),
+    headersSent: false,
+    writableEnded: false,
+    setHeader: vi.fn(),
+    getHeaderNames: () => [],
+    removeHeader: vi.fn(),
+    writeHead: vi.fn(),
+    write: vi.fn(),
+    end: vi.fn(),
+    on: vi.fn(),
+    once: vi.fn(),
+    emit: vi.fn(),
   };
 }
 const handlerLoader = {
@@ -34,16 +42,19 @@ for (const mp of ["/", "/index"]) {
       handlerLoader,
       poolName: "ssr",
       buildId: "b1",
-      staticAssets: [
-        { pathname: "/", filePath: shellFile, prerender: true, ppr: true },
-      ] as any,
+      staticAssets: [{ pathname: "/", filePath: shellFile, prerender: true, ppr: true }] as any,
       pprRoutes: { "/": { postponedState: "tok", fallbackFilePath: shellFile } } as any,
       incrementalCacheShared: true,
-      localHandlerInvoker: (async (a: any) => { calls.push(a); }) as any,
+      localHandlerInvoker: (async (a: any) => {
+        calls.push(a);
+      }) as any,
     } as any);
     const req = mockReq("/");
     await dispatcher.dispatch(req, mockRes(), {
-      kind: "route", matchedPathname: mp, pool: "ssr", routeMatches: null,
+      kind: "route",
+      matchedPathname: mp,
+      pool: "ssr",
+      routeMatches: null,
     } as any);
     expect(calls).toHaveLength(1);
     const meta = (req as any)[Symbol.for("NextInternalRequestMeta")];

--- a/tests/pool-server/dispatch.test.ts
+++ b/tests/pool-server/dispatch.test.ts
@@ -578,7 +578,11 @@ describe("createDispatcher", () => {
       // invokeStatus tells the RENDER it is a 404 (Next then emits the default not-found
       // metadata — robots noindex; metadata-navigation "root not-found with default
       // metadata"); forceStatus alone only rewrites the status after the fact.
-      expect.objectContaining({ matchedPathname: "/docs/404", forceStatus: 404, invokeStatus: 404 }),
+      expect.objectContaining({
+        matchedPathname: "/docs/404",
+        forceStatus: 404,
+        invokeStatus: 404,
+      }),
     );
   });
 

--- a/tests/pool-server/route-matches-sanitization.test.ts
+++ b/tests/pool-server/route-matches-sanitization.test.ts
@@ -37,7 +37,7 @@ describe("extractRouteParams sentinel filtering (the Phase-2 compensation)", () 
     // removed is therefore also removed here, which is why an UNSANITIZED Phase-2 header
     // cannot produce params Phase 1 would not have produced.
     const phase1Drops = (value: string) => /^\$nxtP[^/]*$/.test(value);
-    const consumerDrops = (value: string) => value.startsWith('$nxtP');
+    const consumerDrops = (value: string) => value.startsWith("$nxtP");
     for (const value of [
       "$nxtPid",
       "$nxtPslug",

--- a/tests/pool-server/valkey-cache/build-seed-index.test.ts
+++ b/tests/pool-server/valkey-cache/build-seed-index.test.ts
@@ -101,9 +101,7 @@ describe("createBuildSeedLookup", () => {
   });
 
   it("declines a prerender with no .rsc sibling rather than emit a half-usable entry", async () => {
-    writeManifest([
-      asset({ pathname: "/no-rsc", filePath: ".next/server/app/no-rsc.html" }),
-    ]);
+    writeManifest([asset({ pathname: "/no-rsc", filePath: ".next/server/app/no-rsc.html" })]);
     stage(".next/server/app/no-rsc.html", "<html>x</html>");
     const lookup = createBuildSeedLookup({ appRoot });
     expect(await lookup("/no-rsc")).toBeNull();
@@ -285,7 +283,10 @@ describe("filesystem-mirror seeds (PPR shells, segments — sub-shell-generation
     ]);
     stage(".next/server/app/covered.html", "<html>covered</html>");
     stage(".next/server/app/covered.rsc", "rsc");
-    stage(".next/server/app/covered.meta", JSON.stringify({ headers: { "x-next-cache-tags": "disk-tag" } }));
+    stage(
+      ".next/server/app/covered.meta",
+      JSON.stringify({ headers: { "x-next-cache-tags": "disk-tag" } }),
+    );
     const lookup = createBuildSeedLookup({ appRoot });
 
     const entry = await lookup("/covered", { kind: "APP_PAGE" });

--- a/tests/pool-server/valkey-cache/incremental-cache-handler.test.ts
+++ b/tests/pool-server/valkey-cache/incremental-cache-handler.test.ts
@@ -917,7 +917,11 @@ describe("build-seed fallback: an empty Valkey behaves like next start's warm fi
     const h = new ValkeyIncrementalCacheHandler({ client, buildId: "tagmerge1", now: () => 1000 });
     await h.set(
       "sharedfetchkey",
-      { kind: "FETCH", data: { body: "x", headers: {}, status: 200 }, revalidate: 31536000 } as never,
+      {
+        kind: "FETCH",
+        data: { body: "x", headers: {}, status: 200 },
+        revalidate: 31536000,
+      } as never,
       { tags: ["other-page-tag"] },
     );
 


### PR DESCRIPTION
- Format the repository with the existing `oxfmt` configuration.
- Add the formatting check to GitHub Actions.
- Keep the mechanical formatting baseline separate from functional changes.