### PR TITLE
Preserve hostnames on HTTPS listeners

### DIFF
--- a/src/emit/templates/generic-gateway.ts
+++ b/src/emit/templates/generic-gateway.ts
@@ -82,7 +82,7 @@ export function renderGenericGateway({
 
   if (emitHttps) {
     listeners += `
-    - name: https
+    - name: https${singleHostname}
       protocol: HTTPS
       port: 443
       tls:

--- a/tests/emit/generic-chart.test.ts
+++ b/tests/emit/generic-chart.test.ts
@@ -90,21 +90,23 @@ describe("generic gateway listeners under merged gateways", () => {
   it("stamps the hostname on the listener for a single-host release", () => {
     const yaml = renderGenericGateway({
       releaseName: "e2e-lane1",
-      className: "eg",
-      hosts: [{ hostname: "lane1.localhost", tls: { enabled: false } }],
-    } as never);
+      gatewayClassName: "eg",
+      hosts: [{ hostname: "lane1.localhost", tls: { enabled: true } }],
+      tlsSecretName: "lane1-tls",
+    });
     expect(yaml).toMatch(/- name: http\n\s+hostname: "lane1\.localhost"/);
+    expect(yaml).toMatch(/- name: https\n\s+hostname: "lane1\.localhost"/);
   });
 
   it("keeps the hostname-less listener for multi-host releases (sectionName contract)", () => {
     const yaml = renderGenericGateway({
       releaseName: "multi",
-      className: "eg",
+      gatewayClassName: "eg",
       hosts: [
         { hostname: "a.example.com", tls: { enabled: false } },
         { hostname: "b.example.com", tls: { enabled: false } },
       ],
-    } as never);
+    });
     expect(yaml).not.toContain("hostname:");
   });
 });

--- a/tests/emit/templates/generic-gateway.test.ts
+++ b/tests/emit/templates/generic-gateway.test.ts
@@ -47,6 +47,8 @@ describe("renderGenericGateway", () => {
     expect(y).toContain("port: 443");
     expect(y).toContain("certificateRefs:");
     expect(y).toContain("name: app-tls");
+    expect(y).toMatch(/- name: http\n\s+hostname: "app\.example\.com"/);
+    expect(y).toMatch(/- name: https\n\s+hostname: "app\.example\.com"/);
   });
 
   it("omits HTTPS when TLS is enabled but no cert Secret was supplied", () => {


### PR DESCRIPTION
## Summary

- preserve the configured hostname on generated HTTPS listeners
- keep single-host listeners compatible with merged Envoy Gateways
- cover HTTP and HTTPS hostname generation

## Testing

- `npm test -- --run tests/emit/generic-chart.test.ts tests/emit/templates/generic-gateway.test.ts`
- `npx tsc --noEmit`