### PR TITLE
Respect pool ownership during local routing

### DIFF
--- a/src/pool-server/dispatch.ts
+++ b/src/pool-server/dispatch.ts
@@ -2839,8 +2839,13 @@ export function createDispatcher(options: DispatcherOptions) {
             req.headers = nextHeaders;
           }
 
-          // If this output belongs to another pool, proxy the request
-          if (resolution.pool !== poolName && !handlerLoader.has(handlerPathname)) {
+          // Pool ownership is authoritative. A broad local dynamic template can match the
+          // same concrete pathname as an exact route assigned elsewhere (for example an App
+          // `/[locale]` beside a Pages `/legacy`). Serving merely because this image has that
+          // template runs the wrong router and can feed a Pages cache entry to an App handler.
+          // Shared static files have already returned through the fast path above; every
+          // remaining foreign execution must go to its assigned pool.
+          if (resolution.pool !== poolName) {
             return proxyToPool(
               req,
               res,

--- a/tests/pool-server/dispatch-proxy.test.ts
+++ b/tests/pool-server/dispatch-proxy.test.ts
@@ -394,6 +394,49 @@ describe("cross-pool proxy hardening", () => {
     }
   }
 
+  it("does not let a local dynamic template steal a route assigned to another pool", async (ctx) => {
+    pinPoolDns();
+    let targetRequests = 0;
+    await startTargetPool((_req, res) => {
+      targetRequests += 1;
+      res.writeHead(200, { "content-type": "text/plain" });
+      res.end("from-legacy-pool");
+    }, ctx);
+
+    const localHandler = vi.fn();
+    const handlerLoader = {
+      load: vi.fn().mockResolvedValue(localHandler),
+      has: vi.fn((pathname: string) => pathname === "/[locale]"),
+      get: vi.fn().mockReturnValue({ runtime: "nodejs", type: "APP_PAGE" }),
+    } as any;
+    const front = await track(
+      startFront(
+        {
+          kind: "route",
+          pool: "legacy",
+          matchedPathname: "/legacy",
+          routeMatches: null,
+          resolvedHeaders: undefined,
+        },
+        {
+          releaseName: "rel",
+          handlerLoader,
+          outputIds: ["/[locale]"],
+          localHandlerInvoker: vi.fn(async ({ res }) => {
+            res.writeHead(500, { "content-type": "text/plain" });
+            res.end("wrong-local-template");
+          }),
+        },
+      ),
+    );
+
+    const response = await fetch(`http://127.0.0.1:${front.port}/legacy`);
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("from-legacy-pool");
+    expect(targetRequests).toBe(1);
+    expect(localHandler).not.toHaveBeenCalled();
+  });
+
   it("applies resolvedHeaders exactly once — front wrapper only, never re-forwarded", async (ctx) => {
     const lookedUp = pinPoolDns();
     let seenResolvedHeaders: string | undefined;


### PR DESCRIPTION
## Summary

- keep locally owned routes in their selected pool before probing sibling pools
- prevent App and Pages Router outputs from being claimed by the wrong runtime
- retain cross-pool fallback for routes the selected pool does not own

## Testing

- npx vitest run tests/pool-server/dispatch-proxy.test.ts tests/pool-server/dispatch.test.ts
- npx tsc --noEmit
- npm run build
- verified Pages Router, metadata, and header rewrites on the live conformance deployment