### PR TITLE
Support route cache clearing in ext-proc responses

### DIFF
--- a/src/routing-service/ext-proc-types.ts
+++ b/src/routing-service/ext-proc-types.ts
@@ -32,6 +32,8 @@ export interface HeaderMutation {
 export interface CommonResponse {
   headerMutation?: HeaderMutation;
   status?: "CONTINUE" | "CONTINUE_AND_REPLACE";
+  /** Re-run route selection after mutating a header used by the data plane's route table. */
+  clearRouteCache?: boolean;
 }
 
 export interface ImmediateResponse {

--- a/src/routing-service/server.ts
+++ b/src/routing-service/server.ts
@@ -106,6 +106,7 @@ export function plainResponseToProto(plain: PlainProcessingResponse): Processing
             setHeaders: toProtoSetHeaders(common?.headerMutation?.setHeaders ?? []),
             removeHeaders: common?.headerMutation?.removeHeaders ?? [],
           },
+          clearRouteCache: common?.clearRouteCache ?? false,
         },
       },
     },

--- a/tests/routing-service/server.test.ts
+++ b/tests/routing-service/server.test.ts
@@ -177,6 +177,7 @@ describe("plainResponseToProto (Fix E converter)", () => {
               },
             ],
           },
+          clearRouteCache: true,
           status: "CONTINUE",
         },
       },
@@ -186,6 +187,7 @@ describe("plainResponseToProto (Fix E converter)", () => {
     if (decoded.response.case !== "requestHeaders") throw new Error("wrong case");
     const common = decoded.response.value.response!;
     expect(common.status).toBe(CommonResponse_ResponseStatus.CONTINUE);
+    expect(common.clearRouteCache).toBe(true);
     const h = common.headerMutation!.setHeaders[0]!;
     expect(h.header!.key).toBe("x-upstream-pool");
     expect(dec.decode(h.header!.rawValue)).toBe("ssr");


### PR DESCRIPTION
## Summary

- expose Envoy's clear-route-cache field in processed-request responses
- serialize the field through the ext-proc server
- cover the protobuf response contract

## Testing

- npx vitest run tests/routing-service/server.test.ts
- npx tsc --noEmit
- npm run build