### PR TITLE
Support configurable Kubernetes namespaces

### DIFF
--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -1740,23 +1740,6 @@ export function createK8sAdapter(userConfig?: K8sAdapterConfig): NextAdapter {
           `[adapter-k8s] Unsafe namespace in .k8s-adapter/infrastructure.json: ${(err as Error).message}`,
         );
       }
-      // The namespace feeds ONLY the ext_proc extension-chain authority
-      // (`<release>-routing-service.<namespace>.svc.cluster.local`, extension-chain.ts)
-      // — every kubectl/helm call in the CLI pins the literal K8S_NAMESPACE, and init
-      // binds Workload Identity to default/<release>-deploy-sa. A non-default value
-      // here would land workloads in "default" while the GXLB callout targets the
-      // other namespace: every edge callout fails, and diagnostics chase the "wrong"
-      // resources. Fail fast at build time instead of emitting a skewed chain.
-      if (namespace !== K8S_NAMESPACE) {
-        throw new Error(
-          `[adapter-k8s] Unsupported namespace "${namespace}" in ` +
-            `.k8s-adapter/infrastructure.json: this adapter version deploys only to the ` +
-            `"${K8S_NAMESPACE}" namespace (init binds Workload Identity to ` +
-            `${K8S_NAMESPACE}/<release>-deploy-sa and every kubectl/helm call pins it). ` +
-            `Remove "namespace" from infrastructure.json.`,
-        );
-      }
-
       const configuredRegistry = infra.containerRegistry ?? process.env.IMAGE_REGISTRY;
       if (configuredRegistry !== undefined) {
         try {
@@ -2551,6 +2534,7 @@ export function createK8sAdapter(userConfig?: K8sAdapterConfig): NextAdapter {
           // provider-specific decisions (kube context, digest resolution, NetworkPolicy
           // discovery) on that basis.
           provider: resolveProvider(cfg).name,
+          namespace,
           // The chart bakes this registry into image references; deploy refuses a chart whose
           // registry does not match the infrastructure it is deploying with.
           containerRegistry: imageRegistry,

--- a/src/cli/deploy.ts
+++ b/src/cli/deploy.ts
@@ -57,15 +57,11 @@ import {
   findBuildIdNameCollision,
   findEmittedNameCollision,
   assertSafeImageRegistry,
-  assertSafeNamespace,
   assertSafeProbePath,
   assertSafeProjectId,
   assertSafeRegion,
   poolResourceNames,
-  // init binds Workload Identity to [default/<release>-deploy-sa]; the release lives
-  // in the literal "default" namespace. Pin it on every kubectl/helm call instead of
-  // trusting whatever namespace the operator's context happens to have.
-  K8S_NAMESPACE,
+  resolveK8sNamespace,
 } from "../emit/templates/utils.js";
 import { sanitizeForTerminal } from "./terminal.js";
 import { resolveContainerCli, targetPlatform } from "./container-runtime.js";
@@ -172,17 +168,21 @@ function promptConfirmation(question: string): Promise<string> {
  * Throws (never returns a guess) when the cluster cannot be read, when pools disagree, or
  * when the selected build has no Deployment.
  */
-export async function discoverServingBuildId(releaseName: string): Promise<string> {
+export async function discoverServingBuildId(
+  releaseName: string,
+  configuredNamespace?: string,
+): Promise<string> {
+  const namespace = resolveK8sNamespace(configuredNamespace);
   const REPAIR =
     `Repair deploy state before deploying: run \`npx adapter-k8s doctor\`, then either ` +
     `restore .k8s-adapter/state.json or fix access to the ${releaseName}-adapter-state ` +
-    `ConfigMap in namespace ${K8S_NAMESPACE}.`;
+    `ConfigMap in namespace ${namespace}.`;
 
   const svcResult = await execCapture("kubectl", [
     "get",
     "svc",
     "-n",
-    K8S_NAMESPACE,
+    namespace,
     "-l",
     `app.kubernetes.io/name=${releaseName}`,
     "-o",
@@ -210,7 +210,7 @@ export async function discoverServingBuildId(releaseName: string): Promise<strin
   if (labels.size === 0) {
     throw new Error(
       `Deploy state could not be determined and no active pool Service in namespace ` +
-        `${K8S_NAMESPACE} carries an app.kubernetes.io/version selector, so the live build ` +
+        `${namespace} carries an app.kubernetes.io/version selector, so the live build ` +
         `is unknown. Refusing to deploy as if this were a first deploy. ${REPAIR}`,
     );
   }
@@ -227,7 +227,7 @@ export async function discoverServingBuildId(releaseName: string): Promise<strin
     "get",
     "deployments",
     "-n",
-    K8S_NAMESPACE,
+    namespace,
     "-l",
     `app.kubernetes.io/name=${releaseName},app.kubernetes.io/version=${label},` +
       `app.kubernetes.io/component!=routing-service`,
@@ -737,6 +737,7 @@ export function buildHelmUpgradeArgs(options: {
   buildId: string;
   registry: string;
   previousBuildId: string | null;
+  namespace?: string;
   overridesFile?: string;
   podCidrs?: string | null;
   /** S22: node/subnet range(s) for the strict posture's kubelet allowance. */
@@ -756,12 +757,14 @@ export function buildHelmUpgradeArgs(options: {
     buildId,
     registry,
     previousBuildId,
+    namespace: configuredNamespace,
     overridesFile,
     podCidrs,
     nodeCidrs,
     imageDigests,
     poolHealthCheckPath,
   } = options;
+  const namespace = resolveK8sNamespace(configuredNamespace);
   // H2: these values land in `helm --set` assignments — reject helm metacharacters
   // (","  "\"  quotes) before they can split one assignment into several. The buildId
   // comes from generateBuildId()/git refs and the registry from infrastructure.json.
@@ -781,7 +784,7 @@ export function buildHelmUpgradeArgs(options: {
     // The release lives in the namespace init binds Workload Identity to — pin it rather
     // than installing into whatever namespace the operator's context happens to have.
     "--namespace",
-    "default",
+    namespace,
     "--create-namespace",
     "--set",
     `global.image.tag=${buildId}`,
@@ -1118,22 +1121,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
   // assignments / docker tags (containerRegistry) — validate before any use.
   if (infra.projectId) assertSafeProjectId(infra.projectId);
   if (infra.region) assertSafeRegion(infra.region);
-  if (infra.namespace) assertSafeNamespace(infra.namespace);
-  // Same fail-fast as build time (adapter.ts): every kubectl/helm call below pins
-  // K8S_NAMESPACE, but the build-time extension chain derives the ext_proc authority
-  // from infra.namespace — honoring any other value would put the workloads in
-  // "default" while the GXLB callout targets the other namespace, failing every edge
-  // callout. Reject instead of deploying skewed. (Deploy-time too, not just build
-  // time: --skip-build deploys ship a chart built elsewhere, possibly before this
-  // guard existed.)
-  if (infra.namespace !== undefined && infra.namespace !== K8S_NAMESPACE) {
-    throw new Error(
-      `Unsupported namespace "${infra.namespace}" in .k8s-adapter/infrastructure.json: ` +
-        `this adapter version deploys only to the "${K8S_NAMESPACE}" namespace (init binds ` +
-        `Workload Identity to ${K8S_NAMESPACE}/<release>-deploy-sa and every kubectl/helm ` +
-        `call pins it). Remove "namespace" from infrastructure.json.`,
-    );
-  }
+  const namespace = resolveK8sNamespace(infra.namespace);
   if (infra.containerRegistry) assertSafeImageRegistry(infra.containerRegistry);
   // Without a registry, docker tags and the helm --set image registry can't be formed —
   // fail with a pointer to the fix instead of a raw TypeError deep in the deploy.
@@ -1189,6 +1177,18 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
         `(and fail to authenticate against a registry this cluster cannot reach).\n` +
         `${process.env.ADAPTER_K8S_CONFIG ? `You are using ADAPTER_K8S_CONFIG=${process.env.ADAPTER_K8S_CONFIG}; the output directory is shared between variants.\n` : ""}` +
         `Re-run without --skip-build so the chart is emitted for this target.`,
+    );
+  }
+  // Build metadata predating namespace support has no field and therefore targets the
+  // historical default namespace.
+  const builtNamespace = resolveK8sNamespace(metadata.namespace);
+  if (builtNamespace !== namespace) {
+    throw new Error(
+      `The build output in .k8s-adapter/output was emitted for namespace ` +
+        `"${builtNamespace}", but this deploy targets "${namespace}". The ext_proc authority ` +
+        `is namespace-qualified at build time, so deploying this chart would make routing ` +
+        `callouts target the wrong Service. Re-run without --skip-build so the chart is ` +
+        `emitted for this target.`,
     );
   }
 
@@ -1455,7 +1455,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
         "secret",
         `${releaseName}-valkey`,
         "-n",
-        K8S_NAMESPACE,
+        namespace,
         "--ignore-not-found",
       ]);
       if (secretDelete.stdout.trim())
@@ -1632,7 +1632,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
     state = await readState(projectDir).catch(() => null);
   } else {
     try {
-      state = await readState(projectDir, releaseName);
+      state = await readState(projectDir, releaseName, { namespace });
     } catch (err) {
       if (!(err instanceof StateUnavailableError)) throw err;
       stateUnavailable = err.message;
@@ -1649,7 +1649,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
     console.warn(
       `\n  ! Committed deploy state could not be determined:\n    ${sanitizeForTerminal(stateUnavailable)}`,
     );
-    previousBuildId = await discoverServingBuildId(releaseName);
+    previousBuildId = await discoverServingBuildId(releaseName, namespace);
     console.warn(
       `  ! Recovered the currently-serving build "${previousBuildId}" from the active ` +
         `Service selector. Proceeding with it as the previous build — its recorded CDN tag ` +
@@ -1729,6 +1729,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
     buildId,
     registry: infra.containerRegistry,
     previousBuildId,
+    namespace,
     overridesFile,
     podCidrs: podCidr,
     nodeCidrs: nodeCidr,
@@ -1832,7 +1833,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
           "deployment",
           poolPrevName,
           "-n",
-          K8S_NAMESPACE,
+          namespace,
           "--ignore-not-found",
           "-o",
           // N66: one probe, one round trip — every field the retained manifest must
@@ -1897,7 +1898,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
             "service",
             activeServiceName,
             "-n",
-            K8S_NAMESPACE,
+            namespace,
             "--ignore-not-found",
             "-o",
             "name",
@@ -2055,7 +2056,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
   // revert the edge IMAGE — silently, with the degradation recorded nowhere.
   let unretainedManifestBuild: string | null = null;
   if (!dryRun) {
-    const retention = await retainLiveRoutingManifest(releaseName);
+    const retention = await retainLiveRoutingManifest(releaseName, namespace);
     if (retention.status === "failed") {
       if (!allowUnretainedManifest) {
         throw new Error(
@@ -2095,7 +2096,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
     const keepAnnotation = "helm.sh/resource-policy=keep";
     if (dryRun) {
       console.log(
-        `    [dry-run] kubectl annotate secret ${legacySecret} -n ${K8S_NAMESPACE} ` +
+        `    [dry-run] kubectl annotate secret ${legacySecret} -n ${namespace} ` +
           `${keepAnnotation} --overwrite (if it exists)`,
       );
     } else {
@@ -2104,7 +2105,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
         "secret",
         legacySecret,
         "-n",
-        K8S_NAMESPACE,
+        namespace,
         "--ignore-not-found",
         "-o",
         "name",
@@ -2126,7 +2127,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
           "secret",
           legacySecret,
           "-n",
-          K8S_NAMESPACE,
+          namespace,
           keepAnnotation,
           "--overwrite",
         ]);
@@ -2181,6 +2182,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
     try {
       await revertRoutingServiceToBuild({
         releaseName,
+        namespace,
         targetBuildId: previousBuildId,
         registry: infra.containerRegistry,
         targetImageDigest: state?.routingImageDigests?.[previousBuildId],
@@ -2214,7 +2216,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
       `  The edge (ext_proc) is running build ${buildId}'s middleware and routing manifest ` +
         `while the pools serve ${previousBuildId}. Mismatched routes fall back to pool-local ` +
         `re-resolution (invariant 1), but edge middleware is the NEW build's until repaired:`,
-      `    kubectl -n ${K8S_NAMESPACE} set image deployment/` +
+      `    kubectl -n ${namespace} set image deployment/` +
         `${routingServiceDeploymentName(releaseName)} routing-service=` +
         `${infra.containerRegistry}/routing-service:${previousBuildId}`,
     ];
@@ -2228,7 +2230,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
       "httproute",
       `${releaseName}-routes`,
       "-n",
-      K8S_NAMESPACE,
+      namespace,
       "-o",
       "jsonpath={.spec.rules[*].filters[*].extensionRef.kind}",
     ]);
@@ -2237,7 +2239,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
     } else {
       console.warn(
         "  ! Could not confirm the Cloud CDN filter on the HTTPRoute (non-fatal). " +
-          `Inspect with: kubectl get httproute ${releaseName}-routes -o yaml`,
+          `Inspect with: kubectl get httproute ${releaseName}-routes -n ${namespace} -o yaml`,
       );
     }
   }
@@ -2263,7 +2265,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
       "get",
       "deployments",
       "-n",
-      K8S_NAMESPACE,
+      namespace,
       "-l",
       `app.kubernetes.io/name=${releaseName},app.kubernetes.io/version=${safeBuildId}`,
       "-o",
@@ -2284,7 +2286,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
         "status",
         `deployment/${deployName}`,
         "-n",
-        K8S_NAMESPACE,
+        namespace,
         KUBECTL_ROLLOUT_TIMEOUT,
       ]);
       // The pod-health gate below is the real readiness gate, but don't walk into it on
@@ -2300,7 +2302,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
               `NOT switched — the previous build's pools are still serving.`,
             // L14: kubectl rollout output carries controller/admission messages.
             `${sanitizeForTerminal((rollout.stderr || rollout.stdout).trim())}`,
-            `Inspect: kubectl logs deployment/${deployName} -n ${K8S_NAMESPACE} --tail=40`,
+            `Inspect: kubectl logs deployment/${deployName} -n ${namespace} --tail=40`,
             ...edgeStatusLines(edge),
           ].join("\n"),
         );
@@ -2317,7 +2319,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
       "deployment",
       routingDeploy,
       "-n",
-      K8S_NAMESPACE,
+      namespace,
       "--ignore-not-found",
       "-o",
       "name",
@@ -2329,7 +2331,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
         "status",
         `deployment/${routingDeploy}`,
         "-n",
-        K8S_NAMESPACE,
+        namespace,
         KUBECTL_ROLLOUT_TIMEOUT,
       ]);
       if (rsRollout.exitCode !== 0) {
@@ -2342,7 +2344,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
             `Routing service (${routingDeploy}) did not become healthy. Traffic was NOT ` +
               `switched — the previous build's pools are still serving.`,
             `${(rsRollout.stderr || rsRollout.stdout).trim()}`,
-            `Inspect: kubectl logs -l app.kubernetes.io/component=routing-service -n ${K8S_NAMESPACE} --tail=40`,
+            `Inspect: kubectl logs -l app.kubernetes.io/component=routing-service -n ${namespace} --tail=40`,
             ...edgeStatusLines(edge),
           ].join("\n"),
         );
@@ -2360,7 +2362,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
         "--for=condition=complete",
         `job/${currentRouteExtJob}`,
         "-n",
-        K8S_NAMESPACE,
+        namespace,
         "--timeout=600s",
       ]);
       if (wait.exitCode !== 0) {
@@ -2371,7 +2373,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
               `traffic cutover because middleware may not be wired.`,
             // L14: kubectl wait output carries controller/admission messages.
             `${sanitizeForTerminal((wait.stderr || wait.stdout).trim())}`,
-            `Inspect: kubectl logs job/${currentRouteExtJob} -n ${K8S_NAMESPACE}`,
+            `Inspect: kubectl logs job/${currentRouteExtJob} -n ${namespace}`,
             ...edgeStatusLines(edge),
           ].join("\n"),
         );
@@ -2406,7 +2408,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
           "envoyextensionpolicy",
           policyName,
           "-n",
-          K8S_NAMESPACE,
+          namespace,
           "-o",
           "json",
         ]);
