### PR TITLE
Match Next.js route templates literally

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,12 @@ pools: {
 },
 ```
 
-Routes match by output type (`appPages`, `appRoutes`, `pagesApi`) or glob pattern, first-match-wins in config order.
+Routes match by output type (`appPages`, `appRoutes`, `pagesApi`) or a glob over the build-time
+route template pathname, first-match-wins in config order. Next.js dynamic segments are literal:
+`/blog/[slug]` selects that template and `/[locale]/lab/**` selects templates below it. Dynamic
+segments glued to interception markers are literal too, including `(.)[user]`, `(..)[...slug]`,
+`(...)[[...slug]]`, and `(..)(..)[slug]`. Ordinary glob syntax remains available outside these
+Next-specific segment forms, such as `/api/v[12]/**`.
 
 ### Multiple hosts & wildcards
 

--- a/src/classify.ts
+++ b/src/classify.ts
@@ -1,5 +1,5 @@
 // src/classify.ts
-import { minimatch } from "minimatch";
+import { escape, minimatch } from "minimatch";
 import type { AdapterOutput, AdapterOutputs, K8sAdapterConfig, PoolDefinition } from "./types.js";
 
 type FunctionOutput =
@@ -17,6 +17,24 @@ const OUTPUT_TYPE_KEYS: Record<
   pages: "pages",
   pagesApi: "pagesApi",
 };
+
+// Pool selectors are globs over the route template pathnames emitted by Next, not over
+// concrete request URLs. A full segment such as `[slug]` therefore names that literal route
+// template. Passing it straight to minimatch instead treats the brackets as a character class:
+// `/blog/[slug]` misses the dynamic output and can claim an unrelated `/blog/s` route instead.
+// Interception markers are glued to the segment they target (`(.)[user]`,
+// `(..)(..)[...slug]`) and remain present in Next's output pathname. Treat that whole form as
+// literal too; otherwise the dynamic tail is still a minimatch character class and can claim a
+// static interception output such as `(.)u`. Ordinary glob syntax such as `v[12]`, `*`, `**`,
+// braces, and extglobs keeps its minimatch meaning outside these Next-specific segment forms.
+const NEXT_DYNAMIC_SEGMENT = /^(?:\(\.{1,3}\))*(?:\[(?:\.\.\.)?[^/[\]]+\]|\[\[\.\.\.[^/[\]]+\]\])$/;
+
+function normalizeRouteSelector(selector: string): string {
+  return selector
+    .split("/")
+    .map((segment) => (NEXT_DYNAMIC_SEGMENT.test(segment) ? escape(segment) : segment))
+    .join("/");
+}
 
 export function classifyIntoPools(
   outputs: AdapterOutputs,
@@ -36,12 +54,13 @@ export function classifyIntoPools(
       if (typeKey) {
         candidates = outputs[typeKey] as FunctionOutput[];
       } else {
+        const selector = normalizeRouteSelector(routeSpec);
         candidates = [
           ...outputs.appPages,
           ...outputs.appRoutes,
           ...outputs.pages,
           ...outputs.pagesApi,
-        ].filter((o) => minimatch(o.pathname, routeSpec));
+        ].filter((o) => minimatch(o.pathname, selector));
       }
 
       if (candidates.length > 0) specsWithCandidates.add(routeSpec);

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,7 +33,14 @@ export type EnvFromSource =
   | { configMap: string; prefix?: string; optional?: boolean };
 
 export interface PoolConfig {
-  routes: string[]; // OutputType name ('appPages', 'appRoutes', 'pages', 'pagesApi') or glob pattern
+  /**
+   * Output type name (`appPages`, `appRoutes`, `pages`, `pagesApi`) or a glob over the
+   * build-time route template pathname. Full Next.js dynamic segments (`[slug]`,
+   * `[...slug]`, `[[...slug]]`) are literal template names, not minimatch character classes.
+   * The same is true when an interception marker is glued to the segment, such as
+   * `(.)[slug]`, `(..)[...slug]`, or `(...)[[...slug]]`.
+   */
+  routes: string[];
   scaling?: { min: number; max: number; targetCPU: number };
   resources?: { cpu?: string; memory?: string; cpuLimit?: string; memoryLimit?: string };
   timeout?: number;

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -50,6 +50,112 @@ describe("classifyIntoPools", () => {
     expect(pools.get("api")!.outputs[0]!.pathname).toBe("/api/hello");
   });
 
