### PR TITLE
Preserve traced dependencies during Sharp install

### DIFF
--- a/src/emit/dockerfiles.ts
+++ b/src/emit/dockerfiles.ts
@@ -65,11 +65,15 @@ function assertSafeSharpVersion(version: string): void {
 }
 
 // The in-image sharp install, shared by both emitted app Dockerfiles.
+// Keep it outside /app: npm would otherwise prune traced packages that are deliberately
+// absent from the minimal staged package.json before the container ever starts.
 function sharpInstallStep(installSharpVersion: string): string {
   assertSafeSharpVersion(installSharpVersion);
   return `# Build host had no linux-x64 sharp binding to stage — install it in-image so
 # /_next/image works (pool-server.cjs requires @img/sharp-linux-x64 at runtime).
-RUN npm install --no-save --no-audit --no-fund sharp@${installSharpVersion} \\
+RUN npm install --prefix /tmp/adapter-k8s-sharp --no-save --no-audit --no-fund sharp@${installSharpVersion} \\
+ && cp -R /tmp/adapter-k8s-sharp/node_modules/. /app/node_modules/ \\
+ && rm -rf /tmp/adapter-k8s-sharp \\
  && npm cache clean --force
 `;
 }

--- a/tests/emit/dockerfiles.test.ts
+++ b/tests/emit/dockerfiles.test.ts
@@ -67,7 +67,11 @@ describe("generateDockerfile", () => {
       buildId: "abc123",
       installSharpVersion: "0.34.5",
     });
-    expect(result).toContain("RUN npm install --no-save --no-audit --no-fund sharp@0.34.5");
+    expect(result).toContain(
+      "RUN npm install --prefix /tmp/adapter-k8s-sharp --no-save --no-audit --no-fund sharp@0.34.5",
+    );
+    expect(result).toContain("cp -R /tmp/adapter-k8s-sharp/node_modules/. /app/node_modules/");
+    expect(result).not.toContain("RUN npm install --no-save");
     expect(result.indexOf("COPY --chown=node:node . .")).toBeLessThan(
       result.indexOf("RUN npm install"),
     );
@@ -121,7 +125,11 @@ describe("generatePoolDockerfile", () => {
       buildId: "abc123",
       installSharpVersion: "0.34.5",
     });
-    expect(result).toContain("RUN npm install --no-save --no-audit --no-fund sharp@0.34.5");
+    expect(result).toContain(
+      "RUN npm install --prefix /tmp/adapter-k8s-sharp --no-save --no-audit --no-fund sharp@0.34.5",
+    );
+    expect(result).toContain("cp -R /tmp/adapter-k8s-sharp/node_modules/. /app/node_modules/");
+    expect(result).not.toContain("RUN npm install --no-save");
     // Must run after the context is copied (needs /app) and before dropping to the
     // non-root user (npm writes node_modules as root at build time).
     expect(result.indexOf("COPY --chown=node:node context/ .")).toBeLessThan(


### PR DESCRIPTION
## Summary

- install the Linux Sharp fallback in an isolated prefix
- merge Sharp runtime packages without pruning traced dependencies
- cover shared and traced image Dockerfiles

## Verification

- `npm test -- --run tests/emit/dockerfiles.test.ts`
- `npm run fmt:check`
- `npm run lint`
- `npm run typecheck`
- built and booted a Next.js 16.3 traced pool image