### PR TITLE
Preserve rollback resources across upgrades

### DIFF
--- a/src/cli/deploy.ts
+++ b/src/cli/deploy.ts
@@ -33,6 +33,7 @@ import { isAlreadyGoneError } from "./destroy.js";
 import { MIN_GKE_VERSION_FOR_CDN } from "./gke-version.js";
 import { routeExtJobName } from "../emit/templates/route-ext-update-job.js";
 import {
+  ROUTING_MANIFEST_SNAPSHOT_COMPONENT,
   routingManifestSnapshotName,
   routingServiceDeploymentName,
 } from "../emit/templates/routing-manifest-configmap.js";
@@ -3212,8 +3213,8 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
         "-n",
         namespace,
         "-l",
-        `app.kubernetes.io/name=${releaseName},app.kubernetes.io/managed-by=adapter-k8s,` +
-          `app.kubernetes.io/component=routing-manifest-snapshot`,
+        `app.kubernetes.io/name=${releaseName},` +
+          `app.kubernetes.io/component=${ROUTING_MANIFEST_SNAPSHOT_COMPONENT}`,
         "-o",
         'jsonpath={range .items[*]}{.metadata.name}{"\\n"}{end}',
       ]);

--- a/src/cli/deploy.ts
+++ b/src/cli/deploy.ts
@@ -26,7 +26,6 @@ import { renderDeployment, POOL_READINESS_PATH } from "../emit/templates/deploym
  */
 const LIVENESS_PATH_FOR_MIGRATION = "/healthz";
 import { renderService } from "../emit/templates/service.js";
-import { renderHPA } from "../emit/templates/hpa.js";
 import { renderValkeySecret } from "../emit/templates/valkey-secret.js";
 import { provisionMemorystore, buildDeleteMemorystoreCommand } from "./provision-cache.js";
 import { isAlreadyGoneError } from "./destroy.js";
@@ -1791,8 +1790,13 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
   // have no live capacity to match.
   const previousReplicasByPool = new Map<string, number>();
 
-  // Inject previous build's deployment+service into the chart so Helm doesn't delete it.
-  // Without this, helm upgrade only sees the current build's templates and deletes the previous.
+  // Inject the previous build's Deployment+Service into the chart so Helm doesn't delete them.
+  // Its HPA remains LIVE but is deliberately omitted from the new release manifest: before the
+  // upgrade we annotate the object `keep`, so Helm stops owning it without deleting or mutating
+  // it. That preserves autoscaling for the build carrying traffic throughout warm-up (and every
+  // pre-cutover abort), while making deploy solely responsible for deleting the HPA before it
+  // parks the rollback Deployment at zero after a durable cutover. This also adopts the same
+  // lifecycle for an HPA created imperatively by rollback.
   if (previousBuildId && previousBuildId !== buildId) {
     for (const poolName of pools) {
       const poolPrevName = sanitizeK8sName(`${releaseName}-${poolName}-${previousBuildId}`);
@@ -2003,7 +2007,9 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
 
       // Render retained resources through the same canonical templates as a normal build.
       // Hand-copying this Deployment previously omitted resources, changing the serving pod
-      // template and rolling the old build during every upgrade.
+      // template and rolling the old build during every upgrade. Do not render its HPA into the
+      // new release: the live object remains active under the explicit keep transfer below, so
+      // Helm cannot rewrite its scaling policy from the incoming build's values.
       // L13: dry-run must not write into the chart — report the planned writes instead.
       const retainedFiles: [string, string][] = [
         [
@@ -2027,10 +2033,6 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
           `${poolName}-prev-service.yaml`,
           renderService({ poolName, buildId: previousBuildId, releaseName }),
         ],
-        [
-          `${poolName}-prev-hpa.yaml`,
-          renderHPA({ poolName, buildId: previousBuildId, releaseName }),
-        ],
       ];
       for (const [fileName, content] of retainedFiles) {
         const target = path.join(chartTemplatesDir, fileName);
@@ -2038,6 +2040,62 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
           console.log(`    [dry-run] would write ${target}`);
         } else {
           writeFileSync(target, content);
+        }
+      }
+
+      // Keep the outgoing HPA active and byte-for-byte unchanged while its Deployment still
+      // carries traffic, but remove it from Helm's next release manifest. Rendering it here
+      // would overwrite a rollback-created HPA's incident-sized min/max with the incoming
+      // build's config; merely omitting it would let Helm prune it before the new build is ready.
+      // The live keep annotation makes the ownership transfer explicit. On every abort before
+      // the durable state commit the HPA remains present and active; step 7f deletes it only
+      // after traffic and state have moved to the new build.
+      const outgoingHpa = poolResourceNames(releaseName, poolName, previousBuildId).hpa;
+      const keepAnnotation = "helm.sh/resource-policy=keep";
+      if (dryRun) {
+        console.log(
+          `    [dry-run] kubectl annotate hpa ${outgoingHpa} -n ${namespace} ` +
+            `${keepAnnotation} --overwrite (if it exists)`,
+        );
+      } else {
+        const foundHpa = await execCapture("kubectl", [
+          "get",
+          "hpa",
+          outgoingHpa,
+          "-n",
+          namespace,
+          "--ignore-not-found",
+          "-o",
+          "name",
+        ]);
+        if (foundHpa.exitCode !== 0) {
+          throw new Error(
+            `Could not determine whether the outgoing HPA ${outgoingHpa} exists (kubectl ` +
+              `exited ${foundHpa.exitCode}: ${foundHpa.stderr.trim()}). Refusing to run ` +
+              `\`helm upgrade\`: omitting an HPA that Helm still owns could delete the ` +
+              `autoscaler for build ${previousBuildId} while it is serving traffic. Fix ` +
+              `kubectl access and re-run.`,
+          );
+        }
+        if (foundHpa.stdout.trim()) {
+          const keptHpa = await execCapture("kubectl", [
+            "annotate",
+            "hpa",
+            outgoingHpa,
+            "-n",
+            namespace,
+            keepAnnotation,
+            "--overwrite",
+          ]);
+          if (keptHpa.exitCode !== 0) {
+            throw new Error(
+              `Could not transfer the outgoing HPA ${outgoingHpa} out of Helm ownership ` +
+                `(${keptHpa.stderr.trim() || `kubectl exited ${keptHpa.exitCode}`}). Refusing ` +
+                `to run \`helm upgrade\`: the serving build must keep autoscaling until ` +
+                `cutover. Fix kubectl access and re-run.`,
+            );
+          }
+          console.log(`  → Preserved outgoing autoscaler (${outgoingHpa}) through cutover`);
         }
       }
     }