+  it("treats Next.js dynamic route segments literally inside route selectors", () => {
+    const outputs = mockOutputs({
+      appPages: [
+        mockAppPage({ pathname: "/blog/[slug]" }),
+        mockAppPage({ pathname: "/blog/s" }),
+        mockAppPage({ pathname: "/[locale]/lab/[view]" }),
+        mockAppPage({ pathname: "/l/lab/report" }),
+        mockAppPage({ pathname: "/docs/[...slug]" }),
+        mockAppPage({ pathname: "/docs/." }),
+        mockAppPage({ pathname: "/shop/[[...slug]]" }),
+      ],
+    });
+    const config: K8sAdapterConfig = {
+      pools: {
+        dynamic: {
+          routes: ["/blog/[slug]", "/[locale]/lab/**", "/docs/[...slug]", "/shop/[[...slug]]"],
+        },
+        static: { routes: ["appPages"] },
+      },
+      provider: { gke: {} },
+    };
+
+    const pools = classifyIntoPools(outputs, config);
+    expect(pools.get("dynamic")!.outputs.map((output) => output.pathname)).toEqual([
+      "/blog/[slug]",
+      "/[locale]/lab/[view]",
+      "/docs/[...slug]",
+      "/shop/[[...slug]]",
+    ]);
+    expect(pools.get("static")!.outputs.map((output) => output.pathname)).toEqual([
+      "/blog/s",
+      "/l/lab/report",
+      "/docs/.",
+    ]);
+  });
+
+  it("treats interception-prefixed dynamic segments literally without claiming static decoys", () => {
+    const outputs = mockOutputs({
+      appPages: [
+        // Real App Router output shape from fixtures/interception.
+        mockAppPage({ pathname: "/[locale]/(.)[username]/p/[id]" }),
+        mockAppPage({ pathname: "/[locale]/(.)u/p/[id]" }),
+        mockAppPage({ pathname: "/feed/(..)[...slug]" }),
+        mockAppPage({ pathname: "/feed/(..)s" }),
+        mockAppPage({ pathname: "/root/(...)[[...slug]]" }),
+        mockAppPage({ pathname: "/root/(...)s" }),
+        mockAppPage({ pathname: "/nested/(..)(..)[slug]" }),
+        mockAppPage({ pathname: "/nested/(..)(..)s" }),
+      ],
+    });
+    const config: K8sAdapterConfig = {
+      pools: {
+        intercepted: {
+          routes: [
+            "/[locale]/(.)[username]/p/[id]",
+            "/feed/(..)[...slug]",
+            "/root/(...)[[...slug]]",
+            "/nested/(..)(..)[slug]",
+          ],
+        },
+        static: { routes: ["appPages"] },
+      },
+      provider: { gke: {} },
+    };
+
+    const pools = classifyIntoPools(outputs, config);
+    expect(pools.get("intercepted")!.outputs.map((output) => output.pathname)).toEqual([
+      "/[locale]/(.)[username]/p/[id]",
+      "/feed/(..)[...slug]",
+      "/root/(...)[[...slug]]",
+      "/nested/(..)(..)[slug]",
+    ]);
+    expect(pools.get("static")!.outputs.map((output) => output.pathname)).toEqual([
+      "/[locale]/(.)u/p/[id]",
+      "/feed/(..)s",
+      "/root/(...)s",
+      "/nested/(..)(..)s",
+    ]);
+  });
+
+  it("keeps minimatch syntax for ordinary static route globs", () => {
+    const outputs = mockOutputs({
+      appPages: [
+        mockAppPage({ pathname: "/reports/2025/weekly" }),
+        mockAppPage({ pathname: "/reports/2026/monthly" }),
+        mockAppPage({ pathname: "/api/v1/users" }),
+        mockAppPage({ pathname: "/api/v3/users" }),
+      ],
+    });
+    const config: K8sAdapterConfig = {
+      pools: {
+        selected: { routes: ["/reports/{2025,2026}/**", "/api/v[12]/**"] },
+        rest: { routes: ["appPages"] },
+      },
+      provider: { gke: {} },
+    };
+
+    const pools = classifyIntoPools(outputs, config);
+    expect(pools.get("selected")!.outputs.map((output) => output.pathname)).toEqual([
+      "/reports/2025/weekly",
+      "/reports/2026/monthly",
+      "/api/v1/users",
+    ]);
+    expect(pools.get("rest")!.outputs.map((output) => output.pathname)).toEqual(["/api/v3/users"]);
+  });
+
   it("uses first-match-wins — earlier pool takes precedence", () => {
     const outputs = mockOutputs({
       appPages: [mockAppPage({ pathname: "/dashboard" })],


### PR DESCRIPTION
## Summary

- treat Next.js dynamic route segments as route templates instead of minimatch syntax
- support catch-all, optional catch-all, and interception-route prefixes
- preserve ordinary glob behavior for user-defined selectors

## Testing

- npx vitest run tests/classify.test.ts
- npx tsc --noEmit
- npm run build
- verified intercepted and dynamic routes in the Next.js 16.3 conformance app