@@ -2457,7 +2459,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
               `${status || "unknown"}); refusing traffic cutover because middleware would not ` +
               `run at the edge.`,
             sanitizeForTerminal(detail),
-            `Inspect: kubectl describe envoyextensionpolicy ${policyName} -n ${K8S_NAMESPACE}`,
+            `Inspect: kubectl describe envoyextensionpolicy ${policyName} -n ${namespace}`,
             `Common causes: the GatewayClass controller is not Envoy Gateway (an ` +
               `EnvoyExtensionPolicy only applies to one), or the Gateway it targets does not exist.`,
             ...edgeStatusLines(edge),
@@ -2503,7 +2505,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
           "hpa",
           name,
           "-n",
-          K8S_NAMESPACE,
+          namespace,
           "--type=merge",
           // Same field-manager rationale as the Service/Deployment patches: helm owns the
           // chart-rendered HPA, so the next `helm upgrade` must not conflict here.
@@ -2519,7 +2521,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
               `(${restore.stderr.trim() || `exit ${restore.exitCode}`}) — it is STILL widened ` +
               `for the pre-cutover warm-up, so this pool may autoscale above its configured ` +
               `ceiling until the next \`helm upgrade\` re-renders it. Fix it with: kubectl -n ` +
-              `${K8S_NAMESPACE} patch hpa ${name} --type=merge -p ` +
+              `${namespace} patch hpa ${name} --type=merge -p ` +
               `'{"spec":{"maxReplicas":${max}}}'`,
           );
         }
@@ -2559,7 +2561,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
         "hpa",
         newHpaName,
         "-n",
-        K8S_NAMESPACE,
+        namespace,
         "--ignore-not-found",
         "-o",
         "jsonpath={.metadata.name}|{.spec.minReplicas}|{.spec.maxReplicas}",
@@ -2589,7 +2591,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
             "hpa",
             newHpaName,
             "-n",
-            K8S_NAMESPACE,
+            namespace,
             "--type=merge",
             "--field-manager=helm",
             "-p",
@@ -2622,7 +2624,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
         "deployment",
         newDeployName,
         "-n",
-        K8S_NAMESPACE,
+        namespace,
         "--ignore-not-found",
         "-o",
         "jsonpath={.metadata.name}|{.spec.replicas}",
@@ -2648,7 +2650,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
         "scale",
         `deployment/${newDeployName}`,
         "-n",
-        K8S_NAMESPACE,
+        namespace,
         `--replicas=${expected}`,
       ]);
       if (scaleUp.exitCode !== 0) {
@@ -2688,7 +2690,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
         "get",
         "pods",
         "-n",
-        K8S_NAMESPACE,
+        namespace,
         "-l",
         // The routing service shares the version label; exclude it by its component label
         // (exact — a name substring match would also drop pool pods named similarly).
@@ -2758,7 +2760,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
         "get",
         "pods",
         "-n",
-        K8S_NAMESPACE,
+        namespace,
         "-l",
         `app.kubernetes.io/name=${releaseName},app.kubernetes.io/version=${safeBuildId},app.kubernetes.io/component!=routing-service`,
         "-o",
@@ -2780,7 +2782,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
             "exec",
             podName,
             "-n",
-            K8S_NAMESPACE,
+            namespace,
             "--",
             "node",
             "-e",
@@ -2804,7 +2806,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
             "logs",
             podName,
             "-n",
-            K8S_NAMESPACE,
+            namespace,
             "--tail=20",
           ]);
           if (logsResult.exitCode === 0) {
@@ -2856,7 +2858,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
         "service",
         activeServiceName,
         "-n",
-        K8S_NAMESPACE,
+        namespace,
         "--type=json",
         // Impersonate helm as the field manager so the next helm upgrade (server-side
         // apply, manager "helm") does not conflict on the selector field we flip here.
@@ -2898,7 +2900,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
             "service",
             serviceName,
             "-n",
-            K8S_NAMESPACE,
+            namespace,
             "--type=json",
             "--field-manager=helm",
             "-p",
@@ -3000,6 +3002,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
           basedOnGeneration: state?.generation ?? null,
         },
         releaseName,
+        namespace,
       );
     } catch (err) {
       // N67: the warm-up widening is scoped to the warm-up on this path too — traffic HAS
@@ -3075,14 +3078,14 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
           "hpa",
           poolPrevHpa,
           "-n",
-          K8S_NAMESPACE,
+          namespace,
           "--ignore-not-found",
         ]);
         const scaleDown = await execCapture("kubectl", [
           "scale",
           `deployment/${poolPrevName}`,
           "-n",
-          K8S_NAMESPACE,
+          namespace,
           "--replicas=0",
         ]);
         if (hpaDelete.exitCode !== 0 || scaleDown.exitCode !== 0) {
@@ -3119,7 +3122,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
       "get",
       "deployments",
       "-n",
-      K8S_NAMESPACE,
+      namespace,
       "-l",
       `app.kubernetes.io/name=${releaseName}`,
       "-o",
@@ -3150,10 +3153,8 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
         }
         // Delete everything else
         console.log(`  → Deleting old build: ${name}`);
-        await execCapture("kubectl", ["delete", "deployment", name, "-n", K8S_NAMESPACE]);
-        await execCapture("kubectl", ["delete", "service", name, "-n", K8S_NAMESPACE]).catch(
-          () => {},
-        );
+        await execCapture("kubectl", ["delete", "deployment", name, "-n", namespace]);
+        await execCapture("kubectl", ["delete", "service", name, "-n", namespace]).catch(() => {});
         // This build's raw release/pool/buildId parts are unknowable here (`name` is a
         // cluster-listed deployment of a build state no longer tracks), so the HCP name
         // can't go through poolResourceNames. Re-sanitizing the deployment name with the
@@ -3167,7 +3168,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
           "healthcheckpolicy",
           sanitizeK8sName(name, "-hcp"),
           "-n",
-          K8S_NAMESPACE,
+          namespace,
         ]).catch(() => {});
       }
     }
@@ -3180,7 +3181,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
       "get",
       "jobs",
       "-n",
-      K8S_NAMESPACE,
+      namespace,
       "-l",
       `app.kubernetes.io/name=${releaseName},app.kubernetes.io/component=route-ext-job`,
       "-o",
@@ -3189,7 +3190,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
     if (oldJobs.exitCode === 0) {
       for (const jobName of oldJobs.stdout.trim().split("\n")) {
         if (!jobName || jobName === currentRouteExtJob) continue;
-        await execCapture("kubectl", ["delete", "job", jobName, "-n", K8S_NAMESPACE]);
+        await execCapture("kubectl", ["delete", "job", jobName, "-n", namespace]);
       }
     }
 
@@ -3209,7 +3210,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
         "get",
         "configmaps",
         "-n",
-        K8S_NAMESPACE,
+        namespace,
         "-l",
         `app.kubernetes.io/name=${releaseName},app.kubernetes.io/managed-by=adapter-k8s,` +
           `app.kubernetes.io/component=routing-manifest-snapshot`,
@@ -3220,7 +3221,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
         for (const cmName of snapshots.stdout.trim().split("\n")) {
           if (!cmName || keepSnapshots.has(cmName)) continue;
           console.log(`  → Deleting old routing-manifest snapshot: ${cmName}`);
-          await execCapture("kubectl", ["delete", "configmap", cmName, "-n", K8S_NAMESPACE]);
+          await execCapture("kubectl", ["delete", "configmap", cmName, "-n", namespace]);
         }
       }
     }
@@ -3245,7 +3246,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
       "get",
       "deployments",
       "-n",
-      K8S_NAMESPACE,
+      namespace,
       "-l",
       `app.kubernetes.io/name=${releaseName}`,
       "-o",
@@ -3297,7 +3298,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
         "get",
         "secrets",
         "-n",
-        K8S_NAMESPACE,
+        namespace,
         "-l",
         `app.kubernetes.io/name=${releaseName},` +
           `app.kubernetes.io/component=${INTERNAL_SECRET_COMPONENT}`,
@@ -3308,7 +3309,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
         for (const secretName of internalSecrets.stdout.trim().split("\n")) {
           if (!secretName || referencedSecrets.has(secretName)) continue;
           console.log(`  → Deleting unreferenced internal dispatch Secret: ${secretName}`);
-          await execCapture("kubectl", ["delete", "secret", secretName, "-n", K8S_NAMESPACE]);
+          await execCapture("kubectl", ["delete", "secret", secretName, "-n", namespace]);
         }
       }
     }

--- a/src/cli/describe.ts
+++ b/src/cli/describe.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import boxen from "boxen";
 import { execCapture } from "./exec.js";
 import { sanitizeForTerminal } from "./terminal.js";