@@ -3060,7 +3118,10 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
     // build down to 0. It served through the rollout and remains as the rollback target.
     // Best-effort: success is already durable (7d) — a failure here warns instead of
     // failing the whole deploy (the previous build just keeps burning replicas until the
-    // next deploy or a manual scale-down).
+    // next deploy or a manual scale-down). The outgoing HPA was transferred out of Helm
+    // ownership before the upgrade so it could remain active while this build served. Delete it
+    // now and wait for that deletion to finish BEFORE setting replicas=0; if deletion fails,
+    // leave the Deployment alone rather than asking a still-live HPA to fight the scale command.
     if (previousBuildId && previousBuildId !== buildId) {
       let scaleDownFailed = false;
       for (const poolName of pools) {
@@ -3082,6 +3143,15 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
           namespace,
           "--ignore-not-found",
         ]);
+        if (hpaDelete.exitCode !== 0) {
+          scaleDownFailed = true;
+          console.warn(
+            `  ! Could not remove outgoing autoscaler ${poolPrevHpa}; leaving ` +
+              `${poolPrevName} at its current replica count because that HPA could immediately ` +
+              `undo a scale to zero: ${hpaDelete.stderr.trim() || "unknown error"}`,
+          );
+          continue;
+        }
         const scaleDown = await execCapture("kubectl", [
           "scale",
           `deployment/${poolPrevName}`,
@@ -3089,11 +3159,11 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
           namespace,
           "--replicas=0",
         ]);
-        if (hpaDelete.exitCode !== 0 || scaleDown.exitCode !== 0) {
+        if (scaleDown.exitCode !== 0) {
           scaleDownFailed = true;
           console.warn(
             `  ! Could not scale down ${poolPrevName}: ` +
-              `${(scaleDown.stderr || hpaDelete.stderr).trim() || "unknown error"}`,
+              `${scaleDown.stderr.trim() || "unknown error"}`,
           );
         }
       }

--- a/src/cli/destroy.ts
+++ b/src/cli/destroy.ts
@@ -5,6 +5,7 @@ import { execCapture } from "./exec.js";
 import { cliServiceAccountEmail, deployExtRoleId, deployServiceAccountEmail } from "./init.js";
 import { sanitizeForTerminal } from "./terminal.js";
 import { INTERNAL_SECRET_COMPONENT } from "../emit/templates/internal-secret.js";
+import { ROUTING_MANIFEST_SNAPSHOT_COMPONENT } from "../emit/templates/routing-manifest-configmap.js";
 import { resolveK8sNamespace } from "../emit/templates/utils.js";
 import { assertSafeInfrastructure, infrastructurePath } from "./infrastructure-validation.js";
 
@@ -338,6 +339,32 @@ export async function runDestroy(options: DestroyOptions): Promise<void> {
           `${sanitizeForTerminal(res.stderr.trim()) || `exit ${res.exitCode}`}. Delete them manually ` +
           `(kubectl delete configmap -n ${namespace} -l app.kubernetes.io/name=${releaseName},` +
           `app.kubernetes.io/managed-by=adapter-k8s) or the next deploy may see stale state.`,
+      );
+    }
+  }
+
+  // Helm-owned per-build routing snapshots carry resource-policy: keep so an outgoing
+  // ReplicaSet and rollback target never lose the ConfigMap they mount. Helm uninstall
+  // deliberately leaves them behind; remove the release-scoped snapshots explicitly.
+  const snapshotDeleteArgs = [
+    "delete",
+    "configmap",
+    "-n",
+    namespace,
+    "-l",
+    `app.kubernetes.io/name=${releaseName},app.kubernetes.io/component=${ROUTING_MANIFEST_SNAPSHOT_COMPONENT}`,
+    "--ignore-not-found",
+  ];
+  if (dryRun) {
+    console.log(`  [dry-run] kubectl ${snapshotDeleteArgs.join(" ")}`);
+  } else {
+    const res = await execCapture("kubectl", snapshotDeleteArgs);
+    if (res.exitCode !== 0 && !isAlreadyGoneError(res.stderr)) {
+      console.warn(
+        `    WARNING: could not delete retained routing-manifest ConfigMaps: ` +
+          `${sanitizeForTerminal(res.stderr.trim()) || `exit ${res.exitCode}`}. Delete them manually ` +
+          `(kubectl delete configmap -n ${namespace} -l app.kubernetes.io/name=${releaseName},` +
+          `app.kubernetes.io/component=${ROUTING_MANIFEST_SNAPSHOT_COMPONENT}).`,
       );
     }
   }

