### PR TITLE
Resolve packages through exports maps

### DIFF
--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -755,11 +755,7 @@ export const SHARP_RUNTIME_PACKAGES = [
 // bundle no longer inlines sharp's JS, so the version that matters is the one the APP's
 // next install brought — resolving adapter-first staged a different generation's
 // binaries than the app's sharp JS expects and 503'd every /_next/image.
-export function resolveSharpDepDir(dep: string, projectDir: string): string | undefined {
-  const fromFiles = [
-    path.join(projectDir, "package.json"), // app root (authoritative version)
-    path.join(_dirname, "index.js"), // adapter package (dist/) fallback
-  ];
+function resolvePackageDirFromFiles(dep: string, fromFiles: string[]): string | undefined {
   for (const fromFile of fromFiles) {
     const req = createRequire(fromFile);
     for (const subpath of [`${dep}/package`, `${dep}/package.json`]) {
@@ -792,6 +788,16 @@ export function resolveSharpDepDir(dep: string, projectDir: string): string | un
       // not resolvable from this root at all
     }
   }
+  return undefined;
+}
+
+export function resolveSharpDepDir(dep: string, projectDir: string): string | undefined {
+  const fromFiles = [
+    path.join(projectDir, "package.json"), // app root (authoritative version)
+    path.join(_dirname, "index.js"), // adapter package (dist/) fallback
+  ];
+  const resolved = resolvePackageDirFromFiles(dep, fromFiles);
+  if (resolved) return resolved;
   if (dep !== "sharp") {
     // Check the sibling of EVERY resolvable sharp copy — one root's copy may simply not
     // have this platform package installed while another root's does.
@@ -844,16 +850,7 @@ async function stagePackageTree(
       if (seen.has(dep)) continue;
       seen.add(dep);
       // Resolve the dep relative to its dependent first (nested installs), then the app.
-      const req = createRequire(path.join(dir, "package.json"));
-      let depDir: string | undefined;
-      for (const subpath of [`${dep}/package.json`, `${dep}/package`]) {
-        try {
-          depDir = path.dirname(req.resolve(subpath));
-          break;
-        } catch {
-          // next shape
-        }
-      }
+      let depDir = resolvePackageDirFromFiles(dep, [path.join(dir, "package.json")]);
       depDir ??= resolveSharpDepDir(dep, projectDir);
       if (depDir) queue.push([dep, depDir]);
       else {
@@ -885,13 +882,7 @@ export async function stageExternalsDependencies(
   if (!existsSync(externalsDir)) return { staged, unresolved };
 
   const fromApp = (dep: string): string | undefined => {
-    try {
-      return path.dirname(
-        createRequire(path.join(projectDir, "package.json")).resolve(`${dep}/package.json`),
-      );
-    } catch {
-      return undefined;
-    }
+    return resolvePackageDirFromFiles(dep, [path.join(projectDir, "package.json")]);
   };
 
   const packageDirs: string[] = [];
@@ -969,13 +960,7 @@ export async function stageNextRuntimeDependencies(
   // (and its deps) into an app that has none — a version pairing guaranteed not to match the
   // build output. An app without a resolvable next is not buildable anyway.
   const fromDir = (dep: string, dir: string): string | undefined => {
-    try {
-      return path.dirname(
-        createRequire(path.join(dir, "package.json")).resolve(`${dep}/package.json`),
-      );
-    } catch {
-      return undefined;
-    }
+    return resolvePackageDirFromFiles(dep, [path.join(dir, "package.json")]);
   };
   const nextDir = (resolveDep ?? fromDir)("next", projectDir);
   const staged: string[] = [];

--- a/tests/adapter-externals-deps.test.ts
+++ b/tests/adapter-externals-deps.test.ts
@@ -79,6 +79,35 @@ describe("stageExternalsDependencies", () => {
     expect(staged("node_modules/left-pad/package.json")).toBe(true);
   });
 
+  it("stages dependencies whose exports hide package.json", async () => {
+    const externals = path.join(projectDir, ".next", "node_modules");
+    writePkg(path.join(externals, "external-123"), {
+      name: "external",
+      dependencies: { locked: "1.0.0" },
+    });
+    const nm = path.join(projectDir, "node_modules");
+    writePkg(
+      path.join(nm, "locked"),
+      {
+        name: "locked",
+        exports: { ".": "./dist/index.js" },
+        dependencies: { "locked-child": "1.0.0" },
+      },
+      { "dist/index.js": "module.exports = {};" },
+    );
+    writePkg(
+      path.join(nm, "locked-child"),
+      { name: "locked-child", exports: { ".": "./index.js" } },
+      { "index.js": "module.exports = {};" },
+    );
+
+    const result = await stageExternalsDependencies(projectDir, externals, "ssr", false);
+
+    expect(result.unresolved).toEqual([]);
+    expect(staged("node_modules/locked/package.json")).toBe(true);
+    expect(staged("node_modules/locked-child/package.json")).toBe(true);
+  });
+
   it("reports (not throws) an unresolvable dependency and continues", async () => {
     const externals = path.join(projectDir, ".next", "node_modules");
     writePkg(path.join(externals, "thing-123"), {

--- a/tests/adapter-next-runtime-deps.test.ts
+++ b/tests/adapter-next-runtime-deps.test.ts
@@ -163,6 +163,21 @@ describe("staging next's runtime dependency closure", () => {
     expect(staged("node_modules/@swc/helpers/package.json")).toBe(false);
   });
 
+  it("stages a Next dependency whose exports hide package.json", async () => {
+    seedApp({ "locked-runtime": "1.0.0" });
+    writePkg(
+      path.join(projectDir, "node_modules", "locked-runtime"),
+      { name: "locked-runtime", exports: { ".": "./dist/index.js" } },
+      { "dist/index.js": "module.exports = {};" },
+    );
+
+    const result = await stageNextRuntimeDependencies(projectDir, "ssr");
+
+    expect(result.staged).toContain("locked-runtime");
+    expect(result.unresolved).not.toContain("locked-runtime");
+    expect(staged("node_modules/locked-runtime/package.json")).toBe(true);
+  });
+
   it("warns and continues when a declared dependency is unresolvable", async () => {
     // A pnpm/monorepo layout can hide one. Refusing to build the image over a package the app
     // may never load would be worse than the CrashLoop it prevents.


### PR DESCRIPTION
## Summary

- resolve runtime packages through supported metadata exports or their public entrypoint
- use the same package resolver for traced externals, Next.js runtime dependencies, and transitive dependencies
- cover direct and transitive packages that hide `package.json` behind an exports map

## Testing

- `npm run build`
- `npm test`
- `npm run typecheck`
- `npm run lint`
- `npm run fmt`
- `git diff --check`