-import { sanitizeK8sName } from "../emit/templates/utils.js";
+import { resolveK8sNamespace, sanitizeK8sName } from "../emit/templates/utils.js";
 import {
   assertSafeInfrastructure,
   infrastructurePath,
@@ -32,10 +32,12 @@ export async function runDescribe(options: {
         projectId?: string;
         region?: string;
         hosts?: string[];
+        namespace?: string;
       } | null)
     : null;
   // S13: validate before any of these reach a gcloud/kubectl argv.
   assertSafeInfrastructure(infra);
+  const namespace = resolveK8sNamespace(infra?.namespace);
 
   // Ensure kubectl is pointing at the right cluster BEFORE reading state — readState
   // prefers the cluster ConfigMap, and with kubectl still pinned to a stale context it
@@ -66,7 +68,7 @@ export async function runDescribe(options: {
   const { readState, StateUnavailableError } = await import("./state.js");
   // N20: state reads now throw when state is indeterminate. describe is diagnostic — report
   // and continue rather than crashing the one command an operator runs to inspect a release.
-  const state = await readState(projectDir, releaseName).catch((err: unknown) => {
+  const state = await readState(projectDir, releaseName, { namespace }).catch((err: unknown) => {
     if (!(err instanceof StateUnavailableError)) throw err;
     console.warn(
       `  ! Deploy state could not be determined: ${(err as Error).message.split("\n")[0]}`,
@@ -119,10 +121,8 @@ export async function runDescribe(options: {
   const deploymentsResult = await execCapture("kubectl", [
     "get",
     "deployments",
-    // The release lives in the literal "default" namespace (same pin as deploy/
-    // rollback/state) — a kubeconfig namespace override would otherwise show nothing.
     "-n",
-    "default",
+    namespace,
     "-l",
     `app.kubernetes.io/name=${releaseName}`,
     "-o",

--- a/src/cli/destroy.ts
+++ b/src/cli/destroy.ts
@@ -5,7 +5,7 @@ import { execCapture } from "./exec.js";
 import { cliServiceAccountEmail, deployExtRoleId, deployServiceAccountEmail } from "./init.js";
 import { sanitizeForTerminal } from "./terminal.js";
 import { INTERNAL_SECRET_COMPONENT } from "../emit/templates/internal-secret.js";
-import { K8S_NAMESPACE } from "../emit/templates/utils.js";
+import { resolveK8sNamespace } from "../emit/templates/utils.js";
 import { assertSafeInfrastructure, infrastructurePath } from "./infrastructure-validation.js";
 
 export interface DestroyOptions {
@@ -163,6 +163,7 @@ export async function runDestroy(options: DestroyOptions): Promise<void> {
   const infra = existsSync(infraPath) ? JSON.parse(readFileSync(infraPath, "utf-8")) : undefined;
   // S13: validate before any of these reach a gcloud/kubectl argv.
   assertSafeInfrastructure(infra);
+  const namespace = resolveK8sNamespace(infra?.namespace);
   const projectId: string | undefined = infra?.projectId;
   const region: string | undefined = infra?.region;
 
@@ -295,13 +296,12 @@ export async function runDestroy(options: DestroyOptions): Promise<void> {
     }
   }
 
-  // 1. Helm uninstall. The release lives in the "default" namespace — the same one init
-  // binds Workload Identity to — so pin it instead of trusting the context's namespace.
+  // Pin every cluster-side deletion to the release namespace instead of trusting the context.
   if (dryRun) {
-    console.log(`  [dry-run] helm uninstall ${releaseName} --namespace default`);
+    console.log(`  [dry-run] helm uninstall ${releaseName} --namespace ${namespace}`);
   } else {
     console.log("  → Running helm uninstall...");
-    const res = await execCapture("helm", ["uninstall", releaseName, "--namespace", "default"]);
+    const res = await execCapture("helm", ["uninstall", releaseName, "--namespace", namespace]);
     if (res.exitCode !== 0) {
       if (isAlreadyGoneError(res.stderr)) {
         console.log("    (release not found or already uninstalled)");
@@ -323,7 +323,7 @@ export async function runDestroy(options: DestroyOptions): Promise<void> {
     "delete",
     "configmap",
     "-n",
-    "default",
+    namespace,
     "-l",
     `app.kubernetes.io/name=${releaseName},app.kubernetes.io/managed-by=adapter-k8s`,
     "--ignore-not-found",
@@ -336,7 +336,7 @@ export async function runDestroy(options: DestroyOptions): Promise<void> {
       console.warn(
         `    WARNING: could not delete adapter state ConfigMaps: ` +
           `${sanitizeForTerminal(res.stderr.trim()) || `exit ${res.exitCode}`}. Delete them manually ` +
-          `(kubectl delete configmap -n default -l app.kubernetes.io/name=${releaseName},` +
+          `(kubectl delete configmap -n ${namespace} -l app.kubernetes.io/name=${releaseName},` +
           `app.kubernetes.io/managed-by=adapter-k8s) or the next deploy may see stale state.`,
       );
     }
@@ -354,7 +354,7 @@ export async function runDestroy(options: DestroyOptions): Promise<void> {
     "delete",
     "secret",
     "-n",
-    K8S_NAMESPACE,
+    namespace,
     "-l",
     `app.kubernetes.io/name=${releaseName},app.kubernetes.io/component=${INTERNAL_SECRET_COMPONENT}`,
     "--ignore-not-found",
@@ -367,7 +367,7 @@ export async function runDestroy(options: DestroyOptions): Promise<void> {
       console.warn(
         `    WARNING: could not delete the internal-dispatch Secrets: ` +
           `${sanitizeForTerminal(res.stderr.trim()) || `exit ${res.exitCode}`}. Delete them ` +
-          `manually (kubectl delete secret -n ${K8S_NAMESPACE} -l ` +
+          `manually (kubectl delete secret -n ${namespace} -l ` +
           `app.kubernetes.io/name=${releaseName},` +
           `app.kubernetes.io/component=${INTERNAL_SECRET_COMPONENT}); they are retained by ` +
           `resource-policy and helm uninstall will not remove them.`,

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -5,17 +5,12 @@ import path from "node:path";
 import { execCapture } from "./exec.js";
 import { sanitizeForTerminal } from "./terminal.js";
 import { checkContainerRuntime } from "./container-runtime.js";
-import { sanitizeK8sName } from "../emit/templates/utils.js";
+import { resolveK8sNamespace, sanitizeK8sName } from "../emit/templates/utils.js";
 import {
   assertSafeInfrastructure,
   infrastructurePath,
   outputDirName,
 } from "./infrastructure-validation.js";
-
-// The release lives in the literal "default" namespace (init binds Workload Identity
-// there; deploy/rollback/state/destroy all pin it). Pin every kubectl read here too —
-// a kubeconfig namespace override otherwise makes every check report "not found".
-const K8S_NAMESPACE = "default";
 
 // Name the file in parse errors — a bare SyntaxError from JSON.parse gives no clue
 // WHICH file is corrupt.
@@ -190,13 +185,17 @@ export async function runDoctor(options: {
 }): Promise<void> {
   const { projectDir, releaseName } = options;
   const results: CheckResult[] = [];
+  let namespace = resolveK8sNamespace();
 
   // Ensure kubectl is pointing at the right cluster
   const infraPathForCtx = infrastructurePath(projectDir);
   if (existsSync(infraPathForCtx)) {
-    const infraCtx = readJsonFile<{ projectId?: string; region?: string }>(infraPathForCtx);
+    const infraCtx = readJsonFile<{ projectId?: string; region?: string; namespace?: string }>(
+      infraPathForCtx,
+    );
     // S13: validate before these reach a gcloud/kubectl argv.
     assertSafeInfrastructure(infraCtx);
+    namespace = resolveK8sNamespace(infraCtx.namespace);
     if (infraCtx.projectId && infraCtx.region) {
       const clusterName = `${releaseName}-cluster`;
       const credResult = await execCapture("gcloud", [
@@ -270,7 +269,7 @@ export async function runDoctor(options: {
   let state: Awaited<ReturnType<typeof readState>> = null;
   let stateError: string | null = null;
   try {
-    state = await readState(projectDir, releaseName);
+    state = await readState(projectDir, releaseName, { namespace });
   } catch (err) {
     if (!(err instanceof StateUnavailableError)) throw err;
     stateError = err.message;
@@ -417,7 +416,7 @@ export async function runDoctor(options: {
       "gateway",
       `${releaseName}-gateway`,
       "-n",
-      K8S_NAMESPACE,
+      namespace,
       "-o",
       "jsonpath={.status.conditions[?(@.type=='Accepted')].status}",
     ]);
@@ -432,7 +431,7 @@ export async function runDoctor(options: {
           "gateway",
           `${releaseName}-gateway`,
           "-n",
-          K8S_NAMESPACE,
+          namespace,
           "-o",
           "jsonpath={.status.conditions[?(@.type=='Accepted')].message}",
         ]);
@@ -442,7 +441,7 @@ export async function runDoctor(options: {
           // L14: condition messages are cluster-sourced — strip terminal control chars.
           message:
             sanitizeForTerminal(reasonResult.stdout.trim()) || `Status: ${accepted || "Unknown"}`,
-          fix: `kubectl describe gateway ${releaseName}-gateway`,
+          fix: `kubectl describe gateway ${releaseName}-gateway -n ${namespace}`,
         });
       }
     } else {
@@ -460,7 +459,7 @@ export async function runDoctor(options: {
       "gateway",
       `${releaseName}-gateway`,
       "-n",
-      K8S_NAMESPACE,
+      namespace,
       "-o",
       "jsonpath={.status.addresses[0].value}",
     ]);
@@ -499,7 +498,7 @@ export async function runDoctor(options: {
       "httproute",
       `${releaseName}-routes`,
       "-n",
-      K8S_NAMESPACE,
+      namespace,
       "-o",
       "jsonpath={.status.parents[0].conditions[?(@.type=='Accepted')].status}",
     ]);
@@ -512,7 +511,7 @@ export async function runDoctor(options: {
               name: "HTTPRoute",
               status: "fail",
               message: `Status: ${accepted || "Unknown"}`,
-              fix: `kubectl describe httproute ${releaseName}-routes`,
+              fix: `kubectl describe httproute ${releaseName}-routes -n ${namespace}`,
             },
       );
     } else {
@@ -524,7 +523,7 @@ export async function runDoctor(options: {
       "get",
       "deployments",
       "-n",
-      K8S_NAMESPACE,
+      namespace,
       "-l",
       `app.kubernetes.io/name=${releaseName}`,
       "-o",
@@ -594,7 +593,7 @@ export async function runDoctor(options: {
             name: `${label}${roleTag}`,
             status: "fail",
             message: `${ready}/${total} ready`,
-            fix: `kubectl describe deployment/${name}`,
+            fix: `kubectl describe deployment/${name} -n ${namespace}`,
           });
         } else if (ready < total) {
           results.push({
@@ -607,7 +606,7 @@ export async function runDoctor(options: {
             name: `${label}${roleTag}`,
             status: "fail",
             message: `${ready}/${total} ready`,
-            fix: `kubectl describe deployment/${name}`,
+            fix: `kubectl describe deployment/${name} -n ${namespace}`,
           });
         }
       }
@@ -651,7 +650,7 @@ export async function runDoctor(options: {
       "get",
       "svc",
       "-n",
-      K8S_NAMESPACE,
+      namespace,
       "-l",
       `app.kubernetes.io/name=${releaseName}`,
       "-o",
@@ -704,7 +703,7 @@ export async function runDoctor(options: {
         "get",
         "endpointslice",
         "-n",
-        K8S_NAMESPACE,
+        namespace,
         "-l",
         `kubernetes.io/service-name=${svc}`,
         "-o",
@@ -728,7 +727,7 @@ export async function runDoctor(options: {
           name: `Active Service endpoints: ${svc}`,
           status: "fail",
           message: "0 ready endpoints — selector matches no ready pods (origin will 503)",
-          fix: `kubectl get svc ${svc} -o jsonpath='{.spec.selector}' — verify app.kubernetes.io/version matches a running pod's label`,
+          fix: `kubectl get svc ${svc} -n ${namespace} -o jsonpath='{.spec.selector}' — verify app.kubernetes.io/version matches a running pod's label`,
         });
       }
       // readyEndpoints === -1 (kubectl error) is left unreported — cluster-connectivity
@@ -779,7 +778,7 @@ export async function runDoctor(options: {
       "get",
       "pods",
       "-n",
-      K8S_NAMESPACE,
+      namespace,
       "-l",
       `app.kubernetes.io/name=${releaseName}`,
       "-o",
@@ -796,7 +795,7 @@ export async function runDoctor(options: {
           "logs",
           pod,
           "-n",
-          K8S_NAMESPACE,
+          namespace,
           "--tail=50",
         ]);
         if (logsResult.exitCode !== 0) continue;
@@ -812,14 +811,14 @@ export async function runDoctor(options: {
           name: "Pod logs",
           status: "fail",
           message: `Fatal error in ${fatalHit.pod}: ${firstFatal}`,
-          fix: `kubectl logs ${fatalHit.pod} --tail=50`,
+          fix: `kubectl logs ${fatalHit.pod} -n ${namespace} --tail=50`,
         });
       } else if (errorPods.length > 0) {
         results.push({
           name: "Pod logs",
           status: "warn",
           message: `error-level lines in ${errorPods.length}/${podsToCheck.length} pod(s) — likely transient app errors`,
-          fix: `kubectl logs ${errorPods[0]} --tail=50`,
+          fix: `kubectl logs ${errorPods[0]} -n ${namespace} --tail=50`,
         });
       } else if (podsToCheck.length > 0) {
         results.push({
@@ -940,7 +939,7 @@ export async function runDoctor(options: {
         "get",
         "svcneg",
         "-n",
-        K8S_NAMESPACE,
+        namespace,
         "-o",
         "jsonpath={range .items[*]}{.metadata.name}|{.status.conditions[?(@.type=='Initialized')].status}{\"\\n\"}{end}",
       ]);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,6 +1,6 @@
 // src/cli/index.ts
 import path from "node:path";
-import { infrastructurePath } from "./infrastructure-validation.js";
+import { infrastructurePath, infrastructureWritePath } from "./infrastructure-validation.js";
 import { sanitizeForTerminal } from "./terminal.js";
 import { existsSync, readFileSync } from "node:fs";
 import { runInit } from "./init.js";
@@ -40,6 +40,7 @@ const VALUE_FLAGS = new Set([
   "bucket",
   "registry",
   "release-name",
+  "namespace",
   "port",
 ]);
 
@@ -143,6 +144,7 @@ Options:
   --bucket <name>          GCS bucket name for static assets (init)
   --registry <url>         Container registry URL (init)
   --release-name <name>    Helm release name (default: current directory name)
+  --namespace <name>       Kubernetes namespace (init; default: persisted value or default)
   --standard               Provision a GKE Standard cluster instead of Autopilot (init)
   --skip-build             Skip next build (deploy, emulate)
   --skip-push              Skip docker build + push (deploy)
@@ -188,12 +190,17 @@ async function main(): Promise<void> {
       .slice(0, 40)
       .replace(/-+$/, "") || "app";
   let persistedReleaseName: string | undefined;
-  const infraPath = infrastructurePath(projectDir);
+  let persistedNamespace: string | undefined;
+  const infraPath =
+    command === "init" ? infrastructureWritePath(projectDir) : infrastructurePath(projectDir);
   if (existsSync(infraPath)) {
     try {
       const infra = JSON.parse(readFileSync(infraPath, "utf-8"));
       if (typeof infra.releaseName === "string" && infra.releaseName) {
         persistedReleaseName = infra.releaseName;
+      }
+      if (typeof infra.namespace === "string" && infra.namespace) {
+        persistedNamespace = infra.namespace;
       }
     } catch (err) {
       // Malformed infrastructure.json — fall back to the directory default, but name
@@ -229,6 +236,7 @@ async function main(): Promise<void> {
       const registry =
         (flags["registry"] as string) ??
         (projectId && region ? `${region}-docker.pkg.dev/${projectId}/nextjs` : undefined);
+      const initNamespace = (flags["namespace"] as string | undefined) ?? persistedNamespace;
 
       if (!projectId || hosts.length === 0) {
         console.error("Error: --project-id and --host are required for init");
@@ -248,6 +256,7 @@ async function main(): Promise<void> {
         bucket: bucket!,
         registry: registry!,
         releaseName,
+        ...(initNamespace ? { namespace: initNamespace } : {}),
         projectDir,
         dryRun,
         // --standard opts out of the Autopilot default (Standard clusters get

--- a/src/cli/infrastructure-validation.ts
+++ b/src/cli/infrastructure-validation.ts
@@ -12,7 +12,7 @@ import {
 export interface InfrastructureArgvFields {
   projectId?: string | undefined;
   region?: string | undefined;
-  namespace?: string | undefined;
+  namespace?: unknown;
   containerRegistry?: string | undefined;
   gcsBucket?: string | undefined;
   cacheRegion?: string | undefined;
@@ -40,7 +40,7 @@ export function assertSafeInfrastructure(infra: InfrastructureArgvFields | null 
   if (!infra) return;
   if (infra.projectId) assertSafeProjectId(infra.projectId);
   if (infra.region) assertSafeRegion(infra.region);
-  if (infra.namespace) assertSafeNamespace(infra.namespace);
+  if (infra.namespace !== undefined) assertSafeNamespace(infra.namespace);
   if (infra.containerRegistry) assertSafeImageRegistry(infra.containerRegistry);
   // A region-shaped value; same charset as `region` (lowercase alnum + hyphen).
   if (infra.cacheRegion) assertSafeRegion(infra.cacheRegion);
@@ -74,16 +74,9 @@ export function assertSafeInfrastructure(infra: InfrastructureArgvFields | null 
  * existing single-target project is unaffected.
  */
 export function infrastructurePath(projectDir: string): string {
+  const scoped = infrastructureWritePath(projectDir);
   const variant = process.env.ADAPTER_K8S_CONFIG?.trim();
-  const base = path.join(projectDir, ".k8s-adapter");
-  if (!variant) return path.join(base, "infrastructure.json");
-  if (!/^[a-z0-9][-a-z0-9_]*$/i.test(variant)) {
-    throw new Error(
-      `ADAPTER_K8S_CONFIG=${JSON.stringify(variant)} is not a valid variant name. Use a bare ` +
-        `name like "scaleway"; it is interpolated into a filename, so a path is refused.`,
-    );
-  }
-  const scoped = path.join(base, `infrastructure.${variant}.json`);
+  if (!variant) return scoped;
   // NO FALLBACK. Falling back was a cross-wiring hazard: the adapter loads
   // adapter.config.<variant>.mjs while this returned the DEFAULT infrastructure.json, so a
   // half-present variant built config A against infrastructure B — a deploy aimed at one
@@ -98,6 +91,23 @@ export function infrastructurePath(projectDir: string): string {
     );
   }
   return scoped;
+}
+
+/**
+ * Path where init writes infrastructure state. Unlike infrastructurePath(), this permits a
+ * selected variant not to exist yet because creating it is init's job.
+ */
+export function infrastructureWritePath(projectDir: string): string {
+  const variant = process.env.ADAPTER_K8S_CONFIG?.trim();
+  const base = path.join(projectDir, ".k8s-adapter");
+  if (!variant) return path.join(base, "infrastructure.json");
+  if (!/^[a-z0-9][-a-z0-9_]*$/i.test(variant)) {
+    throw new Error(
+      `ADAPTER_K8S_CONFIG=${JSON.stringify(variant)} is not a valid variant name. Use a bare ` +
+        `name like "scaleway"; it is interpolated into a filename, so a path is refused.`,
+    );
+  }
+  return path.join(base, `infrastructure.${variant}.json`);
 }
 
 /**

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -5,12 +5,14 @@ import { execCapture } from "./exec.js";
 import { generateAdapterConfig, generateInfrastructureJson } from "./scaffold.js";
 import { gkeVersionAtLeast, MIN_GKE_VERSION_FOR_CDN } from "./gke-version.js";
 import { sanitizeForTerminal } from "./terminal.js";
+import { infrastructureWritePath } from "./infrastructure-validation.js";
 import {
   assertSafeBucketName,
   assertSafeHostname,
   assertSafeImageRegistry,
   assertSafeProjectId,
   assertSafeRegion,
+  resolveK8sNamespace,
 } from "../emit/templates/utils.js";
 
 export interface InitOptions {
@@ -20,6 +22,7 @@ export interface InitOptions {
   bucket: string;
   registry: string;
   releaseName: string;
+  namespace?: string;
   projectDir: string;
   dryRun?: boolean;
   /** Backoff between IAM-binding retries (ms). Defaults to 5000; tests override to run fast. */
@@ -94,10 +97,12 @@ export function buildInitGcloudCommands(options: {
   region: string;
   bucket: string;
   releaseName: string;
+  namespace?: string;
   hosts?: string[];
   autopilot?: boolean;
 }): GcloudCommand[] {
   const { projectId, region, bucket, releaseName, hosts = [], autopilot = true } = options;
+  const namespace = resolveK8sNamespace(options.namespace);
   const commands: GcloudCommand[] = [];
   // S6: the impersonable Job identity and the CLI-only one. See the doc comments above —
   // every grant below is deliberate about WHICH of the two it lands on.
@@ -390,7 +395,7 @@ export function buildInitGcloudCommands(options: {
       "--role",
       "roles/iam.workloadIdentityUser",
       "--member",
-      `serviceAccount:${projectId}.svc.id.goog[default/${releaseName}-deploy-sa]`,
+      `serviceAccount:${projectId}.svc.id.goog[${namespace}/${releaseName}-deploy-sa]`,
       "--condition=None",
       "--project",
       projectId,
@@ -609,11 +614,34 @@ export async function runInit(options: InitOptions): Promise<void> {
     bucket,
     registry,
     releaseName,
+    namespace: configuredNamespace,
     projectDir,
     dryRun,
     iamRetryDelayMs = 5000,
     autopilot = true,
   } = options;
+  const namespace = resolveK8sNamespace(configuredNamespace);
+
+  const infraPath = infrastructureWritePath(projectDir);
+  if (existsSync(infraPath)) {
+    let existing: { namespace?: unknown };
+    try {
+      existing = JSON.parse(readFileSync(infraPath, "utf-8"));
+    } catch (err) {
+      throw new Error(
+        `Failed to parse ${infraPath}: ${err instanceof Error ? err.message : String(err)}. ` +
+          `Fix the file before re-running init.`,
+      );
+    }
+    const existingNamespace = resolveK8sNamespace(existing.namespace);
+    if (existingNamespace !== namespace) {
+      throw new Error(
+        `Cannot change the namespace of an existing release from "${existingNamespace}" to ` +
+          `"${namespace}". The old namespace still contains release state and Workload ` +
+          `Identity bindings. Destroy that release first, or use a new release/config variant.`,
+      );
+    }
+  }
 
   // Validate every operator-supplied value BEFORE it reaches a gcloud arg array or the
   // scaffolded adapter.config.mjs — a `'` in a host/bucket name would otherwise be raw
@@ -682,6 +710,7 @@ export async function runInit(options: InitOptions): Promise<void> {
     region,
     bucket,
     releaseName,
+    namespace,
     hosts,
     autopilot,
   });
@@ -914,9 +943,8 @@ export async function runInit(options: InitOptions): Promise<void> {
   }
 
   // 4. Write infrastructure.json
-  const infraDir = path.join(projectDir, ".k8s-adapter");
-  const infraPath = path.join(infraDir, "infrastructure.json");
-  console.log("  → Writing .k8s-adapter/infrastructure.json");
+  const infraDir = path.dirname(infraPath);
+  console.log(`  → Writing ${path.relative(projectDir, infraPath)}`);
   if (!dryRun) {
     mkdirSync(infraDir, { recursive: true });
     writeFileSync(
@@ -930,6 +958,7 @@ export async function runInit(options: InitOptions): Promise<void> {
         gatewayName: `${releaseName}-gateway`,
         routeExtensionName: `${releaseName}-route-ext`,
         releaseName,
+        namespace,
       }),
     );
   }
@@ -992,7 +1021,7 @@ export async function runInit(options: InitOptions): Promise<void> {
   console.log(`  3. Configure your DNS A records for your hosts:`);
   console.log("     - Wait 5-10 minutes for the GCP Load Balancer to initialize.");
   console.log(
-    `     - Run \`kubectl get gateway ${releaseName}-gateway\` to find your external IP address.`,
+    `     - Run \`kubectl get gateway ${releaseName}-gateway -n ${namespace}\` to find your external IP address.`,
   );
   for (const h of hosts) {
     console.log(`     - Create a DNS A record for ${h} pointing to that IP.`);

--- a/src/cli/rollback.ts
+++ b/src/cli/rollback.ts
@@ -9,10 +9,7 @@ import {
   assertSafeImageRegistry,
   poolResourceNames,
   sanitizeK8sName,
-  // init binds Workload Identity to [default/<release>-deploy-sa]; the release lives
-  // in the literal "default" namespace. Pin it on every kubectl call instead of
-  // trusting whatever namespace the operator's context happens to have.
-  K8S_NAMESPACE,
+  resolveK8sNamespace,
 } from "../emit/templates/utils.js";
 import {
   ROUTING_MANIFEST_VOLUME_NAME,
@@ -89,14 +86,18 @@ type RoutingServingRead =
  * it from the image reference broke once images became digest-pinned (see the NEXT_BUILD_ID note
  * inside).
  */
-export async function readRoutingServingConfig(releaseName: string): Promise<RoutingServingRead> {
+export async function readRoutingServingConfig(
+  releaseName: string,
+  configuredNamespace?: string,
+): Promise<RoutingServingRead> {
+  const namespace = resolveK8sNamespace(configuredNamespace);
   const deployName = routingServiceDeploymentName(releaseName);
   const res = await execCapture("kubectl", [
     "get",
     "deployment",
     deployName,
     "-n",
-    K8S_NAMESPACE,
+    namespace,
     "--ignore-not-found",
     "-o",
     "json",
@@ -223,9 +224,11 @@ export type RetainManifestResult =
 // by deploy (pre-helm-upgrade) to retain the outgoing build.
 export async function retainLiveRoutingManifest(
   releaseName: string,
+  configuredNamespace?: string,
   log: (msg: string) => void = (m) => console.log(m),
 ): Promise<RetainManifestResult> {
-  const read = await readRoutingServingConfig(releaseName);
+  const namespace = resolveK8sNamespace(configuredNamespace);
+  const read = await readRoutingServingConfig(releaseName, namespace);
   // N68: absence (proven by --ignore-not-found) is the ONLY outcome that means "nothing to
   // retain". A read failure is a retention failure, which deploy treats as fatal unless
   // --allow-unretained-manifest — otherwise helm overwrites the stable ConfigMap and the
@@ -253,7 +256,7 @@ export async function retainLiveRoutingManifest(
     "configmap",
     snapshotName,
     "-n",
-    K8S_NAMESPACE,
+    namespace,
     "--ignore-not-found",
     "-o",
     "json",
@@ -283,7 +286,7 @@ export async function retainLiveRoutingManifest(
     "configmap",
     serving.manifestConfigMap,
     "-n",
-    K8S_NAMESPACE,
+    namespace,
     "-o",
     "json",
   ]);
@@ -328,7 +331,7 @@ export async function retainLiveRoutingManifest(
   // argv length, and secrets never go on argv.
   const applied = await execCaptureStdin(
     "kubectl",
-    ["apply", "-n", K8S_NAMESPACE, "-f", "-"],
+    ["apply", "-n", namespace, "-f", "-"],
     JSON.stringify(snapshot),
   );
   if (applied.exitCode !== 0) {
@@ -366,6 +369,7 @@ export async function retainLiveRoutingManifest(
 // still serving traffic. No cutover performed."
 export async function revertRoutingServiceToBuild(opts: {
   releaseName: string;
+  namespace?: string;
   targetBuildId: string;
   registry: string | undefined;
   /**
@@ -376,13 +380,14 @@ export async function revertRoutingServiceToBuild(opts: {
   targetImageDigest?: string | undefined;
 }): Promise<void> {
   const { releaseName, targetBuildId, registry, targetImageDigest } = opts;
+  const namespace = resolveK8sNamespace(opts.namespace);
   const deployName = routingServiceDeploymentName(releaseName);
   // N68: same distinction as retention — a read failure here used to return silently, i.e.
   // report "this release has no routing tier" and let the caller believe the edge was
   // reverted (deploy's abort path prints "the routing edge was reverted") while the edge
   // kept serving the other build's middleware. Absence is exit 0 + empty stdout; anything
   // else throws so the caller can say what it does not know.
-  const exists = await readRoutingServingConfig(releaseName);
+  const exists = await readRoutingServingConfig(releaseName, namespace);
   if (exists.status === "failed") {
     throw new Error(
       `Could not determine what the routing tier (${deployName}) is serving: ${exists.reason}. ` +
@@ -412,7 +417,7 @@ export async function revertRoutingServiceToBuild(opts: {
 
   // Retain the manifest we are about to roll AWAY from, so the symmetric roll-forward
   // can restore it (its stable-ConfigMap content is otherwise lost on the next deploy).
-  await retainLiveRoutingManifest(releaseName);
+  await retainLiveRoutingManifest(releaseName, namespace);
 
   const targetSnapshot = routingManifestSnapshotName(releaseName, targetBuildId);
   const snap = await execCapture("kubectl", [
@@ -420,7 +425,7 @@ export async function revertRoutingServiceToBuild(opts: {
     "configmap",
     targetSnapshot,
     "-n",
-    K8S_NAMESPACE,
+    namespace,
     "--ignore-not-found",
     "-o",
     "name",
@@ -466,7 +471,7 @@ export async function revertRoutingServiceToBuild(opts: {
       "secret",
       candidate,
       "-n",
-      K8S_NAMESPACE,
+      namespace,
       "--ignore-not-found",
       "-o",
       "name",
@@ -547,7 +552,7 @@ export async function revertRoutingServiceToBuild(opts: {
     "deployment",
     deployName,
     "-n",
-    K8S_NAMESPACE,
+    namespace,
     "--type=strategic",
     // Same field-manager rationale as the Service selector patches below: helm owns this
     // Deployment, so the next `helm upgrade` must not conflict on the fields we flip here.
@@ -577,12 +582,12 @@ export async function revertRoutingServiceToBuild(opts: {
     "status",
     `deployment/${deployName}`,
     "-n",
-    K8S_NAMESPACE,
+    namespace,
     `--timeout=${ROUTING_ROLLOUT_TIMEOUT_SECONDS}s`,
   ]);
   if (rollout.exitCode !== 0) {
     const detail = rollout.stderr.trim() || rollout.stdout.trim() || `exit ${rollout.exitCode}`;
-    const restored = await restoreRoutingSpec(deployName, priorSpec);
+    const restored = await restoreRoutingSpec(deployName, priorSpec, namespace);
     throw new Error(
       `The routing service did not roll out to build ${targetBuildId} within ` +
         `${ROUTING_ROLLOUT_TIMEOUT_SECONDS}s: ${detail}\n` +
@@ -590,7 +595,7 @@ export async function revertRoutingServiceToBuild(opts: {
           ? `  The edge was restored to what it was serving before (${priorSpec.buildId ?? "unknown build"}), ` +
             `so the pools and the edge still agree. Traffic was NOT switched.`
           : `  !! The edge could NOT be restored, so the pools and the edge may now be on ` +
-            `DIFFERENT builds. Check \`kubectl -n ${K8S_NAMESPACE} describe deployment ` +
+            `DIFFERENT builds. Check \`kubectl -n ${namespace} describe deployment ` +
             `${deployName}\` and the routing pod logs — a manifest that does not match the ` +
             `image makes the pod refuse to start on purpose.`) +
         `\n  Traffic was NOT switched.`,
@@ -623,6 +628,7 @@ interface RoutingSpecSnapshot {
 async function restoreRoutingSpec(
   deployName: string,
   prior: RoutingSpecSnapshot,
+  namespace: string,
 ): Promise<boolean> {
   if (!prior.image) return false;
   const patch = {
@@ -677,7 +683,7 @@ async function restoreRoutingSpec(
     "deployment",
     deployName,
     "-n",
-    K8S_NAMESPACE,
+    namespace,
     "--type=strategic",
     "--field-manager=helm",
     "-p",
@@ -735,6 +741,7 @@ async function readLiveCapacity(
   releaseName: string,
   pool: string,
   currentBuildId: string,
+  namespace: string,
 ): Promise<{ observed: LiveCapacity; unreadable: string[] }> {
   const { deployment, hpa } = poolResourceNames(releaseName, pool, currentBuildId);
   const unreadable: string[] = [];
@@ -750,7 +757,7 @@ async function readLiveCapacity(
     "deployment",
     deployment,
     "-n",
-    K8S_NAMESPACE,
+    namespace,
     "--ignore-not-found",
     "-o",
     "jsonpath={.metadata.name}|{.spec.replicas}|{.status.readyReplicas}",
@@ -771,7 +778,7 @@ async function readLiveCapacity(
     "hpa",
     hpa,
     "-n",
-    K8S_NAMESPACE,
+    namespace,
     "--ignore-not-found",
     "-o",
     "jsonpath={.metadata.name}|{.status.desiredReplicas}|{.spec.maxReplicas}",
@@ -801,6 +808,7 @@ export async function runRollback(options: {
   const infra = existsSync(infraPath) ? JSON.parse(readFileSync(infraPath, "utf-8")) : undefined;
   // S13: validate before these reach a gcloud/kubectl argv.
   assertSafeInfrastructure(infra);
+  const namespace = resolveK8sNamespace(infra?.namespace);
 
   // Pin kubectl at THIS release's cluster BEFORE any cluster read — the state ConfigMap
   // read below previously ran against whatever context happened to be current, so a
@@ -824,7 +832,10 @@ export async function runRollback(options: {
     }
   }
 
-  const state = await readState(projectDir, releaseName, dryRun ? { localOnly: true } : undefined);
+  const state = await readState(projectDir, releaseName, {
+    ...(dryRun ? { localOnly: true } : {}),
+    namespace,
+  });
   if (!state?.previousBuildId) {
     // Dry-run deliberately reads the LOCAL state file only (L13 — no cluster access),
     // so "no previous build" may just mean the local file is missing/stale while the
@@ -904,7 +915,7 @@ export async function runRollback(options: {
     "get",
     "deployments",
     "-n",
-    K8S_NAMESPACE,
+    namespace,
     "-l",
     `app.kubernetes.io/name=${releaseName}`,
     "-o",
@@ -987,6 +998,7 @@ export async function runRollback(options: {
       releaseName,
       previousDeploy.pool,
       currentBuildId,
+      namespace,
     );
     if (unreadable.length > 0) {
       console.warn(
@@ -1010,7 +1022,7 @@ export async function runRollback(options: {
       "scale",
       `deployment/${previousDeploy.name}`,
       "-n",
-      K8S_NAMESPACE,
+      namespace,
       `--replicas=${plan.replicas}`,
     ]);
   }
@@ -1035,7 +1047,7 @@ export async function runRollback(options: {
       "hpa",
       hpaName,
       "-n",
-      K8S_NAMESPACE,
+      namespace,
       "--ignore-not-found",
       "-o",
       "name",
@@ -1046,7 +1058,7 @@ export async function runRollback(options: {
         "deployment",
         previousDeploy.name,
         "-n",
-        K8S_NAMESPACE,
+        namespace,
         `--name=${hpaName}`,
         `--min=${plan.min}`,
         `--max=${plan.max}`,
@@ -1058,7 +1070,7 @@ export async function runRollback(options: {
         "hpa",
         hpaName,
         "-n",
-        K8S_NAMESPACE,
+        namespace,
         "--type=merge",
         // Same field-manager rationale as the Service/Deployment patches: helm owns the
         // chart-rendered HPA, so the next `helm upgrade` must not conflict here.
@@ -1084,7 +1096,7 @@ export async function runRollback(options: {
       "status",
       `deployment/${previousDeploy.name}`,
       "-n",
-      K8S_NAMESPACE,
+      namespace,
       "--timeout=120s",
     ]);
   }
@@ -1108,7 +1120,7 @@ export async function runRollback(options: {
       "get",
       "pods",
       "-n",
-      K8S_NAMESPACE,
+      namespace,
       "-l",
       `app.kubernetes.io/name=${releaseName},app.kubernetes.io/version=${safePreviousBuild},app.kubernetes.io/component!=routing-service`,
       "-o",
@@ -1129,7 +1141,7 @@ export async function runRollback(options: {
           "exec",
           pod,
           "-n",
-          K8S_NAMESPACE,
+          namespace,
           "--",
           "node",
           "-e",
@@ -1153,7 +1165,8 @@ export async function runRollback(options: {
     throw new Error(
       `Previous build ${previousBuildId} did not pass /healthz within 2 minutes. Traffic ` +
         `was NOT switched — the current build is still serving. Both builds were left scaled ` +
-        `up; investigate (kubectl logs -l app.kubernetes.io/version=${safePreviousBuild}) and ` +
+        `up; investigate (kubectl logs -n ${namespace} -l ` +
+        `app.kubernetes.io/version=${safePreviousBuild}) and ` +
         `re-run the rollback.`,
     );
   }
@@ -1165,6 +1178,7 @@ export async function runRollback(options: {
   if (infra?.containerRegistry) assertSafeImageRegistry(infra.containerRegistry);
   await revertRoutingServiceToBuild({
     releaseName,
+    namespace,
     targetBuildId: previousBuildId,
     registry: infra?.containerRegistry,
     targetImageDigest: state.routingImageDigests?.[previousBuildId],
@@ -1192,7 +1206,7 @@ export async function runRollback(options: {
       "service",
       svcName,
       "-n",
-      K8S_NAMESPACE,
+      namespace,
       "--type=json",
       // --force-conflicts is NOT a valid `kubectl patch` flag (only `apply
       // --server-side` accepts it); a JSON patch needs no conflict override.
@@ -1225,7 +1239,7 @@ export async function runRollback(options: {
         "service",
         serviceName,
         "-n",
-        K8S_NAMESPACE,
+        namespace,
         "--type=json",
         "--field-manager=helm",
         "-p",
@@ -1252,6 +1266,7 @@ export async function runRollback(options: {
       assertSafeBuildId(currentBuildId);
       await revertRoutingServiceToBuild({
         releaseName,
+        namespace,
         targetBuildId: currentBuildId,
         registry: infra?.containerRegistry,
         targetImageDigest: state.routingImageDigests?.[currentBuildId],
@@ -1287,7 +1302,7 @@ export async function runRollback(options: {
       );
       console.error(`  Recover by re-running the rollback, or restore the edge manually:`);
       console.error(
-        `    kubectl -n ${K8S_NAMESPACE} set image deployment/` +
+        `    kubectl -n ${namespace} set image deployment/` +
           `${routingServiceDeploymentName(releaseName)} routing-service=` +
           `${infra?.containerRegistry ?? "<registry>"}/routing-service:${currentBuildId}`,
       );
@@ -1331,6 +1346,7 @@ export async function runRollback(options: {
         basedOnGeneration: state.generation ?? null,
       },
       releaseName,
+      namespace,
     );
   } catch (err) {
     console.error(`\n  Rollback traffic switch succeeded, but persisting state failed:`);
@@ -1380,14 +1396,14 @@ export async function runRollback(options: {
       "hpa",
       currentDeploy.hpa,
       "-n",
-      K8S_NAMESPACE,
+      namespace,
       "--ignore-not-found",
     ]);
     await execOrThrow("kubectl", [
       "scale",
       `deployment/${currentDeploy.name}`,
       "-n",
-      K8S_NAMESPACE,
+      namespace,
       "--replicas=0",
     ]);
   }

--- a/src/cli/scaffold.ts
+++ b/src/cli/scaffold.ts
@@ -1,4 +1,5 @@
 // src/cli/scaffold.ts
+import { K8S_NAMESPACE } from "../emit/templates/utils.js";
 
 export interface ScaffoldOptions {
   projectId: string;
@@ -57,6 +58,7 @@ export interface InfrastructureConfig {
   gatewayName: string;
   routeExtensionName: string;
   releaseName: string;
+  namespace?: string;
 }
 
 export function generateInfrastructureJson(config: InfrastructureConfig): string {
@@ -70,6 +72,7 @@ export function generateInfrastructureJson(config: InfrastructureConfig): string
       gatewayName: config.gatewayName,
       routeExtensionName: config.routeExtensionName,
       releaseName: config.releaseName,
+      namespace: config.namespace ?? K8S_NAMESPACE,
     },
     null,
     2,

--- a/src/cli/state.ts
+++ b/src/cli/state.ts
@@ -3,6 +3,7 @@ import { existsSync, readFileSync, writeFileSync, renameSync, mkdirSync } from "
 import path from "node:path";
 import { stateFileName } from "./infrastructure-validation.js";
 import { execCapture, execCaptureStdin } from "./exec.js";
+import { resolveK8sNamespace } from "../emit/templates/utils.js";
 
 const STATE_DIR = ".k8s-adapter";
 // Variant-scoped: see stateFileName(). Sharing one state file across deploy targets lets a
@@ -10,11 +11,6 @@ const STATE_DIR = ".k8s-adapter";
 // cluster's Services at a build that only ever existed on the other one.
 const STATE_FILE = (): string => stateFileName();
 const CONFIGMAP_NAME_SUFFIX = "-adapter-state";
-// init binds Workload Identity to [<namespace>/${releaseName}-deploy-sa] with the literal
-// namespace "default" — the release (and therefore this ConfigMap) lives there. Pin it:
-// reading/writing via whatever namespace the operator's context happens to have can
-// silently target the wrong namespace.
-const STATE_NAMESPACE = "default";
 // N22: every shell-out goes through exec.ts (AGENTS.md) — this file used to call
 // `spawn("kubectl", …)` directly, which meant no `stdin.on("error")` handler (the
 // ERR_STREAM_DESTROYED crash exec.ts:231-236 documents, hit immediately AFTER cutover,
@@ -228,7 +224,7 @@ export function chooseNewerState(local: AdapterState, cluster: AdapterState): Ad
       `selector onto a build that may be scaled to zero. Confirm which build is serving ` +
       `(\`npx adapter-k8s doctor\`), then delete the stale copy — ` +
       `\`rm ${path.join(STATE_DIR, STATE_FILE())}\` to accept the cluster's, or re-run the ` +
-      `deploy after \`kubectl delete configmap <release>${CONFIGMAP_NAME_SUFFIX} -n ${STATE_NAMESPACE}\` ` +
+      `deploy after \`kubectl delete configmap <release>${CONFIGMAP_NAME_SUFFIX} -n <namespace>\` ` +
       `to accept the local one.`,
   );
 }
@@ -241,12 +237,15 @@ export function chooseNewerState(local: AdapterState, cluster: AdapterState): Ad
 export async function readState(
   projectDir: string,
   releaseName?: string,
-  opts?: { localOnly?: boolean },
+  opts?: { localOnly?: boolean; namespace?: string },
 ): Promise<AdapterState | null> {
   const local = readLocalState(projectDir);
   if (!releaseName || opts?.localOnly) return local;
 
-  const { state: cluster } = await readClusterState(releaseName);
+  const { state: cluster } = await readClusterState(
+    releaseName,
+    resolveK8sNamespace(opts?.namespace),
+  );
   if (!cluster) return local;
   if (!local) return cluster;
   return chooseNewerState(local, cluster);
@@ -288,7 +287,9 @@ export async function writeState(
   projectDir: string,
   state: StateWrite,
   releaseName?: string,
+  configuredNamespace?: string,
 ): Promise<void> {
+  const namespace = resolveK8sNamespace(configuredNamespace);
   const { basedOnGeneration, ...body } = state;
   const localExisting = readLocalStateQuiet(projectDir);
 
@@ -304,7 +305,7 @@ export async function writeState(
   let clusterReadError: ClusterStateWriteError | null = null;
   if (releaseName) {
     try {
-      const existing = await readClusterStateForWrite(releaseName);
+      const existing = await readClusterStateForWrite(releaseName, namespace);
       clusterGeneration = existing.generation;
       resourceVersion = existing.resourceVersion;
     } catch (err) {
@@ -378,7 +379,7 @@ export async function writeState(
 
   // Write to cluster ConfigMap (throws ClusterStateWriteError on failure)
   if (releaseName) {
-    await writeClusterState(releaseName, stamped, resourceVersion);
+    await writeClusterState(releaseName, stamped, resourceVersion, namespace);
   }
 }
 
@@ -386,12 +387,12 @@ function configMapName(releaseName: string): string {
   return `${releaseName}${CONFIGMAP_NAME_SUFFIX}`;
 }
 
-const STATE_GET_ARGS = (cmName: string): string[] => [
+const STATE_GET_ARGS = (cmName: string, namespace: string): string[] => [
   "get",
   "configmap",
   cmName,
   "-n",
-  STATE_NAMESPACE,
+  namespace,
   // N20: THE machine-readable absence signal. With --ignore-not-found a genuinely absent
   // ConfigMap is exit 0 + empty stdout, so any non-zero exit is a real failure
   // (connectivity, RBAC, expired credentials) and must never read as "no state yet".
@@ -460,19 +461,19 @@ function parseStateConfigMap(
   return { state, resourceVersion };
 }
 
-async function readClusterState(releaseName: string): Promise<ClusterStateRead> {
+async function readClusterState(releaseName: string, namespace: string): Promise<ClusterStateRead> {
   const cmName = configMapName(releaseName);
-  const result = await execCapture("kubectl", STATE_GET_ARGS(cmName), {
+  const result = await execCapture("kubectl", STATE_GET_ARGS(cmName, namespace), {
     timeoutMs: KUBECTL_TIMEOUT_MS,
   }).catch((err: unknown) => {
     throw new ClusterStateReadError(
-      `Could not read the deploy-state ConfigMap ${cmName} in namespace ${STATE_NAMESPACE}: ` +
+      `Could not read the deploy-state ConfigMap ${cmName} in namespace ${namespace}: ` +
         `${err instanceof Error ? err.message : String(err)}`,
     );
   });
   if (result.exitCode !== 0) {
     throw new ClusterStateReadError(
-      `Could not read the deploy-state ConfigMap ${cmName} in namespace ${STATE_NAMESPACE} ` +
+      `Could not read the deploy-state ConfigMap ${cmName} in namespace ${namespace} ` +
         `(kubectl exited ${result.exitCode}${result.timedOut ? ", timed out" : ""}). ` +
         `--ignore-not-found makes a genuinely absent ConfigMap exit 0, so this is a ` +
         `connectivity/RBAC failure, NOT "no deploys yet".` +
@@ -488,9 +489,10 @@ async function readClusterState(releaseName: string): Promise<ClusterStateRead> 
 // while an unreadable cluster IS (see writeState).
 async function readClusterStateForWrite(
   releaseName: string,
+  namespace: string,
 ): Promise<{ generation: number; resourceVersion: string | null }> {
   const cmName = configMapName(releaseName);
-  const result = await execCapture("kubectl", STATE_GET_ARGS(cmName), {
+  const result = await execCapture("kubectl", STATE_GET_ARGS(cmName, namespace), {
     timeoutMs: KUBECTL_TIMEOUT_MS,
   }).catch((err: unknown) => {
     throw new ClusterStateWriteError(
@@ -513,10 +515,17 @@ async function readClusterStateForWrite(
   };
 }
 
-async function currentResourceVersion(releaseName: string): Promise<string | null> {
-  const result = await execCapture("kubectl", STATE_GET_ARGS(configMapName(releaseName)), {
-    timeoutMs: KUBECTL_TIMEOUT_MS,
-  });
+async function currentResourceVersion(
+  releaseName: string,
+  namespace: string,
+): Promise<string | null> {
+  const result = await execCapture(
+    "kubectl",
+    STATE_GET_ARGS(configMapName(releaseName), namespace),
+    {
+      timeoutMs: KUBECTL_TIMEOUT_MS,
+    },
+  );
   if (result.exitCode !== 0) return null;
   return parseStateConfigMap(configMapName(releaseName), result.stdout).resourceVersion;
 }
@@ -525,6 +534,7 @@ async function writeClusterState(
   releaseName: string,
   state: AdapterState,
   resourceVersion: string | null,
+  namespace: string,
 ): Promise<void> {
   const cmName = configMapName(releaseName);
   // JSON, not hand-built YAML: the old writer embedded the state in a single-quoted YAML
@@ -551,8 +561,8 @@ async function writeClusterState(
   // replace (update, precondition) when it exists; create (fails AlreadyExists if a
   // racing writer got there first) when it does not.
   const args = resourceVersion
-    ? ["replace", "-n", STATE_NAMESPACE, "-f", "-"]
-    : ["create", "-n", STATE_NAMESPACE, "-f", "-"];
+    ? ["replace", "-n", namespace, "-f", "-"]
+    : ["create", "-n", namespace, "-f", "-"];
 
   // N22: via execCaptureStdin — the stdin 'error' handler, timeout, and Windows shim
   // handling all live in exec.ts. The payload never goes on argv (size + secrets rule).
@@ -570,7 +580,7 @@ async function writeClusterState(
   // N23: classify the failure on the machine-readable signal — did the object move? —
   // never on stderr text. A moved (or newly created) resourceVersion means a concurrent
   // deploy/rollback committed state while we were writing.
-  const observed = await currentResourceVersion(releaseName).catch(() => null);
+  const observed = await currentResourceVersion(releaseName, namespace).catch(() => null);
   const concurrent = observed !== null && observed !== resourceVersion;
   const detail = result.stderr.trim() || `kubectl ${args[0]} exited ${result.exitCode}`;
   throw new ClusterStateWriteError(

--- a/src/cli/tail.ts
+++ b/src/cli/tail.ts
@@ -4,6 +4,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { execCapture } from "./exec.js";
 import { sanitizeForTerminal } from "./terminal.js";
 import { assertSafeInfrastructure, infrastructurePath } from "./infrastructure-validation.js";
+import { resolveK8sNamespace } from "../emit/templates/utils.js";
 
 const COLORS = [
   "\x1b[36m", // cyan
@@ -23,18 +24,21 @@ const RED = "\x1b[31m";
 
 export async function runTail(options: { projectDir: string; releaseName: string }): Promise<void> {
   const { projectDir, releaseName } = options;
+  let namespace = resolveK8sNamespace();
 
   // Connect to the right cluster
   const infraPath = infrastructurePath(projectDir);
   if (existsSync(infraPath)) {
-    let infra: { projectId?: string; region?: string };
+    let infra: { projectId?: string; region?: string; namespace?: string };
     try {
       infra = JSON.parse(readFileSync(infraPath, "utf-8"));
       // S13: validate before these reach a gcloud/kubectl argv.
       assertSafeInfrastructure(infra);
+      namespace = resolveK8sNamespace(infra.namespace);
     } catch (err) {
-      // Name the file — a bare SyntaxError gives no clue WHICH file is corrupt.
-      throw new Error(`Failed to parse ${infraPath}: ${(err as Error).message}`);
+      // Name the file — this covers both malformed JSON and a parsed value that fails
+      // infrastructure validation (for example, an invalid namespace).
+      throw new Error(`Invalid ${infraPath}: ${(err as Error).message}`);
     }
     if (infra.projectId && infra.region) {
       const credResult = await execCapture("gcloud", [
@@ -77,7 +81,7 @@ export async function runTail(options: { projectDir: string; releaseName: string
     const shortId = podName.split("-").pop()!.slice(0, 5);
     const badge = `${component}/${shortId}`;
 
-    const child = spawn("kubectl", ["logs", "-f", "--tail=10", podName], {
+    const child = spawn("kubectl", ["logs", "-f", "--tail=10", "-n", namespace, podName], {
       stdio: ["ignore", "pipe", "pipe"],
     });
 
@@ -121,6 +125,8 @@ export async function runTail(options: { projectDir: string; releaseName: string
     const podsResult = await execCapture("kubectl", [
       "get",
       "pods",
+      "-n",
+      namespace,
       "-l",
       `app.kubernetes.io/name=${releaseName}`,
       "-o",

--- a/src/emit/metadata.ts
+++ b/src/emit/metadata.ts
@@ -20,6 +20,7 @@ export function generateBuildMetadata({
   poolNames,
   generatedAt,
   provider,
+  namespace,
   containerRegistry,
   nodeCidrs,
   containerStrategy,
@@ -72,6 +73,8 @@ export function generateBuildMetadata({
    * discover NetworkPolicy ranges through gcloud.
    */
   provider: string;
+  /** Namespace qualified into the ext_proc authority at build time. */
+  namespace: string;
   /**
    * Registry the emitted chart's image references were built against. The routing tier's image
    * is baked into its Deployment template at BUILD time, so a chart is only valid for the
@@ -86,6 +89,7 @@ export function generateBuildMetadata({
       buildId,
       nextVersion,
       provider,
+      namespace,
       ...(containerRegistry ? { containerRegistry } : {}),
       ...(nodeCidrs && nodeCidrs.length > 0 ? { nodeCidrs } : {}),
       pools: poolNames,

--- a/src/emit/templates/route-ext-update-job.ts
+++ b/src/emit/templates/route-ext-update-job.ts
@@ -4,7 +4,6 @@ import {
   assertSafeProjectId,
   assertSafeRegion,
   assertSafeBuildId,
-  K8S_NAMESPACE,
 } from "./utils.js";
 
 // Single source of truth for the traffic-ext registration Job name. deploy.ts's
@@ -178,10 +177,10 @@ spec:
               # A rewritten \`service\`/\`authority\` would point this LB's callout at a
               # DIFFERENT backend — i.e. insert a middleware tier that sees and rewrites
               # every request. Both values are fully determined by the release name,
-              # project, and the single supported namespace, so verify them against the
+              # project, and the Helm release namespace, so verify them against the
               # values this Job was RENDERED with instead of trusting the mount. (The
               # residual IAM exposure — the binding is project-wide, so any principal who
-              # can create a pod in "${K8S_NAMESPACE}" can set
+              # can create a pod in this release namespace can set
               # serviceAccountName: ${releaseName}-deploy-sa and inherit it — needs a
               # resource condition on the binding in cli/init.ts; that is tracked
               # separately.)
@@ -216,7 +215,7 @@ spec:
                 echo "route-extension.yaml matches the rendered chart (sha256) ✓"
               fi
               EXPECT_SERVICE="projects/${projectId}/global/backendServices/${releaseName}-routing-service"
-              EXPECT_AUTHORITY="${releaseName}-routing-service.${K8S_NAMESPACE}.svc.cluster.local"
+              EXPECT_AUTHORITY="${releaseName}-routing-service.{{ .Release.Namespace }}.svc.cluster.local"
               GOT_SERVICE=$(sed -n 's/^ *service: *"\\(.*\\)" *$/\\1/p' /tmp/ext.yaml)
               GOT_AUTHORITY=$(sed -n 's/^ *authority: *"\\(.*\\)" *$/\\1/p' /tmp/ext.yaml)
               if [ "$GOT_SERVICE" != "$EXPECT_SERVICE" ]; then

--- a/src/emit/templates/utils.ts
+++ b/src/emit/templates/utils.ts
@@ -1,16 +1,15 @@
 // src/emit/templates/utils.ts
 import { createHash } from "node:crypto";
 
-/**
- * The ONLY namespace this adapter deploys to. init binds Workload Identity to
- * `default/<release>-deploy-sa`, and every kubectl/helm call in the CLI pins this
- * literal instead of trusting the operator's current context. Build time
- * (adapter.ts) and deploy time (deploy.ts) both REJECT an infrastructure.json
- * `namespace` other than this: honoring it only in the ext_proc extension-chain
- * authority (extension-chain.ts) while workloads land in "default" skewed the
- * GXLB callout target and failed every edge callout.
- */
+/** Default release namespace when infrastructure.json does not declare one. */
 export const K8S_NAMESPACE = "default";
+
+/** Resolve and validate the release namespace at each cluster/YAML consumption boundary. */
+export function resolveK8sNamespace(namespace?: unknown): string {
+  const resolved = namespace ?? K8S_NAMESPACE;
+  assertSafeNamespace(resolved);
+  return resolved;
+}
 
 export function sanitizeK8sName(name: string, suffix = ""): string {
   // Lowercase, replace non-alphanumeric with hyphens
@@ -233,7 +232,7 @@ const IMAGE_REGISTRY_RE =
 // Next.js build ids (default or from `generateBuildId()` — commonly a git ref in CI).
 // Excludes helm `--set` metacharacters (`,` `\`) and YAML/template breakouts (`"` `'` `{`).
 const BUILD_ID_RE = /^[A-Za-z0-9._-]{1,128}$/;
-const NAMESPACE_RE = /^[a-z0-9-]{1,63}$/;
+const NAMESPACE_RE = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
 // GCS bucket naming rules (https://cloud.google.com/storage/docs/buckets#naming).
 const BUCKET_RE = /^[a-z0-9][a-z0-9._-]{1,61}[a-z0-9]$/;
 
@@ -301,11 +300,12 @@ export function assertSafeBuildId(buildId: string): void {
   }
 }
 
-export function assertSafeNamespace(namespace: string): void {
-  if (!NAMESPACE_RE.test(namespace)) {
+export function assertSafeNamespace(namespace: unknown): asserts namespace is string {
+  if (typeof namespace !== "string" || !NAMESPACE_RE.test(namespace)) {
     throw new Error(
-      `Invalid namespace "${namespace}": must match ${NAMESPACE_RE} ` +
-        `(lowercase letters, digits, and hyphens only, max 63 chars).`,
+      `Invalid namespace ${JSON.stringify(namespace)}: must be a DNS-1123 label ` +
+        `(lowercase letters, digits, and hyphens only, max 63 chars, and must start ` +
+        `and end with a letter or digit).`,
     );
   }
 }

--- a/tests/adapter-config-variant.test.ts
+++ b/tests/adapter-config-variant.test.ts
@@ -9,6 +9,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import {
   infrastructurePath,
+  infrastructureWritePath,
   outputDirName,
   stateFileName,
 } from "../src/cli/infrastructure-validation.js";
@@ -54,6 +55,14 @@ describe("infrastructurePath — config variants", () => {
     const dir = project({ ".k8s-adapter/infrastructure.json": "{}" });
     process.env.ADAPTER_K8S_CONFIG = "nosuch";
     expect(() => infrastructurePath(dir)).toThrow(/nosuch/);
+  });
+
+  it("lets init select the missing variant path without falling back", () => {
+    const dir = project({ ".k8s-adapter/infrastructure.json": "{}" });
+    process.env.ADAPTER_K8S_CONFIG = "scaleway";
+    expect(infrastructureWritePath(dir)).toBe(
+      path.join(dir, ".k8s-adapter", "infrastructure.scaleway.json"),
+    );
   });
 
   it("rejects a variant that is a PATH rather than a name", () => {

--- a/tests/adapter-config.test.ts
+++ b/tests/adapter-config.test.ts
@@ -380,17 +380,26 @@ describe("onBuildComplete build-time guards", () => {
     await expect(adapter.onBuildComplete!(ctx("b12345"))).resolves.toBeUndefined();
   });
 
-  it("rejects a non-default namespace from infrastructure.json (fail-fast, actionable)", async () => {
-    // The namespace feeds ONLY the ext_proc extension-chain authority; every
-    // kubectl/helm call pins the literal "default" (init binds Workload Identity
-    // there). Honoring "prod" here shipped workloads to default while the GXLB
-    // callout targeted prod — every edge callout failed. The build must refuse.
+  it("records a custom namespace in the build handoff", async () => {
     writeInfra({ namespace: "prod" });
     const adapter = createK8sAdapter(validConfig);
     await adapter.modifyConfig!({} as any, {} as any);
-    await expect(adapter.onBuildComplete!(ctx("b12345"))).rejects.toThrow(
-      /Unsupported namespace "prod".*deploys only to the "default" namespace.*Remove "namespace"/s,
-    );
+    await expect(adapter.onBuildComplete!(ctx("b12345"))).resolves.toBeUndefined();
+    expect(
+      JSON.parse(
+        readFileSync(path.join(projectDir, ".k8s-adapter/output/build-metadata.json"), "utf-8"),
+      ).namespace,
+    ).toBe("prod");
+  });
+
+  it("qualifies the GKE extension-chain authority with the custom namespace", async () => {
+    writeInfra({ namespace: "prod", projectId: "my-project-1", region: "us-central1" });
+    const adapter = createK8sAdapter(validConfig);
+    await adapter.modifyConfig!({} as any, {} as any);
+    await expect(adapter.onBuildComplete!(ctx("b12345"))).resolves.toBeUndefined();
+    expect(
+      readFileSync(path.join(projectDir, ".k8s-adapter/output/extension-chains.json"), "utf-8"),
+    ).toContain("-routing-service.prod.svc.cluster.local");
   });
 
   it('accepts an explicit namespace of "default" (and none at all)', async () => {

--- a/tests/cli/deploy-orchestration.test.ts
+++ b/tests/cli/deploy-orchestration.test.ts
@@ -458,6 +458,7 @@ describe("runDeploy — orchestration", () => {
         basedOnGeneration: null,
       },
       RELEASE,
+      "default",
     );
     // CDN invalidated for the OUTGOING build. Prior state (legacy) recorded no tag for
     // it, so no recordedTag is passed — cdn-invalidate falls back to the full purge (M13).
@@ -681,6 +682,7 @@ describe("runDeploy — guards and teardown", () => {
         basedOnGeneration: null,
       },
       RELEASE,
+      "default",
     );
     // A loud warning named the missing deployment...
     expect(
@@ -792,21 +794,66 @@ describe("runDeploy — guards and teardown", () => {
     expect(events).not.toContain("helm");
   });
 
-  it("rejects a non-default namespace in infrastructure.json before touching anything", async () => {
-    // The chart/extension chain were built for the ext_proc authority in
-    // infra.namespace, but every kubectl/helm call pins "default" — deploying would
-    // skew the GXLB callout target away from the workloads. Fail fast instead.
-    setupFs({ infra: { ...BASE_INFRA, namespace: "prod" } });
+  it("uses a custom namespace for Helm, cluster state, and routing retention", async () => {
+    setupFs({
+      infra: { ...BASE_INFRA, namespace: "prod" },
+      metadata: { buildId: "buildn", pools: ["ssr"], cacheEnabled: false, namespace: "prod" },
+    });
     vi.mocked(execCapture).mockImplementation(happyCluster(events) as never);
+
+    await runDeploy({ projectDir: PROJECT, releaseName: RELEASE, skipBuild: true });
+
+    const helmCall = vi.mocked(execOrThrow).mock.calls.find(([cmd]) => cmd === "helm");
+    expect(helmCall?.[1].join(" ")).toContain("--namespace prod --create-namespace");
+    expect(vi.mocked(readState)).toHaveBeenCalledWith(PROJECT, RELEASE, { namespace: "prod" });
+    expect(vi.mocked(retainLiveRoutingManifest)).toHaveBeenCalledWith(RELEASE, "prod");
+    expect(vi.mocked(writeState)).toHaveBeenCalledWith(
+      PROJECT,
+      expect.objectContaining({ buildId: "buildn", previousBuildId: "buildm" }),
+      RELEASE,
+      "prod",
+    );
+  });
+
+  it("refuses build output emitted for a different namespace", async () => {
+    setupFs({
+      infra: { ...BASE_INFRA, namespace: "prod" },
+      metadata: {
+        buildId: "buildn",
+        pools: ["ssr"],
+        cacheEnabled: false,
+        namespace: "staging",
+      },
+    });
 
     await expect(
       runDeploy({ projectDir: PROJECT, releaseName: RELEASE, skipBuild: true }),
-    ).rejects.toThrow(
-      /Unsupported namespace "prod".*deploys only to the "default" namespace.*Remove "namespace"/s,
-    );
+    ).rejects.toThrow(/emitted for namespace "staging".*targets "prod"/s);
     expect(events).not.toContain("helm");
-    expect(events).not.toContain("get-credentials");
-    expect(vi.mocked(writeState)).not.toHaveBeenCalled();
+  });
+
+  it("treats legacy build output with no namespace as default", async () => {
+    setupFs({
+      infra: { ...BASE_INFRA, namespace: "prod" },
+      metadata: { buildId: "buildn", pools: ["ssr"], cacheEnabled: false },
+    });
+
+    await expect(
+      runDeploy({ projectDir: PROJECT, releaseName: RELEASE, skipBuild: true }),
+    ).rejects.toThrow(/emitted for namespace "default".*targets "prod"/s);
+    expect(events).not.toContain("helm");
+  });
+
+  it("rejects malformed namespace metadata instead of bypassing the fingerprint", async () => {
+    setupFs({
+      infra: { ...BASE_INFRA, namespace: "prod" },
+      metadata: { buildId: "buildn", pools: ["ssr"], cacheEnabled: false, namespace: 123 },
+    });
+
+    await expect(
+      runDeploy({ projectDir: PROJECT, releaseName: RELEASE, skipBuild: true }),
+    ).rejects.toThrow(/Invalid namespace/);
+    expect(events).not.toContain("helm");
   });
 
   it('accepts an explicit namespace of "default" in infrastructure.json', async () => {
@@ -831,6 +878,7 @@ describe("runDeploy — guards and teardown", () => {
         basedOnGeneration: null,
       },
       RELEASE,
+      "default",
     );
   });
 
@@ -866,6 +914,7 @@ describe("runDeploy — guards and teardown", () => {
         basedOnGeneration: null,
       },
       RELEASE,
+      "default",
     );
   });
 
@@ -1189,8 +1238,10 @@ describe("runDeploy — N25: every post-helm abort puts the ext_proc edge back",
 
     expect(vi.mocked(revertRoutingServiceToBuild)).toHaveBeenCalledWith({
       releaseName: RELEASE,
+      namespace: "default",
       targetBuildId: "buildm",
       registry: REGISTRY,
+      targetImageDigest: undefined,
     });
     expect(printedErrors()).toContain("reverted to build buildm");
     expect(vi.mocked(writeState)).not.toHaveBeenCalled();
@@ -1484,6 +1535,7 @@ describe("runDeploy — N30: routing-manifest retention failure is fatal by defa
       PROJECT,
       expect.objectContaining({ unretainedManifestBuilds: ["buildm"] }),
       RELEASE,
+      "default",
     );
     expect(printedWarnings()).toContain("revert the routing IMAGE only");
   });
@@ -1512,6 +1564,7 @@ describe("runDeploy — N30: routing-manifest retention failure is fatal by defa
         basedOnGeneration: null,
       },
       RELEASE,
+      "default",
     );
   });
 });

--- a/tests/cli/deploy.test.ts
+++ b/tests/cli/deploy.test.ts
@@ -254,6 +254,19 @@ describe("buildHelmUpgradeArgs", () => {
     expect(args.join(" ")).toContain("activeBuildId=abc123");
   });
 
+  it("pins Helm to the configured namespace", () => {
+    const args = buildHelmUpgradeArgs({
+      releaseName: "my-app",
+      chartPath: ".k8s-adapter/output/chart",
+      buildId: "abc123",
+      registry: "us-central1-docker.pkg.dev/my-project/nextjs",
+      previousBuildId: null,
+      namespace: "apps",
+    });
+
+    expect(args.join(" ")).toContain("--namespace apps --create-namespace");
+  });
+
   it("sanitizes the serving build selector used during the upgrade", () => {
     const args = buildHelmUpgradeArgs({
       releaseName: "my-app",

--- a/tests/cli/describe.test.ts
+++ b/tests/cli/describe.test.ts
@@ -63,6 +63,26 @@ describe("runDescribe", () => {
     expect(depCall![1].join(" ")).toContain("-n default");
   });
 
+  it("uses the configured namespace for state and deployment reads", async () => {
+    writeFileSync(
+      path.join(tmpDir, ".k8s-adapter", "infrastructure.json"),
+      JSON.stringify({
+        projectId: "proj-12345",
+        region: "us-central1",
+        hosts: [],
+        namespace: "apps",
+      }),
+    );
+
+    await runDescribe({ projectDir: tmpDir, releaseName: RELEASE });
+
+    expect(readState).toHaveBeenCalledWith(tmpDir, RELEASE, { namespace: "apps" });
+    const depCall = vi
+      .mocked(execCapture)
+      .mock.calls.find(([cmd, args]) => cmd === "kubectl" && args.includes("deployments"));
+    expect(depCall?.[1].join(" ")).toContain("-n apps");
+  });
+
   it("classifies builds by EXACT version label, not prefix matching", async () => {
     // Two build ids sharing a 12-char normalized prefix must not both classify as
     // "current" (the prefix-substring technique caused a production 503 — see deploy.ts).

--- a/tests/cli/destroy.test.ts
+++ b/tests/cli/destroy.test.ts
@@ -219,6 +219,20 @@ describe("runDestroy — confirmation gate (L12)", () => {
     expect(out).toContain(`[dry-run] gcloud iam roles delete ${deployExtRoleId("my-app")}`);
   });
 
+  it("targets the configured namespace for release-scoped Kubernetes resources", async () => {
+    writeFileSync(
+      path.join(tmpDir, ".k8s-adapter", "infrastructure.json"),
+      JSON.stringify({ ...INFRA, namespace: "apps" }),
+    );
+
+    await runDestroy({ projectDir: tmpDir, releaseName: "my-app", dryRun: true });
+
+    const out = printedOutput();
+    expect(out).toContain("helm uninstall my-app --namespace apps");
+    expect(out).toContain("kubectl delete configmap -n apps");
+    expect(out).toContain("kubectl delete secret -n apps");
+  });
+
   it("deletes BOTH service accounts for real (not only the deploy one)", async () => {
     await runDestroy({ projectDir: tmpDir, releaseName: "my-app", yes: true });
     const deleted = vi

--- a/tests/cli/doctor.test.ts
+++ b/tests/cli/doctor.test.ts
@@ -98,7 +98,7 @@ describe("runDoctor", () => {
   let tmpDir: string;
   const infraDir = () => path.join(tmpDir, ".k8s-adapter");
 
-  function writeInfra(hosts: string[] = []): void {
+  function writeInfra(hosts: string[] = [], namespace?: string): void {
     mkdirSync(infraDir(), { recursive: true });
     writeFileSync(
       path.join(infraDir(), "infrastructure.json"),
@@ -109,6 +109,7 @@ describe("runDoctor", () => {
         gcsBucket: "proj-nextjs-static",
         containerRegistry: "us-central1-docker.pkg.dev/proj/nextjs",
         releaseName: RELEASE,
+        ...(namespace ? { namespace } : {}),
       }),
     );
   }
@@ -398,5 +399,26 @@ describe("runDoctor", () => {
       expect(call, `kubectl ${resource} call`).toBeDefined();
       expect(call!.join(" "), `kubectl ${resource} pinned to -n default`).toContain("-n default");
     }
+  });
+
+  it("includes the configured namespace in kubectl remediation commands", async () => {
+    writeInfra([], "apps");
+    vi.mocked(readState).mockResolvedValue({ buildId: "buildn", previousBuildId: null } as never);
+    stubCluster({
+      deployments: "rel-ssr-buildn|0/1|buildn",
+      services: "rel-ssr|ssr",
+      endpoints: "false",
+      pods: "rel-ssr-buildn-a",
+      logs: "FATAL startup failed",
+    });
+
+    await expect(runDoctor({ projectDir: tmpDir, releaseName: RELEASE })).rejects.toThrow(
+      /process\.exit:1/,
+    );
+
+    const out = printed();
+    expect(out).toContain("kubectl describe deployment/rel-ssr-buildn -n apps");
+    expect(out).toContain("kubectl get svc rel-ssr -n apps");
+    expect(out).toContain("kubectl logs rel-ssr-buildn-a -n apps --tail=50");
   });
 });

--- a/tests/cli/init.test.ts
+++ b/tests/cli/init.test.ts
@@ -10,7 +10,7 @@ import {
 } from "../../src/cli/init.js";
 import * as exec from "../../src/cli/exec.js";
 import * as scaffold from "../../src/cli/scaffold.js";
-import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import path from "node:path";
 import os from "node:os";
 
@@ -62,6 +62,30 @@ describe("buildInitGcloudCommands", () => {
 
     const saCmd = commands.find((c) => c.description.includes("service account"));
     expect(saCmd).toBeDefined();
+  });
+
+  it("binds Workload Identity to the configured namespace", () => {
+    const commands = buildInitGcloudCommands({
+      projectId: "my-project",
+      region: "us-central1",
+      bucket: "my-project-nextjs-static",
+      releaseName: "my-app",
+      namespace: "apps",
+    });
+    const binding = commands.find((c) => c.args.includes("roles/iam.workloadIdentityUser"));
+    expect(binding?.args).toContain("serviceAccount:my-project.svc.id.goog[apps/my-app-deploy-sa]");
+  });
+
+  it("rejects an unsafe namespace before building command arguments", () => {
+    expect(() =>
+      buildInitGcloudCommands({
+        projectId: "my-project",
+        region: "us-central1",
+        bucket: "my-project-nextjs-static",
+        releaseName: "my-app",
+        namespace: 'bad";inject',
+      }),
+    ).toThrow(/Invalid namespace/);
   });
 
   it("includes routing service backend provisioning commands", () => {
@@ -269,8 +293,59 @@ describe("runInit", () => {
 
   function mockScaffold(): void {
     vi.spyOn(scaffold, "generateAdapterConfig").mockReturnValue("config");
-    vi.spyOn(scaffold, "generateInfrastructureJson").mockReturnValue("infra");
+    vi.spyOn(scaffold, "generateInfrastructureJson").mockImplementation((config) =>
+      JSON.stringify(config),
+    );
   }
+
+  it("writes the selected config variant instead of the default infrastructure file", async () => {
+    const execCapture = vi.spyOn(exec, "execCapture");
+    mockScaffold();
+    execCapture.mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+    process.env.ADAPTER_K8S_CONFIG = "staging";
+
+    try {
+      await runInit({ ...VALID, namespace: "apps", projectDir: tmpDir, iamRetryDelayMs: 0 });
+    } finally {
+      delete process.env.ADAPTER_K8S_CONFIG;
+    }
+
+    const variantPath = path.join(tmpDir, ".k8s-adapter", "infrastructure.staging.json");
+    expect(existsSync(variantPath)).toBe(true);
+    expect(existsSync(path.join(tmpDir, ".k8s-adapter", "infrastructure.json"))).toBe(false);
+    expect(JSON.parse(readFileSync(variantPath, "utf-8")).namespace).toBe("apps");
+  });
+
+  it("prints a namespace-pinned Gateway lookup after init", async () => {
+    const execCapture = vi.spyOn(exec, "execCapture");
+    mockScaffold();
+    execCapture.mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+
+    await runInit({
+      ...VALID,
+      namespace: "apps",
+      projectDir: tmpDir,
+      iamRetryDelayMs: 0,
+    });
+
+    expect(console.log).toHaveBeenCalledWith(
+      expect.stringContaining("kubectl get gateway my-app-gateway -n apps"),
+    );
+  });
+
+  it("refuses to move an existing release to another namespace", async () => {
+    mkdirSync(path.join(tmpDir, ".k8s-adapter"), { recursive: true });
+    writeFileSync(
+      path.join(tmpDir, ".k8s-adapter", "infrastructure.json"),
+      JSON.stringify({ namespace: "default" }),
+    );
+    const execCapture = vi.spyOn(exec, "execCapture");
+
+    await expect(
+      runInit({ ...VALID, namespace: "apps", projectDir: tmpDir, iamRetryDelayMs: 0 }),
+    ).rejects.toThrow(/Cannot change the namespace.*default.*apps/s);
+    expect(execCapture).not.toHaveBeenCalled();
+  });
 
   it("retries on IAM binding failure and handles already exists", async () => {
     const execCapture = vi.spyOn(exec, "execCapture");

--- a/tests/cli/parse-args.test.ts
+++ b/tests/cli/parse-args.test.ts
@@ -35,8 +35,9 @@ describe("parseArgs", () => {
   });
 
   it("supports the --flag value form", () => {
-    const { flags } = parseArgs(argv("init", "--project-id", "my-proj"));
+    const { flags } = parseArgs(argv("init", "--project-id", "my-proj", "--namespace", "apps"));
     expect(flags["project-id"]).toBe("my-proj");
+    expect(flags["namespace"]).toBe("apps");
   });
 
   it("value flags hard-error when the value is missing", () => {

--- a/tests/cli/rollback.test.ts
+++ b/tests/cli/rollback.test.ts
@@ -124,6 +124,7 @@ describe("runRollback — CDN invalidation", () => {
       // N69: rollback passes the generation it READ as writeState's floor.
       { buildId: "buildm", previousBuildId: "buildn", cdnTags, basedOnGeneration: null },
       RELEASE,
+      "default",
     );
   });
 
@@ -140,6 +141,7 @@ describe("runRollback — CDN invalidation", () => {
       PROJECT,
       { buildId: "buildm", previousBuildId: "buildn", basedOnGeneration: null },
       RELEASE,
+      "default",
     );
   });
 
@@ -163,7 +165,10 @@ describe("runRollback — CDN invalidation", () => {
     expect(vi.mocked(execCapture)).not.toHaveBeenCalled();
     expect(vi.mocked(execCaptureStdin)).not.toHaveBeenCalled();
     // State came from the LOCAL file only.
-    expect(vi.mocked(readState)).toHaveBeenCalledWith(PROJECT, RELEASE, { localOnly: true });
+    expect(vi.mocked(readState)).toHaveBeenCalledWith(PROJECT, RELEASE, {
+      localOnly: true,
+      namespace: "default",
+    });
     // No mutations of any kind.
     expect(vi.mocked(execOrThrow)).not.toHaveBeenCalled();
     expect(vi.mocked(writeState)).not.toHaveBeenCalled();
@@ -284,6 +289,7 @@ describe("runRollback — HPA names past the 59-char truncation boundary", () =>
       PROJECT,
       { buildId: PREV, previousBuildId: CURR, basedOnGeneration: null },
       LONG_RELEASE,
+      "default",
     );
   });
 });
@@ -319,7 +325,9 @@ describe("runRollback — state read ordering", () => {
     expect(vi.mocked(execCapture).mock.calls[0]![1]).toContain("get-credentials");
     expect(stateOrder).toBeGreaterThan(credOrder);
     // Non-dry-run reads may hit the cluster ConfigMap (no localOnly flag).
-    expect(vi.mocked(readState)).toHaveBeenCalledWith(PROJECT, RELEASE, undefined);
+    expect(vi.mocked(readState)).toHaveBeenCalledWith(PROJECT, RELEASE, {
+      namespace: "default",
+    });
   });
 });
 
@@ -476,6 +484,7 @@ describe("runRollback — routing service revert", () => {
       PROJECT,
       { buildId: "buildm", previousBuildId: "buildn", basedOnGeneration: null },
       RELEASE,
+      "default",
     );
   });
 

--- a/tests/cli/state.test.ts
+++ b/tests/cli/state.test.ts
@@ -30,6 +30,7 @@ describe("state", () => {
   let tmpDir: string;
 
   beforeEach(() => {
+    vi.clearAllMocks();
     tmpDir = mkdtempSync(path.join(os.tmpdir(), "adapter-k8s-test-"));
   });
 
@@ -60,6 +61,23 @@ describe("state", () => {
     // N21: every write stamps a monotonic generation + updatedAt on top of the payload.
     expect(read).toMatchObject(state);
     expect(read!.generation).toBe(1);
+  });
+
+  it("pins cluster state reads and writes to the configured namespace", async () => {
+    vi.clearAllMocks();
+    vi.mocked(execCapture).mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+    vi.mocked(execCaptureStdin).mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+
+    await readState(tmpDir, "rel", { namespace: "apps" });
+    expect(vi.mocked(execCapture).mock.calls[0]![1]).toContain("apps");
+
+    await writeState(
+      tmpDir,
+      { buildId: "b1", previousBuildId: null, basedOnGeneration: null },
+      "rel",
+      "apps",
+    );
+    expect(vi.mocked(execCaptureStdin).mock.calls[0]![1]).toContain("apps");
   });
 
   it("overwrites existing state", async () => {

--- a/tests/cli/tail.test.ts
+++ b/tests/cli/tail.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { runTail } from "../../src/cli/tail.js";
+
+describe("runTail", () => {
+  let projectDir: string | undefined;
+
+  afterEach(() => {
+    if (projectDir) rmSync(projectDir, { recursive: true, force: true });
+    projectDir = undefined;
+  });
+
+  it("reports invalid infrastructure values without mislabeling them as JSON parse failures", async () => {
+    projectDir = mkdtempSync(path.join(os.tmpdir(), "adapter-k8s-tail-test-"));
+    const adapterDir = path.join(projectDir, ".k8s-adapter");
+    mkdirSync(adapterDir);
+    const infraPath = path.join(adapterDir, "infrastructure.json");
+    writeFileSync(infraPath, JSON.stringify({ namespace: "Invalid" }));
+
+    await expect(runTail({ projectDir, releaseName: "my-app" })).rejects.toThrow(
+      new RegExp(`Invalid ${infraPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}: Invalid namespace`),
+    );
+  });
+});

--- a/tests/emit/metadata.test.ts
+++ b/tests/emit/metadata.test.ts
@@ -5,6 +5,8 @@ import { generateBuildMetadata } from "../../src/emit/metadata.js";
 const base = {
   buildId: "b12345",
   nextVersion: "16.2.0",
+  provider: "generic",
+  namespace: "apps",
   poolNames: ["ssr"],
   generatedAt: "2026-01-01T00:00:00.000Z",
   containerStrategy: "traced-assets" as const,
@@ -20,6 +22,8 @@ describe("generateBuildMetadata", () => {
     expect(JSON.parse(generateBuildMetadata(base))).toEqual({
       buildId: "b12345",
       nextVersion: "16.2.0",
+      provider: "generic",
+      namespace: "apps",
       pools: ["ssr"],
       generatedAt: "2026-01-01T00:00:00.000Z",
       containerStrategy: "traced-assets",

--- a/tests/emit/templates/route-ext-job.test.ts
+++ b/tests/emit/templates/route-ext-job.test.ts
@@ -412,12 +412,14 @@ describe("N73: route-ext Job verifies the mounted route-extension.yaml", () => {
 
   it("pins the expected service and authority to the values it was RENDERED with", () => {
     const yaml = job();
-    // Both are fully determined by release name + project + the single supported namespace
-    // (K8S_NAMESPACE), so they can be re-derived rather than trusted from /config.
+    // Both are fully determined by release name + project + the Helm release namespace,
+    // so they can be re-derived rather than trusted from /config.
     expect(yaml).toContain(
       'EXPECT_SERVICE="projects/my-project/global/backendServices/my-app-routing-service"',
     );
-    expect(yaml).toContain('EXPECT_AUTHORITY="my-app-routing-service.default.svc.cluster.local"');
+    expect(yaml).toContain(
+      'EXPECT_AUTHORITY="my-app-routing-service.{{ .Release.Namespace }}.svc.cluster.local"',
+    );
   });
 
   it("aborts before the privileged import when either value mismatches", () => {

--- a/tests/emit/templates/utils.test.ts
+++ b/tests/emit/templates/utils.test.ts
@@ -16,6 +16,8 @@ import {
   assertSafePoolName,
   assertSafeYamlScalar,
   assertSafeImageReference,
+  assertSafeNamespace,
+  resolveK8sNamespace,
   K8S_NAMESPACE,
 } from "../../../src/emit/templates/utils.js";
 // The snapshot name must be importable from its historical home too — deploy.ts and
@@ -88,6 +90,21 @@ describe("sanitizeK8sName", () => {
     // Short names are untouched apart from the suffix.
     expect(sanitizeK8sName("nextjs-ssr", "-hcp")).toBe("nextjs-ssr-hcp");
   });
+});
+
+describe("Kubernetes namespace validation", () => {
+  it("accepts DNS-1123 labels and defaults only absent values", () => {
+    expect(resolveK8sNamespace()).toBe(K8S_NAMESPACE);
+    expect(resolveK8sNamespace("apps-3")).toBe("apps-3");
+    expect(() => assertSafeNamespace("a".repeat(63))).not.toThrow();
+  });
+
+  it.each(["-prod", "prod-", "---", "Prod", "", "a".repeat(64), 123, null])(
+    "rejects an invalid namespace value: %j",
+    (namespace) => {
+      expect(() => assertSafeNamespace(namespace)).toThrow(/Invalid namespace/);
+    },
+  );
 });
 
 describe("routingManifestSnapshotName", () => {


### PR DESCRIPTION
- Persist a validated Kubernetes namespace during init and include it in emitted build metadata.
- Use that namespace consistently across Helm, kubectl, deploy state, rollback, diagnostics, and Workload Identity.
- Add regression coverage for custom namespaces, legacy metadata, config variants, and unsafe namespace changes.