--- a/src/cli/rollback.ts
+++ b/src/cli/rollback.ts
@@ -1358,15 +1358,24 @@ export async function runRollback(options: {
   // already points at the previous build but either version remains safe to select during
   // recovery.
   try {
+    // A rollback swaps the two build pointers; it does not create a new build. Preserve every
+    // other durable state field by default so per-build provenance remains available in BOTH
+    // directions. Keeping an allowlist here already lost routingImageDigests and
+    // unretainedManifestBuilds in production, which made the next rollback downgrade the edge
+    // from an immutable digest to a mutable tag and hid the retained-manifest warning.
+    //
+    // generation/updatedAt belong to writeState, and readinessPathSupported is the one
+    // deliberate exception: it describes the build that is NOW serving, so rolling back to an
+    // older build must conservatively clear it (see below).
+    const { generation, updatedAt, readinessPathSupported, ...durableState } = state;
+    void updatedAt;
+    void readinessPathSupported;
     await writeState(
       projectDir,
       {
+        ...durableState,
         buildId: previousBuildId,
         previousBuildId: currentBuildId,
-        // M13: carry the recorded per-build CDN tags verbatim — a rollback keeps both
-        // builds in play, and each build's tag is only ever the one recorded at ITS
-        // deploy (re-deriving under newer code is exactly the M13 failure).
-        ...(state.cdnTags ? { cdnTags: state.cdnTags } : {}),
         // `readinessPathSupported` is deliberately NOT carried forward. It means "the build
         // now serving answers /readyz", and after a rollback the serving build is an OLDER
         // one that may predate it — so dropping it is the conservative answer, and the next
@@ -1382,7 +1391,7 @@ export async function runRollback(options: {
         // so a post-cutover cluster outage stamped local generation 1 while the stale
         // cluster record sat at N — and readState prefers the higher generation, so the
         // next operation re-drained the build this rollback had just switched TO.
-        basedOnGeneration: state.generation ?? null,
+        basedOnGeneration: generation ?? null,
       },
       releaseName,
       namespace,

--- a/src/cli/rollback.ts
+++ b/src/cli/rollback.ts
@@ -12,6 +12,7 @@ import {
   resolveK8sNamespace,
 } from "../emit/templates/utils.js";
 import {
+  ROUTING_MANIFEST_SNAPSHOT_COMPONENT,
   ROUTING_MANIFEST_VOLUME_NAME,
   routingManifestSnapshotName,
   routingServiceDeploymentName,
@@ -243,8 +244,45 @@ export async function retainLiveRoutingManifest(
   }
   const serving = read.config;
   const snapshotName = routingManifestSnapshotName(releaseName, serving.imageTag);
-  // Already serving from this build's snapshot (post-rollback state) — nothing to copy.
-  if (serving.manifestConfigMap === snapshotName) return { status: "retained", snapshotName };
+  // A current chart renders the serving build's snapshot as a Helm-owned object. Merely
+  // observing that it already has the right name is not retention: Helm deletes resources
+  // that disappear from the next chart. Stamp the keep policy and classification labels
+  // before upgrade so the outgoing routing ReplicaSet and rollback target keep mounting it.
+  // This also migrates snapshots emitted before the chart carried the policy itself.
+  if (serving.manifestConfigMap === snapshotName) {
+    const annotated = await execCapture("kubectl", [
+      "annotate",
+      "configmap",
+      snapshotName,
+      "-n",
+      namespace,
+      "helm.sh/resource-policy=keep",
+      "--overwrite",
+    ]);
+    if (annotated.exitCode !== 0) {
+      return {
+        status: "failed",
+        reason: `could not retain the live snapshot ${snapshotName}: ${annotated.stderr.trim() || `kubectl annotate exited ${annotated.exitCode}`}`,
+      };
+    }
+    const labeled = await execCapture("kubectl", [
+      "label",
+      "configmap",
+      snapshotName,
+      "-n",
+      namespace,
+      `app.kubernetes.io/name=${releaseName}`,
+      `app.kubernetes.io/component=${ROUTING_MANIFEST_SNAPSHOT_COMPONENT}`,
+      "--overwrite",
+    ]);
+    if (labeled.exitCode !== 0) {
+      return {
+        status: "failed",
+        reason: `could not classify the live snapshot ${snapshotName}: ${labeled.stderr.trim() || `kubectl label exited ${labeled.exitCode}`}`,
+      };
+    }
+    return { status: "retained", snapshotName };
+  }
   // Overwrite protection: if a ConfigMap already exists under this snapshot name but is
   // stamped with a DIFFERENT build id, the two builds' snapshot names collide after
   // sanitization — overwriting would destroy that build's only retained manifest.
@@ -318,10 +356,11 @@ export async function retainLiveRoutingManifest(
         "app.kubernetes.io/name": releaseName,
         // kubectl-created (not helm-owned) — destroy deletes by this label pair.
         "app.kubernetes.io/managed-by": "adapter-k8s",
-        "app.kubernetes.io/component": "routing-manifest-snapshot",
+        "app.kubernetes.io/component": ROUTING_MANIFEST_SNAPSHOT_COMPONENT,
       },
       // An ANNOTATION, not a label: build ids may exceed the 63-char label-value limit.
       annotations: {
+        "helm.sh/resource-policy": "keep",
         [SNAPSHOT_BUILD_ID_ANNOTATION]: serving.imageTag,
       },
     },

--- a/src/cli/rollback.ts
+++ b/src/cli/rollback.ts
@@ -765,8 +765,8 @@ export function planRollbackCapacity(
   );
   const replicas = Math.max(ROLLBACK_MIN_REPLICAS, scaling.min, live);
   // The HPA must not immediately undo the scale-up (min) and must be able to grow past
-  // where the current build already was (max). The next deploy re-renders the HPA from
-  // config, so this widening is scoped to the incident.
+  // where the current build already was (max). The next deploy omits this HPA when it parks
+  // the build again, so this widening is scoped to the incident.
   return { replicas, min: replicas, max: Math.max(scaling.max, observed.hpaMax ?? 0, replicas) };
 }
 

--- a/src/emit/templates/configmap.ts
+++ b/src/emit/templates/configmap.ts
@@ -5,15 +5,35 @@ import { assertSafeReleaseName, escapeHelmActions, sanitizeK8sName } from "./uti
 // key is emitted as a BARE YAML scalar before the `|` block indicator, so anything outside
 // that charset is also a YAML-injection sink.
 const CONFIGMAP_KEY_RE = /^[-._a-zA-Z0-9]+$/;
+const METADATA_KEY_RE =
+  /^(?:[a-z0-9](?:[-a-z0-9.]{0,251}[a-z0-9])?\/)?[A-Za-z0-9](?:[-A-Za-z0-9_.]{0,61}[A-Za-z0-9])?$/;
+
+function renderMetadataMap(
+  field: "labels" | "annotations",
+  values: Record<string, string> | undefined,
+): string {
+  if (!values || Object.keys(values).length === 0) return "";
+  const entries = Object.entries(values).map(([key, value]) => {
+    if (!METADATA_KEY_RE.test(key)) {
+      throw new Error(`Invalid ConfigMap metadata key "${key}" in ${field}`);
+    }
+    return `    ${key}: ${escapeHelmActions(JSON.stringify(value))}`;
+  });
+  return `  ${field}:\n${entries.join("\n")}\n`;
+}
 
 export function renderConfigMap({
   name,
   releaseName,
   data,
+  labels,
+  annotations,
 }: {
   name: string;
   releaseName: string;
   data: Record<string, string>;
+  labels?: Record<string, string>;
+  annotations?: Record<string, string>;
 }): string {
   // Sanitize at the point of consumption (AGENTS.md) — nothing here was checked.
   assertSafeReleaseName(releaseName);
@@ -40,7 +60,7 @@ export function renderConfigMap({
 kind: ConfigMap
 metadata:
   name: ${safeName}
-data:
+${renderMetadataMap("labels", labels)}${renderMetadataMap("annotations", annotations)}data:
 ${dataEntries}
 `;
 }

--- a/src/emit/templates/routing-manifest-configmap.ts
+++ b/src/emit/templates/routing-manifest-configmap.ts
@@ -20,6 +20,7 @@ import { renderConfigMap } from "./configmap.js";
 
 // Volume name in the routing-service Deployment template (routing-service-deployment.ts).
 export const ROUTING_MANIFEST_VOLUME_NAME = "routing-manifest";
+export const ROUTING_MANIFEST_SNAPSHOT_COMPONENT = "routing-manifest-snapshot";
 
 /** The stable ConfigMap the chart renders and helm overwrites each deploy. */
 export function routingManifestConfigMapName(releaseName: string): string {
@@ -69,6 +70,15 @@ export function renderRoutingManifestSnapshotConfigMap({
     name: suffix,
     releaseName,
     data: { "routing-manifest.json": routingManifestJson },
+    labels: {
+      "app.kubernetes.io/name": releaseName,
+      "app.kubernetes.io/component": ROUTING_MANIFEST_SNAPSHOT_COMPONENT,
+    },
+    annotations: {
+      // The previous routing ReplicaSet mounts this exact name during the next rollout and
+      // rollback. Helm must retain it when the following chart stops rendering this build.
+      "helm.sh/resource-policy": "keep",
+    },
   });
 }
 

--- a/src/emit/templates/service.ts
+++ b/src/emit/templates/service.ts
@@ -76,7 +76,7 @@ export function renderActiveService({
   const stableHcpName = sanitizeK8sName(`${releaseName}-${poolName}`, "-hcp");
   // N65. The per-pool PodDisruptionBudget lives here, with the other STABLE per-pool
   // objects: this template is rendered exactly once per pool (helm.ts), whereas the
-  // versioned Deployment/Service/HPA templates are rendered a second time by deploy.ts for
+  // versioned Deployment/Service templates are rendered a second time by deploy.ts for
   // the retained previous build — a PDB in one of those would either duplicate a name or
   // need per-build cleanup. Selecting on name+component (no `version`) is also what makes
   // it correct THROUGH a cutover, when both builds' pods exist.

--- a/tests/cli/deploy-orchestration.test.ts
+++ b/tests/cli/deploy-orchestration.test.ts
@@ -756,7 +756,8 @@ describe("runDeploy — guards and teardown", () => {
       .mock.calls.find(([, a]) => a.includes("configmaps"))![1]
       .join(" ");
     expect(listing).toContain("app.kubernetes.io/component=routing-manifest-snapshot");
-    expect(listing).toContain("app.kubernetes.io/managed-by=adapter-k8s");
+    expect(listing).toContain(`app.kubernetes.io/name=${RELEASE}`);
+    expect(listing).not.toContain("app.kubernetes.io/managed-by=adapter-k8s");
   });
 
   it("fails fast when a pool rollout status fails (exit code is not discarded)", async () => {

--- a/tests/cli/deploy-orchestration.test.ts
+++ b/tests/cli/deploy-orchestration.test.ts
@@ -155,6 +155,13 @@ function happyCluster(
     newBuildHpa?: { min?: number; max: number } | null;
     newBuildHpaReadFails?: boolean;
     newBuildHpaPatchFails?: boolean;
+    // The outgoing HPA may have been created imperatively by rollback rather than by the
+    // current Helm revision. Deploy protects either shape by probing the live object by name,
+    // transferring it to `keep`, then deleting it only after cutover is durable.
+    outgoingHpaPresent?: boolean;
+    outgoingHpaProbeFails?: boolean;
+    outgoingHpaAnnotateFails?: boolean;
+    outgoingHpaDeleteFails?: boolean;
     // N87: internal dispatch Secret lifecycle. The legacy stable-named Secret (migrated past
     // helm upgrade), and the per-build ones the post-cutover sweep prunes.
     legacySecretPresent?: boolean;
@@ -325,10 +332,35 @@ function happyCluster(
       });
       return ok(`${rows.join("\n")}\n`);
     }
-    // N67: the new build's HPA — read (min|max), widened for the warm-up, restored after.
-    // MUST come before the generic `patch` branch below, which assumes a Service.
+    // The outgoing HPA is deliberately omitted from the new Helm manifest, but must stay live
+    // while its build serves. Its by-name read/keep/delete lifecycle is separate from N67's
+    // new-build HPA read/patch lifecycle below.
     if (args.includes("hpa")) {
       const hpaName = args[args.indexOf("hpa") + 1]!;
+      if (args[0] === "get" && args.includes("-o") && args[args.indexOf("-o") + 1] === "name") {
+        if (overrides.outgoingHpaProbeFails) {
+          return { exitCode: 1, stdout: "", stderr: "horizontalpodautoscalers is forbidden" };
+        }
+        return overrides.outgoingHpaPresent === false
+          ? ok("")
+          : ok(`horizontalpodautoscaler.autoscaling/${hpaName}\n`);
+      }
+      if (args[0] === "annotate") {
+        events.push(`annotate-hpa:${hpaName}:${args.find((a) => a.includes("resource-policy"))}`);
+        if (overrides.outgoingHpaAnnotateFails) {
+          return { exitCode: 1, stdout: "", stderr: "hpa annotation denied" };
+        }
+        return ok();
+      }
+      if (args.includes("delete")) {
+        events.push(`delete-hpa:${hpaName}`);
+        if (overrides.outgoingHpaDeleteFails) {
+          return { exitCode: 1, stdout: "", stderr: "hpa deletion denied" };
+        }
+        return ok("");
+      }
+      // N67: the new build's HPA — read (min|max), widened for the warm-up, restored after.
+      // MUST come before the generic `patch` branch below, which assumes a Service.
       if (args.includes("patch")) {
         const body = JSON.parse(args[args.length - 1]!) as {
           spec: { maxReplicas?: number; minReplicas?: number };
@@ -339,7 +371,6 @@ function happyCluster(
         }
         return ok();
       }
-      if (args.includes("delete")) return ok(""); // 7f parks the previous build
       if (overrides.newBuildHpaReadFails) {
         return { exitCode: 1, stdout: "", stderr: "connection refused" };
       }
@@ -501,6 +532,57 @@ describe("runDeploy — orchestration", () => {
     });
   });
 
+  it("keeps a rollback-created HPA active through warm-up, then deletes it before parking", async () => {
+    vi.mocked(execCapture).mockImplementation(
+      happyCluster(events, {
+        prevLive: { replicas: 5 },
+        readyPerPool: { ssr: 5 },
+        // The object exists only in the cluster, as after rollback's `kubectl autoscale`.
+        // It is intentionally absent from the retained files asserted below.
+        outgoingHpaPresent: true,
+      }) as never,
+    );
+
+    await runDeploy({ projectDir: PROJECT, releaseName: RELEASE, skipBuild: true });
+
+    const retainedWrites = vi
+      .mocked(writeFileSync)
+      .mock.calls.filter(([p]) => String(p).includes("-prev-"));
+    const retainedNames = retainedWrites.map(([p]) => path.basename(String(p)));
+    expect(retainedNames).toContain("ssr-prev-deployment.yaml");
+    expect(retainedNames).toContain("ssr-prev-service.yaml");
+    expect(retainedNames).not.toContain("ssr-prev-hpa.yaml");
+
+    const retainedDeployment = retainedWrites.find(([p]) =>
+      String(p).endsWith("ssr-prev-deployment.yaml"),
+    );
+    expect(String(retainedDeployment?.[1])).toContain("replicas: 5");
+
+    const keepHpa = events.indexOf("annotate-hpa:rel-ssr-buildm-hpa:helm.sh/resource-policy=keep");
+    expect(keepHpa).toBeGreaterThanOrEqual(0);
+    expect(keepHpa).toBeLessThan(events.indexOf("helm"));
+
+    const stateCommit = events.indexOf("writeState");
+    const deleteHpa = events.indexOf("delete-hpa:rel-ssr-buildm-hpa");
+    const scaleDown = events.indexOf("scale:deployment/rel-ssr-buildm");
+    expect(stateCommit).toBeGreaterThanOrEqual(0);
+    expect(deleteHpa).toBeGreaterThan(stateCommit);
+    expect(scaleDown).toBeGreaterThan(deleteHpa);
+  });
+
+  it("leaves the rollback Deployment running when its outgoing HPA cannot be deleted", async () => {
+    vi.mocked(execCapture).mockImplementation(
+      happyCluster(events, { outgoingHpaDeleteFails: true }) as never,
+    );
+
+    await runDeploy({ projectDir: PROJECT, releaseName: RELEASE, skipBuild: true });
+
+    expect(events).toContain("writeState");
+    expect(events).toContain("delete-hpa:rel-ssr-buildm-hpa");
+    expect(events).not.toContain("scale:deployment/rel-ssr-buildm");
+    expect(printedWarnings()).toContain("could immediately undo a scale to zero");
+  });
+
   it("new build never healthy: no selector patch, no state commit, non-zero exit, previous keeps serving", async () => {
     vi.mocked(execCapture).mockImplementation(
       happyCluster(events, { podsNeverReady: true }) as never,
@@ -516,6 +598,12 @@ describe("runDeploy — orchestration", () => {
     expect(events).not.toContain("writeState");
     expect(events).not.toContain("cdn-invalidate");
     expect(events.some((e) => e.startsWith("scale:"))).toBe(false);
+    // The outgoing autoscaler was transferred out of Helm before the upgrade and is never
+    // deleted on this abort, so the build that still carries traffic keeps autoscaling.
+    const keepHpa = events.indexOf("annotate-hpa:rel-ssr-buildm-hpa:helm.sh/resource-policy=keep");
+    expect(keepHpa).toBeGreaterThanOrEqual(0);
+    expect(keepHpa).toBeLessThan(events.indexOf("helm"));
+    expect(events).not.toContain("delete-hpa:rel-ssr-buildm-hpa");
     expect(vi.mocked(writeState)).not.toHaveBeenCalled();
     const printed = vi
       .mocked(console.error)
@@ -525,6 +613,32 @@ describe("runDeploy — orchestration", () => {
     // N25: the claim is now scoped to the POOLS — the ext_proc edge went to the new build
     // at `helm upgrade` and is reported separately (see the N25 suite below).
     expect(printed).toContain("previous build's pools are still serving");
+  });
+
+  it("aborts before Helm when the outgoing HPA cannot be read", async () => {
+    vi.mocked(execCapture).mockImplementation(
+      happyCluster(events, { outgoingHpaProbeFails: true }) as never,
+    );
+
+    await expect(
+      runDeploy({ projectDir: PROJECT, releaseName: RELEASE, skipBuild: true }),
+    ).rejects.toThrow(/outgoing HPA.*Refusing to run `helm upgrade`/s);
+
+    expect(events).not.toContain("helm");
+    expect(events.some((e) => e.startsWith("scale:"))).toBe(false);
+  });
+
+  it("aborts before Helm when the outgoing HPA cannot be transferred to keep", async () => {
+    vi.mocked(execCapture).mockImplementation(
+      happyCluster(events, { outgoingHpaAnnotateFails: true }) as never,
+    );
+
+    await expect(
+      runDeploy({ projectDir: PROJECT, releaseName: RELEASE, skipBuild: true }),
+    ).rejects.toThrow(/transfer the outgoing HPA.*serving build must keep autoscaling/s);
+
+    expect(events).not.toContain("helm");
+    expect(events.some((e) => e.startsWith("scale:"))).toBe(false);
   });
 
   it("selector patch failure: reverts the successful patches, no state commit, non-zero exit", async () => {
@@ -549,6 +663,10 @@ describe("runDeploy — orchestration", () => {
     expect(vi.mocked(writeState)).not.toHaveBeenCalled();
     expect(vi.mocked(invalidateCdnBuildTag)).not.toHaveBeenCalled();
     expect(events.some((e) => e.startsWith("scale:"))).toBe(false);
+    // Both outgoing autoscalers remain active after the partial selector flip is reverted.
+    expect(events).toContain("annotate-hpa:rel-ssr-buildm-hpa:helm.sh/resource-policy=keep");
+    expect(events).toContain("annotate-hpa:rel-api-buildm-hpa:helm.sh/resource-policy=keep");
+    expect(events.some((e) => e.startsWith("delete-hpa:"))).toBe(false);
   });
 
   it("dry-run: prints the plan and mutates nothing", async () => {
@@ -808,6 +926,13 @@ describe("runDeploy — guards and teardown", () => {
     expect(helmCall?.[1].join(" ")).toContain("--namespace prod --create-namespace");
     expect(vi.mocked(readState)).toHaveBeenCalledWith(PROJECT, RELEASE, { namespace: "prod" });
     expect(vi.mocked(retainLiveRoutingManifest)).toHaveBeenCalledWith(RELEASE, "prod");
+    const outgoingHpaCalls = vi
+      .mocked(execCapture)
+      .mock.calls.filter(([, args]) => args.includes("hpa") && args.includes("rel-ssr-buildm-hpa"));
+    expect(outgoingHpaCalls).not.toHaveLength(0);
+    for (const [, args] of outgoingHpaCalls) {
+      expect(args).toEqual(expect.arrayContaining(["-n", "prod"]));
+    }
     expect(vi.mocked(writeState)).toHaveBeenCalledWith(
       PROJECT,
       expect.objectContaining({ buildId: "buildn", previousBuildId: "buildm" }),

--- a/tests/cli/destroy.test.ts
+++ b/tests/cli/destroy.test.ts
@@ -574,6 +574,25 @@ describe("destroy: retained internal-dispatch Secrets", () => {
     expect(del).toContain("--ignore-not-found");
   });
 
+  it("sweeps retained routing snapshots left behind by Helm", async () => {
+    await runDestroy({ projectDir: tmpDir, releaseName: "my-app", yes: true });
+
+    const del = vi
+      .mocked(exec.execCapture)
+      .mock.calls.map(([, args]) => args)
+      .find(
+        (args) =>
+          args[0] === "delete" &&
+          args[1] === "configmap" &&
+          args.some((arg) => arg.includes("routing-manifest-snapshot")),
+      );
+    expect(del).toBeDefined();
+    expect(del!.join(" ")).toContain(
+      "app.kubernetes.io/name=my-app,app.kubernetes.io/component=routing-manifest-snapshot",
+    );
+    expect(del).toContain("--ignore-not-found");
+  });
+
   it("warns rather than failing the destroy when the sweep cannot run", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     vi.mocked(exec.execCapture).mockImplementation((async (_c: string, args: string[]) => {

--- a/tests/cli/rollback.test.ts
+++ b/tests/cli/rollback.test.ts
@@ -739,7 +739,7 @@ describe("retainLiveRoutingManifest — snapshot overwrite protection", () => {
     // permanently destroys the rollback target's manifest once helm overwrites the stable
     // ConfigMap.
     vi.mocked(execCapture).mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" } as never);
-    await expect(retainLiveRoutingManifest("rel")).resolves.toEqual({
+    await expect(retainLiveRoutingManifest("rel", "prod")).resolves.toEqual({
       status: "no-routing-tier",
     });
     expect(vi.mocked(execCaptureStdin)).not.toHaveBeenCalled();
@@ -825,10 +825,48 @@ describe("retainLiveRoutingManifest — snapshot overwrite protection", () => {
       retainCapture({ existingSnapshotAnnotation: undefined }) as never,
     );
 
-    await expect(retainLiveRoutingManifest("rel")).resolves.toEqual({
+    await expect(retainLiveRoutingManifest("rel", "prod")).resolves.toEqual({
       status: "retained",
       snapshotName: SNAP_N,
     });
+  });
+
+  it("retains a chart-owned live snapshot before the next Helm upgrade", async () => {
+    vi.mocked(execCapture).mockImplementation((async (_cmd: string, args: string[]) => {
+      const j = args.join(" ");
+      const ok = (stdout = "") => ({ exitCode: 0, stdout, stderr: "" });
+      if (j.includes("get deployment rel-routing-service") && args.includes("json")) {
+        return ok(
+          JSON.stringify({
+            spec: {
+              template: {
+                spec: {
+                  containers: [
+                    { name: "routing-service", image: `${REGISTRY}/routing-service:buildn` },
+                  ],
+                  volumes: [{ name: "routing-manifest", configMap: { name: SNAP_N } }],
+                },
+              },
+            },
+          }),
+        );
+      }
+      return ok();
+    }) as never);
+
+    await expect(retainLiveRoutingManifest("rel", "prod")).resolves.toEqual({
+      status: "retained",
+      snapshotName: SNAP_N,
+    });
+
+    const calls = vi.mocked(execCapture).mock.calls.map(([, args]) => args.join(" "));
+    expect(calls).toContain(
+      `annotate configmap ${SNAP_N} -n prod helm.sh/resource-policy=keep --overwrite`,
+    );
+    expect(calls).toContain(
+      `label configmap ${SNAP_N} -n prod app.kubernetes.io/name=rel app.kubernetes.io/component=routing-manifest-snapshot --overwrite`,
+    );
+    expect(vi.mocked(execCaptureStdin)).not.toHaveBeenCalled();
   });
 
   it("N30: reports a failed apply as failed, with a reason", async () => {
@@ -904,6 +942,7 @@ describe("retainLiveRoutingManifest — snapshot overwrite protection", () => {
     });
     const applied = JSON.parse(vi.mocked(execCaptureStdin).mock.calls[0]![2] as string);
     expect(applied.metadata.annotations[SNAPSHOT_BUILD_ID_ANNOTATION]).toBe("buildn");
+    expect(applied.metadata.annotations["helm.sh/resource-policy"]).toBe("keep");
     expect(applied.metadata.labels["app.kubernetes.io/managed-by"]).toBe("adapter-k8s");
   });
 });

--- a/tests/cli/rollback.test.ts
+++ b/tests/cli/rollback.test.ts
@@ -65,7 +65,7 @@ function capture(patchFails: boolean) {
   });
 }
 
-describe("runRollback — CDN invalidation", () => {
+describe("runRollback — state and CDN invalidation", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(readState).mockResolvedValue({
@@ -143,6 +143,133 @@ describe("runRollback — CDN invalidation", () => {
       RELEASE,
       "default",
     );
+  });
+
+  it("preserves per-build provenance across two-way rollbacks while clearing readiness", async () => {
+    const digestN = `sha256:${"a".repeat(64)}`;
+    const digestM = `sha256:${"b".repeat(64)}`;
+    const cdnTags = { buildn: `build-${"ef".repeat(32)}`, buildm: `build-${"0a".repeat(32)}` };
+    const routingImageDigests = { buildn: digestN, buildm: digestM };
+    const unretainedManifestBuilds = ["buildm"];
+    let state = {
+      buildId: "buildn",
+      previousBuildId: "buildm",
+      generation: 7,
+      readinessPathSupported: true,
+      cdnTags,
+      routingImageDigests,
+      unretainedManifestBuilds,
+    };
+    vi.mocked(readState).mockImplementation(async () => state as never);
+    vi.mocked(writeState).mockImplementation(async (_projectDir, next) => {
+      const { basedOnGeneration: _basedOnGeneration, ...body } = next;
+      state = { ...body, generation: state.generation + 1 } as typeof state;
+    });
+    vi.mocked(execCaptureStdin).mockResolvedValue({
+      exitCode: 0,
+      stdout: "",
+      stderr: "",
+    } as never);
+    vi.mocked(existsSync).mockImplementation((p) => p === infraPath || p === metaPath);
+    vi.mocked(readFileSync).mockImplementation((p) => {
+      if (p === infraPath)
+        return JSON.stringify({
+          projectId: "proj-12345",
+          region: "us-central1",
+          containerRegistry: "gcr.io/p",
+        });
+      if (p === metaPath) return '{"pools":["ssr"]}';
+      return "";
+    });
+
+    vi.mocked(execCapture).mockImplementation(async (_cmd, args) => {
+      const joined = args.join(" ");
+      if (args.includes("deployments")) {
+        return {
+          exitCode: 0,
+          stdout: "rel-ssr-buildm|2\nrel-ssr-buildn|2",
+          stderr: "",
+        };
+      }
+      if (joined.includes("get deployment rel-routing-service") && args.includes("json")) {
+        return {
+          exitCode: 0,
+          stdout: JSON.stringify({
+            spec: {
+              template: {
+                spec: {
+                  containers: [
+                    {
+                      name: "routing-service",
+                      image: `gcr.io/p/routing-service:${state.buildId}`,
+                      env: [{ name: "NEXT_BUILD_ID", value: state.buildId }],
+                    },
+                  ],
+                  volumes: [
+                    { name: "routing-manifest", configMap: { name: "rel-routing-manifest" } },
+                  ],
+                },
+              },
+            },
+          }),
+          stderr: "",
+        };
+      }
+      if (joined.includes("get deployment rel-routing-service")) {
+        return { exitCode: 0, stdout: "deployment.apps/rel-routing-service\n", stderr: "" };
+      }
+      if (joined.includes("get configmap rel-rm-")) {
+        return { exitCode: 0, stdout: "configmap/snapshot\n", stderr: "" };
+      }
+      if (joined.includes("get configmap rel-routing-manifest") && args.includes("json")) {
+        return {
+          exitCode: 0,
+          stdout: JSON.stringify({ data: { "routing-manifest.json": "{}" } }),
+          stderr: "",
+        };
+      }
+      if (args.includes("pods")) {
+        return {
+          exitCode: 0,
+          stdout: `rel-ssr-${state.previousBuildId}-abc\n`,
+          stderr: "",
+        };
+      }
+      return { exitCode: 0, stdout: "", stderr: "" };
+    });
+
+    await runRollback({ projectDir: PROJECT, releaseName: RELEASE });
+    await runRollback({ projectDir: PROJECT, releaseName: RELEASE });
+
+    const writes = vi.mocked(writeState).mock.calls.map((call) => call[1]);
+    expect(writes).toEqual([
+      {
+        buildId: "buildm",
+        previousBuildId: "buildn",
+        cdnTags,
+        routingImageDigests,
+        unretainedManifestBuilds,
+        basedOnGeneration: 7,
+      },
+      {
+        buildId: "buildn",
+        previousBuildId: "buildm",
+        cdnTags,
+        routingImageDigests,
+        unretainedManifestBuilds,
+        basedOnGeneration: 8,
+      },
+    ]);
+
+    const edgePatches = vi
+      .mocked(execCapture)
+      .mock.calls.filter(([, args]) => args.includes("patch") && args.includes("deployment"))
+      .map(([, args]) => args[args.length - 1] as string);
+    expect(edgePatches).toHaveLength(2);
+    expect(edgePatches[0]).toContain(`routing-service@${digestM}`);
+    expect(edgePatches[0]).not.toContain("routing-service:buildm");
+    expect(edgePatches[1]).toContain(`routing-service@${digestN}`);
+    expect(edgePatches[1]).not.toContain("routing-service:buildn");
   });
 
   it("does NOT invalidate anything when the selector switch fails", async () => {

--- a/tests/emit/per-build-routing-manifest.test.ts
+++ b/tests/emit/per-build-routing-manifest.test.ts
@@ -31,6 +31,9 @@ describe("per-build routing manifest ConfigMap", () => {
       routingManifestJson: MANIFEST,
     });
     expect(yaml).toContain(`name: ${routingManifestSnapshotName("test-app", "bms7test1")}`);
+    expect(yaml).toContain('app.kubernetes.io/name: "test-app"');
+    expect(yaml).toContain('app.kubernetes.io/component: "routing-manifest-snapshot"');
+    expect(yaml).toContain('helm.sh/resource-policy: "keep"');
     expect(yaml).toContain("routing-manifest.json");
   });
 

--- a/tests/emit/templates/service.test.ts
+++ b/tests/emit/templates/service.test.ts
@@ -110,8 +110,8 @@ describe("renderActiveService (stable)", () => {
   });
 
   it("N65: the PDB lives here (rendered once per pool), never in the per-build templates", () => {
-    // deploy.ts re-renders renderDeployment/renderService/renderHPA for the RETAINED
-    // previous build. A PDB in one of those would either duplicate a resource name or
+    // deploy.ts re-renders renderDeployment/renderService for the RETAINED previous build.
+    // A PDB in one of those would either duplicate a resource name or
     // need per-build cleanup; renderActiveService is emitted exactly once per pool.
     const versioned = renderService({ poolName: "ssr", buildId: "b1", releaseName: "my-app" });
     expect(versioned).not.toContain("PodDisruptionBudget");


### PR DESCRIPTION
## Summary

- retain build-scoped routing manifests while their ReplicaSets remain valid rollback targets
- keep the outgoing build autoscaling until traffic and deploy state move; #30 separately holds the incoming warm-up floor
- preserve per-build rollback metadata so routing images stay digest-pinned in both directions

## Testing

- `npm run build`
- `TMPDIR=/private/tmp npm test`
- `npm run typecheck`
- `npm run lint`
- `npm run fmt`
- `git diff --check`
- live home-cluster deploy and two-way rollback under sustained mixed traffic