### PR TITLE
Make adapter tests portable across environments

### DIFF
--- a/tests/adapter-config.test.ts
+++ b/tests/adapter-config.test.ts
@@ -227,6 +227,7 @@ describe("onBuildComplete build-time guards", () => {
 
   beforeEach(() => {
     projectDir = mkdtempSync(path.join(os.tmpdir(), "adapter-build-"));
+    vi.spyOn(process, "cwd").mockReturnValue(projectDir);
     savedSkip = process.env.ADAPTER_K8S_SKIP_STAGING;
     process.env.ADAPTER_K8S_SKIP_STAGING = "1";
   });
@@ -234,6 +235,7 @@ describe("onBuildComplete build-time guards", () => {
   afterEach(() => {
     if (savedSkip === undefined) delete process.env.ADAPTER_K8S_SKIP_STAGING;
     else process.env.ADAPTER_K8S_SKIP_STAGING = savedSkip;
+    vi.restoreAllMocks();
     rmSync(projectDir, { recursive: true, force: true });
   });
 
@@ -296,21 +298,21 @@ describe("onBuildComplete build-time guards", () => {
   });
 
   it("fails when release+pool truncation collapses distinct build ids (composed-name guard)", async () => {
-    // 20-char release + 38-char pool = a 60-char `release-pool-` prefix: only 3
-    // build-id chars survive the 63-char truncation, so "abc12345xyz" and
-    // "abc99999xyz" produce IDENTICAL composed resource names even though
+    // 20-char release + 29-char pool = a 51-char `release-pool-` prefix: exactly 8
+    // build-id chars survive the 59-char HPA-name budget, so "abcdefgh123" and
+    // "abcdefgh999" produce IDENTICAL composed resource names even though
     // sanitizeK8sName(buildId) alone (the old guard's comparison) differs.
     writeInfra({ releaseName: "r".repeat(20) });
     writeFileSync(
       path.join(projectDir, ".k8s-adapter", "state.json"),
-      JSON.stringify({ buildId: "abc12345xyz", previousBuildId: null }),
+      JSON.stringify({ buildId: "abcdefgh123", previousBuildId: null }),
     );
     const adapter = createK8sAdapter({
       ...validConfig,
-      pools: { ["p".repeat(38)]: { routes: ["appPages"] } },
+      pools: { ["p".repeat(29)]: { routes: ["appPages"] } },
     });
     await adapter.modifyConfig!({} as any, {} as any);
-    await expect(adapter.onBuildComplete!(ctx("abc99999xyz"))).rejects.toThrow(
+    await expect(adapter.onBuildComplete!(ctx("abcdefgh999"))).rejects.toThrow(
       /sanitizes to the same K8s name as the previous build/,
     );
   });

--- a/tests/adapter-sharp-staging.test.ts
+++ b/tests/adapter-sharp-staging.test.ts
@@ -7,7 +7,15 @@
 // Additionally sharp@0.35 gained an exports map WITHOUT a "./package" subpath, which the
 // old `${dep}/package` resolution choked on.
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, readFileSync } from "node:fs";
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  rmSync,
+  existsSync,
+  readFileSync,
+  realpathSync,
+} from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { resolveSharpDepDir, stageSharpRuntimePackages } from "../src/adapter.js";
@@ -78,7 +86,7 @@ afterAll(() => {
 describe("sharp staging survives the 0.35 package shape (survey: canary.97 image cluster)", () => {
   it("resolveSharpDepDir resolves a sharp whose exports map has no ./package subpath", () => {
     const dir = resolveSharpDepDir("sharp", projectDir);
-    expect(dir).toBe(path.join(projectDir, "node_modules", "sharp"));
+    expect(dir).toBe(realpathSync(path.join(projectDir, "node_modules", "sharp")));
   });
 
   it("stages the app's sharp JS package AND its runtime dep tree alongside the @img binaries", async () => {

--- a/tests/adapter-staging.test.ts
+++ b/tests/adapter-staging.test.ts
@@ -13,6 +13,7 @@ import {
   readFileSync,
   existsSync,
   lstatSync,
+  realpathSync,
 } from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -587,7 +588,7 @@ describe("resolveSharpDepDir", () => {
         exports: { "./sharp.node": "./sharp.node", "./package": "./package.json" },
       }),
     );
-    expect(resolveSharpDepDir("@img/sharp-testonly-linux-x64", tmpDir)).toBe(dir);
+    expect(resolveSharpDepDir("@img/sharp-testonly-linux-x64", tmpDir)).toBe(realpathSync(dir));
   });
 
   it("falls back to the sibling of a resolvable sharp copy when exports block resolution entirely", () => {
@@ -609,7 +610,7 @@ describe("resolveSharpDepDir", () => {
         exports: { "./sharp.node": "./sharp.node" },
       }),
     );
-    expect(resolveSharpDepDir("@img/sharp-testonly-sibling", tmpDir)).toBe(dir);
+    expect(resolveSharpDepDir("@img/sharp-testonly-sibling", tmpDir)).toBe(realpathSync(dir));
   });
 
   it("returns undefined for an unresolvable package", () => {

--- a/tests/pool-server/valkey-cache/resp-client-tls.integration.test.ts
+++ b/tests/pool-server/valkey-cache/resp-client-tls.integration.test.ts
@@ -371,12 +371,13 @@ describe("readClientHelloSni (guards the L18 wire assertion from going vacuous)"
     const port = await new Promise<number>((r) => {
       server.listen(0, "127.0.0.1", () => r((server.address() as net.AddressInfo).port));
     });
-    const socket = tls.connect({ host: "127.0.0.1", port, rejectUnauthorized: false, ...options });
-    socket.on("error", () => undefined);
+    let socket: tls.TLSSocket | undefined;
     try {
+      socket = tls.connect({ host: "127.0.0.1", port, rejectUnauthorized: false, ...options });
+      socket.on("error", () => undefined);
       return await seen;
     } finally {
-      socket.destroy();
+      socket?.destroy();
       await new Promise<void>((r) => server.close(() => r()));
     }
   }
@@ -385,8 +386,17 @@ describe("readClientHelloSni (guards the L18 wire assertion from going vacuous)"
     expect(await sniOf({ servername: "valkey.example.internal" })).toBe("valkey.example.internal");
   });
 
-  it("reports an IP servername (Node sends it; this is what L18 must avoid)", async () => {
-    expect(await sniOf({ servername: "10.1.2.3" })).toBe("10.1.2.3");
+  it("reports an IP servername when the Node runtime permits sending one", async () => {
+    try {
+      expect(await sniOf({ servername: "10.1.2.3" })).toBe("10.1.2.3");
+    } catch (error) {
+      // Node 26 upgraded DEP0123 from a warning to a TypeError. That is a stronger runtime
+      // guarantee than L18 needs; Node 20/22/24 still exercise the ClientHello parser above.
+      expect(error).toBeInstanceOf(TypeError);
+      expect(String(error)).toContain(
+        "Setting the TLS ServerName to an IP address is not permitted",
+      );
+    }
   });
 
   it("reports null when no servername is set (the L18 shape)", async () => {


### PR DESCRIPTION
## Summary

- compare canonical temporary paths when macOS aliases `/var` through `/private/var`
- isolate generated release-name fixtures from the worktree directory name
- accept Node.js runtimes that reject IP addresses as TLS server names

## Testing

- `npm run build`
- `npm test`
- `npm run typecheck`
- `npm run lint`
- `npm run fmt`
- `git diff --check`