### PR TITLE
Support Helm 3 deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ Middleware, PPR, cache components, and ISR are verified through the upstream Nex
 - A Kubernetes cluster:
   - **GKE** (Autopilot or Standard) for `provider.gke`, plus `gcloud` in PATH
   - **any conformant cluster** for `provider.generic`, with [Envoy Gateway](https://gateway.envoyproxy.io/) installed and a CNI that enforces NetworkPolicy
-- `kubectl` and `helm` in PATH, plus a container runtime—`docker`, `podman`, or `nerdctl`
+- `kubectl` and Helm >= 3.2 in PATH, plus a container runtime—`docker`, `podman`, or `nerdctl`.
+  Helm 3 uses its client-side upgrade path; Helm 4 uses server-side apply.
 
 Emitted container images run **Node 24** (the generated routing manifest requires it; the build fails on older bases rather than 500ing at runtime).
 
@@ -352,6 +353,13 @@ instead. That is why the generic provider's CNI must actually enforce policy—s
 ### Blue/green deploys
 
 Each deploy creates a new versioned Deployment alongside the previous one. Traffic points at a stable active Service whose selector is patched only after every new pod passes readiness _and_ is verified serving via `/readyz` directly on the pod. The previous build is kept at zero replicas as a rollback target; `rollback` scales it up, reverts the routing tier to that build's image and manifest, and patches the selector back.
+
+Use `npx adapter-k8s rollback`, not `helm rollback`. Helm revisions are reconciliation snapshots
+captured before the adapter's verified Service-selector cutover, not application release
+checkpoints. A raw Helm rollback does not restore adapter state, routing state, pool capacity, or
+CDN state, and can restore a pre-cutover stable Service selector. On Helm 4 it can also conflict
+with HPA-owned Deployment replicas; `--force-conflicts` bypasses that conflict but does not make
+the rollback safe.
 
 ## CI/CD
 

--- a/src/cli/deploy.ts
+++ b/src/cli/deploy.ts
@@ -26,7 +26,7 @@ import { renderDeployment, POOL_READINESS_PATH } from "../emit/templates/deploym
  */
 const LIVENESS_PATH_FOR_MIGRATION = "/healthz";
 import { renderService } from "../emit/templates/service.js";
-import { renderValkeySecret } from "../emit/templates/valkey-secret.js";
+import { renderValkeySecret, VALKEY_SECRET_NAME } from "../emit/templates/valkey-secret.js";
 import { provisionMemorystore, buildDeleteMemorystoreCommand } from "./provision-cache.js";
 import { isAlreadyGoneError } from "./destroy.js";
 import { MIN_GKE_VERSION_FOR_CDN } from "./gke-version.js";
@@ -60,6 +60,7 @@ import {
   assertSafeProbePath,
   assertSafeProjectId,
   assertSafeRegion,
+  assertSafeReleaseName,
   poolResourceNames,
   resolveK8sNamespace,
 } from "../emit/templates/utils.js";
@@ -731,6 +732,195 @@ export async function resolveImageDigest(
   return null;
 }
 
+export type HelmUpgradeMode = "client-side" | "server-side";
+
+function helmHelpHasFlag(help: string, flag: string): boolean {
+  const escaped = flag.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  // Cobra renders options on their own indented rows. Do not accept a flag merely mentioned
+  // in a warning or description: a Helm wrapper saying it *does not support* --server-side
+  // must never make us construct an argv containing that flag.
+  return new RegExp(
+    `^[ \\t]*(?:-\\S+,[ \\t]+)?${escaped}(?:(?:[ \\t]+\\S+)?[ \\t]{2,}\\S.*)$`,
+    "m",
+  ).test(help);
+}
+
+/**
+ * Select the strongest Helm upgrade mode this installation supports without turning a
+ * Helm 3 deployment into an invalid Helm 4 command.
+ *
+ * Helm 3.2 introduced `--create-namespace`, the oldest Helm capability this deploy argv
+ * requires. Helm 4 introduced `--server-side` and `--force-conflicts`; those two are an
+ * optional apply implementation, not a reason to reject an otherwise capable installation.
+ * Probe Cobra's own option rows rather than parsing a version string so downstream builds
+ * remain compatible without treating flags mentioned only in prose as capabilities.
+ */
+export async function detectHelmUpgradeMode(): Promise<HelmUpgradeMode> {
+  let result: Awaited<ReturnType<typeof execCapture>>;
+  try {
+    result = await execCapture("helm", ["upgrade", "--help"]);
+  } catch (err) {
+    throw new Error(
+      `Could not inspect Helm upgrade capabilities: ${err instanceof Error ? err.message : String(err)}. ` +
+        `Install Helm 3.2 or newer and re-run deploy.`,
+    );
+  }
+  if (result.exitCode !== 0) {
+    const detail = sanitizeForTerminal((result.stderr || result.stdout).trim());
+    throw new Error(
+      `Could not inspect Helm upgrade capabilities (helm upgrade --help exited ` +
+        `${result.exitCode}${detail ? `: ${detail}` : ""}). Install Helm 3.2 or newer and ` +
+        `re-run deploy.`,
+    );
+  }
+
+  const help = `${result.stdout}\n${result.stderr}`;
+  if (!helmHelpHasFlag(help, "--create-namespace")) {
+    throw new Error(
+      `This Helm installation does not support --create-namespace. The adapter requires ` +
+        `Helm 3.2 or newer. Upgrade Helm and re-run deploy.`,
+    );
+  }
+
+  // These flags are a pair: --force-conflicts is valid only with server-side apply. If a
+  // downstream Helm build exposes only one, use its portable client-side upgrade instead
+  // of constructing an argv that the CLI cannot honor safely.
+  const serverSide = helmHelpHasFlag(help, "--server-side");
+  const forceConflicts = helmHelpHasFlag(help, "--force-conflicts");
+  return serverSide && forceConflicts ? "server-side" : "client-side";
+}
+
+export type ValkeySecretOwnership = "absent" | "owned" | "adopted";
+
+/**
+ * Migrate only the exact legacy Valkey Secret that adapter versions before Helm ownership
+ * created with `kubectl apply`. Helm's `--take-ownership` applies release-wide and can steal any
+ * colliding object, so it must never be used for this one-resource migration.
+ *
+ * The old rendered Secret has a stable identity we can prove without reading its credential
+ * data: exact name, type Opaque, and the release/component labels below. Adoption is permitted
+ * only when all three Helm ownership fields are absent. Partial or foreign ownership is an
+ * abort, not something `--overwrite` may repair. The single merge patch makes the transition
+ * atomic; if Helm later fails, a retry sees the complete current-release ownership tuple.
+ */
+export async function ensureValkeySecretHelmOwnership(
+  releaseName: string,
+  configuredNamespace?: string,
+): Promise<ValkeySecretOwnership> {
+  assertSafeReleaseName(releaseName);
+  const namespace = resolveK8sNamespace(configuredNamespace);
+  const secretName = `${releaseName}-${VALKEY_SECRET_NAME}`;
+  const result = await execCapture("kubectl", [
+    "get",
+    "secret",
+    secretName,
+    "-n",
+    namespace,
+    "--ignore-not-found",
+    "-o",
+    "jsonpath={.metadata.name}|{.type}|{.metadata.labels.app\\.kubernetes\\.io/name}|" +
+      "{.metadata.labels.app\\.kubernetes\\.io/component}|" +
+      "{.metadata.labels.app\\.kubernetes\\.io/managed-by}|" +
+      "{.metadata.annotations.meta\\.helm\\.sh/release-name}|" +
+      "{.metadata.annotations.meta\\.helm\\.sh/release-namespace}|" +
+      "{.metadata.resourceVersion}",
+  ]);
+  if (result.exitCode !== 0) {
+    const detail = sanitizeForTerminal(result.stderr.trim());
+    throw new Error(
+      `Could not inspect cache Secret ${secretName} before Helm upgrade (kubectl exited ` +
+        `${result.exitCode}${detail ? `: ${detail}` : ""}). Refusing to guess whether it is ` +
+        `safe to adopt.`,
+    );
+  }
+
+  const line = result.stdout.trim();
+  if (!line) return "absent";
+  const fields = line.split("|");
+  if (fields.length !== 8) {
+    throw new Error(
+      `Could not validate cache Secret ${secretName}: kubectl returned an unexpected identity ` +
+        `shape. Refusing to adopt it.`,
+    );
+  }
+  const [name, type, appName, component, managedBy, ownerRelease, ownerNamespace, resourceVersion] =
+    fields;
+  const identityMatches =
+    name === secretName &&
+    type === "Opaque" &&
+    appName === releaseName &&
+    component === "valkey-secret";
+  const ownedByThisRelease =
+    managedBy === "Helm" && ownerRelease === releaseName && ownerNamespace === namespace;
+  if (ownedByThisRelease) {
+    if (!identityMatches) {
+      throw new Error(
+        `Cache Secret ${secretName} has this release's Helm ownership metadata but does not ` +
+          `match the adapter's Valkey Secret identity (expected type Opaque and labels ` +
+          `app.kubernetes.io/name=${releaseName}, app.kubernetes.io/component=valkey-secret). ` +
+          `Refusing to deploy over it.`,
+      );
+    }
+    return "owned";
+  }
+
+  if (managedBy || ownerRelease || ownerNamespace) {
+    const ownership = sanitizeForTerminal(
+      JSON.stringify({ managedBy, release: ownerRelease, namespace: ownerNamespace }),
+    );
+    throw new Error(
+      `Cache Secret ${secretName} has foreign or incomplete ownership metadata ` +
+        `${ownership}. Refusing to adopt it.`,
+    );
+  }
+  if (!identityMatches) {
+    throw new Error(
+      `An unowned Secret named ${secretName} exists but is not the adapter's legacy Valkey ` +
+        `Secret (expected type Opaque and labels app.kubernetes.io/name=${releaseName}, ` +
+        `app.kubernetes.io/component=valkey-secret). Refusing to adopt it.`,
+    );
+  }
+  if (!resourceVersion) {
+    throw new Error(
+      `Could not validate cache Secret ${secretName}: kubectl returned no resourceVersion. ` +
+        `Refusing an adoption patch without an optimistic-concurrency precondition.`,
+    );
+  }
+
+  const ownershipPatch = JSON.stringify({
+    metadata: {
+      // Prevent a get→patch race from overwriting ownership or identity changed after the
+      // validation above. Kubernetes rejects a stale resourceVersion with Conflict.
+      resourceVersion,
+      labels: { "app.kubernetes.io/managed-by": "Helm" },
+      annotations: {
+        "meta.helm.sh/release-name": releaseName,
+        "meta.helm.sh/release-namespace": namespace,
+      },
+    },
+  });
+  const patched = await execCapture("kubectl", [
+    "patch",
+    "secret",
+    secretName,
+    "-n",
+    namespace,
+    "--type=merge",
+    "--field-manager=adapter-k8s-legacy-adoption",
+    "-p",
+    ownershipPatch,
+  ]);
+  if (patched.exitCode !== 0) {
+    const detail = sanitizeForTerminal(patched.stderr.trim());
+    throw new Error(
+      `Could not attach Helm ownership to validated legacy cache Secret ${secretName} ` +
+        `(kubectl exited ${patched.exitCode}${detail ? `: ${detail}` : ""}). Aborting before ` +
+        `Helm upgrade.`,
+    );
+  }
+  return "adopted";
+}
+
 export function buildHelmUpgradeArgs(options: {
   releaseName: string;
   chartPath: string;
@@ -750,6 +940,8 @@ export function buildHelmUpgradeArgs(options: {
    * /readyz — see AdapterState.readinessPathSupported.
    */
   poolHealthCheckPath?: string;
+  /** Determined from `helm upgrade --help`; defaults to the historical Helm 4 behavior. */
+  helmUpgradeMode?: HelmUpgradeMode;
 }): string[] {
   const {
     releaseName,
@@ -763,6 +955,7 @@ export function buildHelmUpgradeArgs(options: {
     nodeCidrs,
     imageDigests,
     poolHealthCheckPath,
+    helmUpgradeMode = "server-side",
   } = options;
   const namespace = resolveK8sNamespace(configuredNamespace);
   // H2: these values land in `helm --set` assignments — reject helm metacharacters
@@ -776,11 +969,7 @@ export function buildHelmUpgradeArgs(options: {
     "--install",
     releaseName,
     chartPath,
-    "--server-side=true",
-    "--force-conflicts",
-    // Cache Secrets are Helm-owned in every enabled mode. This adopts Secrets created by older
-    // adapter versions that provisioned managed-cache credentials imperatively with kubectl.
-    "--take-ownership",
+    ...(helmUpgradeMode === "server-side" ? ["--server-side=true", "--force-conflicts"] : []),
     // The release lives in the namespace init binds Workload Identity to — pin it rather
     // than installing into whatever namespace the operator's context happens to have.
     "--namespace",
@@ -1132,6 +1321,11 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
         ".k8s-adapter/infrastructure.json.",
     );
   }
+
+  // Probe before `next build`, image pushes, credentials, or any cluster mutation. Helm 3
+  // remains a supported deployment client; only Helm 4 receives its SSA-only flags. A dry
+  // run performs no subprocess reads by contract and prints both capability-dependent forms.
+  const helmUpgradeMode = dryRun ? null : await detectHelmUpgradeMode();
 
   // 1. Run next build (adapter's onBuildComplete generates artifacts)
   if (!skipBuild) {
@@ -1723,7 +1917,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
   }
 
   const overridesFile = path.join(projectDir, ".k8s-adapter", "helm", "values.override.yaml");
-  const helmArgs = buildHelmUpgradeArgs({
+  const helmArgsBase = {
     releaseName,
     chartPath: path.join(outputDir, "chart"),
     buildId,
@@ -1745,6 +1939,12 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
     ...(previousBuildId && !state?.readinessPathSupported
       ? { poolHealthCheckPath: LIVENESS_PATH_FOR_MIGRATION }
       : {}),
+  };
+  const helmArgs = buildHelmUpgradeArgs({
+    ...helmArgsBase,
+    // Dry-run's first printed form is the Helm 3 client-side command. The Helm 4 form is
+    // rendered separately at the execution site below.
+    helmUpgradeMode: helmUpgradeMode ?? "client-side",
   });
 
   const chartTemplatesDir = path.join(outputDir, "chart", "templates");
@@ -2101,7 +2301,30 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
     }
   }
 
-  // 6-pre. Retain the OUTGOING build's routing manifest as a build-named snapshot
+  // 6-pre. Adopt only the exact legacy Valkey Secret that older adapter versions created
+  // imperatively. This must happen before Helm sees the chart resource: without the ownership
+  // tuple Helm correctly rejects it, while release-wide --take-ownership would also seize any
+  // unrelated colliding resource. A dry-run cannot inspect the cluster, so describe the guarded
+  // conditional instead of claiming the Secret is present or adoptable.
+  if (metadata.cacheEnabled) {
+    if (dryRun) {
+      console.log(
+        `    [dry-run] if Secret ${releaseName}-${VALKEY_SECRET_NAME} exists without Helm ` +
+          `ownership, verify its exact legacy adapter identity and atomically assign it to ` +
+          `release ${releaseName}; abort on foreign, partial, or mismatched ownership`,
+      );
+    } else {
+      const ownership = await ensureValkeySecretHelmOwnership(releaseName, namespace);
+      if (ownership === "adopted") {
+        console.log(
+          `  → Adopted validated legacy cache Secret ` +
+            `${releaseName}-${VALKEY_SECRET_NAME} into Helm release ${releaseName}`,
+        );
+      }
+    }
+  }
+
+  // 6-pre-bis. Retain the OUTGOING build's routing manifest as a build-named snapshot
   // ConfigMap BEFORE helm overwrites the stable `<release>-routing-manifest` one — the
   // routing tier is updated in place per build, and rollback re-points it at the
   // snapshot. The snapshot keys off what the routing Deployment is ACTUALLY serving
@@ -2138,7 +2361,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
     }
   }
 
-  // 6-pre-bis (N87). Preserve the LEGACY stable-named internal dispatch Secret across this
+  // 6-pre-ter (N87). Preserve the LEGACY stable-named internal dispatch Secret across this
   // upgrade. Internal secrets are now per-BUILD (`<release>-ihs-<build>-<digest>`,
   // emit/templates/internal-secret.ts), so the first upgrade under that scheme removes
   // `<release>-internal-header-secret` from the chart — and helm prunes what the chart no
@@ -2221,7 +2444,9 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
     await execOrThrow("helm", helmArgs);
     helmApplied = true;
   } else {
-    console.log(`    [dry-run] helm ${helmArgs.join(" ")}`);
+    const helm4Args = buildHelmUpgradeArgs({ ...helmArgsBase, helmUpgradeMode: "server-side" });
+    console.log(`    [dry-run] helm ${helmArgs.join(" ")}  # Helm 3.2–3.x, client-side upgrade`);
+    console.log(`    [dry-run] helm ${helm4Args.join(" ")}  # Helm 4+, server-side upgrade`);
   }
 
   /**
@@ -2919,8 +3144,9 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
         "-n",
         namespace,
         "--type=json",
-        // Impersonate helm as the field manager so the next helm upgrade (server-side
-        // apply, manager "helm") does not conflict on the selector field we flip here.
+        // Keep this imperative cutover under helm's field manager. On Helm 4's server-side
+        // path that prevents the next upgrade conflicting on the selector we flip here;
+        // Helm 3's client-side merge does not enforce managed-field conflicts.
         // NOTE: --force-conflicts is NOT a valid `kubectl patch` flag (it only exists on
         // `kubectl apply --server-side`); a JSON patch is not server-side apply and needs
         // no conflict override.

--- a/src/emit/templates/valkey-secret.ts
+++ b/src/emit/templates/valkey-secret.ts
@@ -1,10 +1,11 @@
 import { assertSafeReleaseName, escapeHelmActions } from "./utils.js";
 
 // A per-release Secret holding the Valkey connection URL + AUTH string that the pool servers
-// use for the shared `use cache` / PPR cache. It is created imperatively at deploy time — from
-// the managed Memorystore instance's discovery endpoint after provisioning, or from a
-// bring-your-own `cache.url`/`cache.password`. The pool reads VALKEY_URL / VALKEY_AUTH and, when
-// present, registers the Valkey cache handler.
+// use for the shared `use cache` / PPR cache. It is rendered into the Helm chart from the managed
+// Memorystore instance's discovery endpoint after provisioning, or from a bring-your-own
+// `cache.url`/`cache.password`. The pool reads VALKEY_URL / VALKEY_AUTH and, when present,
+// registers the Valkey cache handler. Older adapter releases applied the same rendered object
+// imperatively; deploy.ts migrates only that strictly identified legacy Secret into Helm.
 export const VALKEY_SECRET_NAME = "valkey";
 export const VALKEY_URL_KEY = "url";
 export const VALKEY_AUTH_KEY = "auth";
@@ -40,7 +41,7 @@ ${indent}      key: ${VALKEY_CA_KEY}
 ${indent}      optional: true`;
 }
 
-/** The Valkey connection Secret, created at deploy time (managed endpoint or BYO). */
+/** The Helm-owned Valkey connection Secret, rendered at build/deploy time (BYO or managed). */
 export function renderValkeySecret({
   releaseName,
   url,

--- a/tests/cli/deploy-orchestration.test.ts
+++ b/tests/cli/deploy-orchestration.test.ts
@@ -66,6 +66,16 @@ const routeExtJobYaml = path.join(
   "route-ext-update-job.yaml",
 );
 
+const HELM_4_UPGRADE_HELP = `
+      --create-namespace   if --install is set, create the release namespace
+      --force-conflicts    if set server-side apply will force changes against conflicts
+      --server-side string    must be "true", "false" or "auto"
+`;
+
+const HELM_3_UPGRADE_HELP = `
+      --create-namespace   if --install is set, create the release namespace
+`;
+
 interface InfraFixture {
   projectId?: string;
   region?: string;
@@ -176,6 +186,9 @@ function happyCluster(
   return vi.fn(async (_cmd: string, args: string[]) => {
     const j = args.join(" ");
     const ok = (stdout = "") => ({ exitCode: 0, stdout, stderr: "" });
+    if (_cmd === "helm" && args[0] === "upgrade" && args.includes("--help")) {
+      return ok(HELM_4_UPGRADE_HELP);
+    }
     // N87 (before the generic `secret` branch below, which answers the cache-Secret delete).
     if (args[0] === "get" && args[1] === "secret" && args.includes("--ignore-not-found")) {
       if (overrides.legacySecretProbeFails) {
@@ -504,6 +517,9 @@ describe("runDeploy — orchestration", () => {
     // Helm pinned to the namespace init binds Workload Identity to.
     const helmCall = vi.mocked(execOrThrow).mock.calls.find(([cmd]) => cmd === "helm");
     expect(helmCall?.[1].join(" ")).toContain("--namespace default --create-namespace");
+    expect(helmCall?.[1]).not.toContain("--take-ownership");
+    expect(helmCall?.[1]).toContain("--server-side=true");
+    expect(helmCall?.[1]).toContain("--force-conflicts");
     // Docker push happened for the pool and the routing service.
     const dockerCalls = vi
       .mocked(execOrThrow)
@@ -581,6 +597,39 @@ describe("runDeploy — orchestration", () => {
     expect(events).toContain("delete-hpa:rel-ssr-buildm-hpa");
     expect(events).not.toContain("scale:deployment/rel-ssr-buildm");
     expect(printedWarnings()).toContain("could immediately undo a scale to zero");
+  });
+
+  it("uses Helm 3's client-side upgrade without passing Helm 4-only flags", async () => {
+    const cluster = happyCluster(events);
+    vi.mocked(execCapture).mockImplementation((async (cmd: string, args: string[]) => {
+      if (cmd === "helm" && args[0] === "upgrade" && args.includes("--help")) {
+        return { exitCode: 0, stdout: HELM_3_UPGRADE_HELP, stderr: "" };
+      }
+      return cluster(cmd, args);
+    }) as never);
+
+    await runDeploy({ projectDir: PROJECT, releaseName: RELEASE, skipBuild: true });
+
+    const helmCall = vi.mocked(execOrThrow).mock.calls.find(([cmd]) => cmd === "helm");
+    expect(helmCall?.[1]).not.toContain("--take-ownership");
+    expect(helmCall?.[1]).not.toContain("--server-side=true");
+    expect(helmCall?.[1]).not.toContain("--force-conflicts");
+  });
+
+  it("rejects Helm older than 3.2 before any deployment mutation", async () => {
+    vi.mocked(execCapture).mockResolvedValue({
+      exitCode: 0,
+      stdout: "Usage: helm upgrade [RELEASE] [CHART]",
+      stderr: "",
+    } as never);
+
+    await expect(runDeploy({ projectDir: PROJECT, releaseName: RELEASE })).rejects.toThrow(
+      /does not support --create-namespace/,
+    );
+
+    expect(vi.mocked(execOrThrow)).not.toHaveBeenCalled();
+    expect(vi.mocked(execCaptureStdin)).not.toHaveBeenCalled();
+    expect(vi.mocked(writeState)).not.toHaveBeenCalled();
   });
 
   it("new build never healthy: no selector patch, no state commit, non-zero exit, previous keeps serving", async () => {
@@ -688,6 +737,14 @@ describe("runDeploy — orchestration", () => {
       .join("\n");
     expect(printed).toContain("[dry-run] helm upgrade");
     expect(printed).toContain("--namespace default --create-namespace");
+    const helmPlans = printed.split("\n").filter((line) => line.includes("[dry-run] helm upgrade"));
+    expect(helmPlans).toHaveLength(2);
+    expect(helmPlans[0]).toContain("Helm 3.2–3.x, client-side upgrade");
+    expect(helmPlans[0]).not.toContain("--server-side=true");
+    expect(helmPlans[0]).not.toContain("--force-conflicts");
+    expect(helmPlans[1]).toContain("Helm 4+, server-side upgrade");
+    expect(helmPlans[1]).toContain("--server-side=true");
+    expect(helmPlans[1]).toContain("--force-conflicts");
   });
 });
 
@@ -1125,6 +1182,40 @@ describe("runDeploy — guards and teardown", () => {
     expect(infraWrites.length).toBeGreaterThan(0);
     expect(infraWrites[infraWrites.length - 1]).not.toContain("cacheRegion");
     expect(vi.mocked(provisionMemorystore)).not.toHaveBeenCalled();
+  });
+
+  it("aborts before Helm rather than adopting a foreign-owned non-cache Secret", async () => {
+    setupFs({
+      metadata: { buildId: "buildn", pools: ["ssr"], cacheEnabled: true, cacheManaged: false },
+    });
+    const cluster = happyCluster(events);
+    vi.mocked(execCapture).mockImplementation((async (cmd: string, args: string[]) => {
+      if (
+        cmd === "kubectl" &&
+        args[0] === "get" &&
+        args[1] === "secret" &&
+        args[2] === "rel-valkey" &&
+        args.some((arg) => arg.includes("resourceVersion"))
+      ) {
+        return {
+          exitCode: 0,
+          stdout:
+            "rel-valkey|Opaque|foreign-app|database-credentials|Helm|foreign-release|default|123",
+          stderr: "",
+        };
+      }
+      return cluster(cmd, args);
+    }) as never);
+
+    await expect(
+      runDeploy({ projectDir: PROJECT, releaseName: RELEASE, skipBuild: true }),
+    ).rejects.toThrow(/foreign or incomplete ownership metadata/);
+
+    expect(events).not.toContain("helm");
+    const valkeyPatches = vi
+      .mocked(execCapture)
+      .mock.calls.filter(([, args]) => args[0] === "patch" && args[2] === "rel-valkey");
+    expect(valkeyPatches).toHaveLength(0);
   });
 
   it("cache disabled: removes the Secret AND the managed instance (regression)", async () => {

--- a/tests/cli/deploy.test.ts
+++ b/tests/cli/deploy.test.ts
@@ -15,6 +15,8 @@ import {
   resolveRegistryDigestAny,
   resolveDeployImageDigests,
   discoverServingBuildId,
+  detectHelmUpgradeMode,
+  ensureValkeySecretHelmOwnership,
   resolveImageDigest,
   refreshFetchCacheStaging,
 } from "../../src/cli/deploy.js";
@@ -238,7 +240,24 @@ describe("buildHelmUpgradeArgs", () => {
     expect(args).toContain(".k8s-adapter/output/chart");
     expect(args.join(" ")).toContain("global.image.tag=abc123");
     expect(args.join(" ")).toContain("activeBuildId=abc123");
-    expect(args).toContain("--take-ownership");
+    expect(args).not.toContain("--take-ownership");
+    expect(args).toContain("--server-side=true");
+    expect(args).toContain("--force-conflicts");
+  });
+
+  it("omits Helm 4-only flags and any release-wide ownership bypass in client-side mode", () => {
+    const args = buildHelmUpgradeArgs({
+      releaseName: "my-app",
+      chartPath: ".k8s-adapter/output/chart",
+      buildId: "abc123",
+      registry: "us-central1-docker.pkg.dev/my-project/nextjs",
+      previousBuildId: null,
+      helmUpgradeMode: "client-side",
+    });
+
+    expect(args).not.toContain("--take-ownership");
+    expect(args).not.toContain("--server-side=true");
+    expect(args).not.toContain("--force-conflicts");
   });
 
   it("includes previousBuildId when set", () => {
@@ -277,6 +296,246 @@ describe("buildHelmUpgradeArgs", () => {
     });
 
     expect(args.join(" ")).toContain("activeBuildId=b-123old");
+  });
+});
+
+describe("detectHelmUpgradeMode", () => {
+  const CREATE_NAMESPACE =
+    "      --create-namespace    if --install is set, create the release namespace";
+
+  beforeEach(() => vi.clearAllMocks());
+
+  it("selects Helm 4 server-side apply from actual Cobra option rows", async () => {
+    vi.mocked(exec.execCapture).mockResolvedValue({
+      exitCode: 0,
+      stdout:
+        `${CREATE_NAMESPACE}\n` +
+        `      --force-conflicts    force server-side apply conflicts\n` +
+        `      --server-side string    must be true, false, or auto\n`,
+      stderr: "",
+    });
+
+    await expect(detectHelmUpgradeMode()).resolves.toBe("server-side");
+  });
+
+  it("selects Helm 3 client-side upgrade and ignores flag names mentioned only in prose", async () => {
+    vi.mocked(exec.execCapture).mockResolvedValue({
+      exitCode: 0,
+      stdout:
+        `${CREATE_NAMESPACE}\n` +
+        `This downstream build does not support --server-side or --force-conflicts.\n`,
+      stderr: "",
+    });
+
+    await expect(detectHelmUpgradeMode()).resolves.toBe("client-side");
+  });
+
+  it.each([
+    ["server-side only", "      --server-side string    must be true, false, or auto"],
+    ["force-conflicts only", "      --force-conflicts    force server-side apply conflicts"],
+  ])("uses client-side mode when a downstream build exposes %s", async (_name, row) => {
+    vi.mocked(exec.execCapture).mockResolvedValue({
+      exitCode: 0,
+      stdout: `${CREATE_NAMESPACE}\n${row}\n`,
+      stderr: "",
+    });
+
+    await expect(detectHelmUpgradeMode()).resolves.toBe("client-side");
+  });
+
+  it("rejects Helm older than the --create-namespace capability floor", async () => {
+    vi.mocked(exec.execCapture).mockResolvedValue({
+      exitCode: 0,
+      stdout: "Usage: helm upgrade [RELEASE] [CHART]",
+      stderr: "",
+    });
+
+    await expect(detectHelmUpgradeMode()).rejects.toThrow(/Helm 3\.2 or newer/);
+  });
+
+  it("reports a non-zero capability probe without leaking terminal controls", async () => {
+    vi.mocked(exec.execCapture).mockResolvedValue({
+      exitCode: 2,
+      stdout: "",
+      stderr: "\u001b[31munknown command\u001b[0m",
+    });
+
+    let message = "";
+    try {
+      await detectHelmUpgradeMode();
+    } catch (err) {
+      message = err instanceof Error ? err.message : String(err);
+    }
+    expect(message).toContain("helm upgrade --help exited 2:");
+    expect(message).toContain("unknown command");
+    expect(message).not.toContain("\u001b");
+  });
+
+  it("reports a failed capability probe invocation", async () => {
+    vi.mocked(exec.execCapture).mockRejectedValue(new Error("spawn helm ENOENT"));
+
+    await expect(detectHelmUpgradeMode()).rejects.toThrow(/spawn helm ENOENT.*Helm 3\.2/s);
+  });
+});
+
+describe("ensureValkeySecretHelmOwnership", () => {
+  const response = (
+    fields: [string, string, string, string, string, string, string, string],
+  ): { exitCode: number; stdout: string; stderr: string } => ({
+    exitCode: 0,
+    stdout: fields.join("|"),
+    stderr: "",
+  });
+
+  beforeEach(() => vi.clearAllMocks());
+
+  it("atomically adopts only the exact unowned legacy adapter Valkey Secret", async () => {
+    vi.mocked(exec.execCapture)
+      .mockResolvedValueOnce(
+        response(["rel-valkey", "Opaque", "rel", "valkey-secret", "", "", "", "123"]),
+      )
+      .mockResolvedValueOnce({ exitCode: 0, stdout: "secret/rel-valkey patched", stderr: "" });
+
+    await expect(ensureValkeySecretHelmOwnership("rel")).resolves.toBe("adopted");
+
+    const calls = vi.mocked(exec.execCapture).mock.calls;
+    expect(calls).toHaveLength(2);
+    expect(calls[0]).toEqual([
+      "kubectl",
+      expect.arrayContaining(["get", "secret", "rel-valkey", "--ignore-not-found"]),
+    ]);
+    const patchArgs = calls[1]![1];
+    expect(patchArgs).toEqual(
+      expect.arrayContaining(["patch", "secret", "rel-valkey", "--type=merge", "-p"]),
+    );
+    const body = JSON.parse(patchArgs[patchArgs.indexOf("-p") + 1]!) as {
+      metadata: {
+        resourceVersion: string;
+        labels: Record<string, string>;
+        annotations: Record<string, string>;
+      };
+    };
+    expect(body.metadata).toEqual({
+      resourceVersion: "123",
+      labels: { "app.kubernetes.io/managed-by": "Helm" },
+      annotations: {
+        "meta.helm.sh/release-name": "rel",
+        "meta.helm.sh/release-namespace": "default",
+      },
+    });
+  });
+
+  it("accepts an exact Secret already owned by this release without patching it", async () => {
+    vi.mocked(exec.execCapture).mockResolvedValue(
+      response(["rel-valkey", "Opaque", "rel", "valkey-secret", "Helm", "rel", "default", "123"]),
+    );
+
+    await expect(ensureValkeySecretHelmOwnership("rel")).resolves.toBe("owned");
+    expect(vi.mocked(exec.execCapture)).toHaveBeenCalledOnce();
+  });
+
+  it("adopts the legacy Secret into the configured namespace", async () => {
+    vi.mocked(exec.execCapture)
+      .mockResolvedValueOnce(
+        response(["rel-valkey", "Opaque", "rel", "valkey-secret", "", "", "", "123"]),
+      )
+      .mockResolvedValueOnce({ exitCode: 0, stdout: "secret/rel-valkey patched", stderr: "" });
+
+    await expect(ensureValkeySecretHelmOwnership("rel", "prod")).resolves.toBe("adopted");
+
+    for (const [, args] of vi.mocked(exec.execCapture).mock.calls) {
+      expect(args).toEqual(expect.arrayContaining(["-n", "prod"]));
+    }
+    const patchArgs = vi.mocked(exec.execCapture).mock.calls[1]![1];
+    const body = JSON.parse(patchArgs[patchArgs.indexOf("-p") + 1]!) as {
+      metadata: { annotations: Record<string, string> };
+    };
+    expect(body.metadata.annotations["meta.helm.sh/release-namespace"]).toBe("prod");
+  });
+
+  it("does nothing when the exact Secret is absent", async () => {
+    vi.mocked(exec.execCapture).mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+
+    await expect(ensureValkeySecretHelmOwnership("rel")).resolves.toBe("absent");
+    expect(vi.mocked(exec.execCapture)).toHaveBeenCalledOnce();
+  });
+
+  it("cannot adopt a foreign-owned non-cache resource with the colliding name", async () => {
+    vi.mocked(exec.execCapture).mockResolvedValue(
+      response([
+        "rel-valkey",
+        "Opaque",
+        "foreign-app",
+        "database-credentials",
+        "Helm",
+        "foreign-release",
+        "default",
+        "123",
+      ]),
+    );
+
+    await expect(ensureValkeySecretHelmOwnership("rel")).rejects.toThrow(
+      /foreign or incomplete ownership metadata/,
+    );
+    expect(vi.mocked(exec.execCapture)).toHaveBeenCalledOnce();
+  });
+
+  it("cannot adopt an unowned non-cache resource with the colliding name", async () => {
+    vi.mocked(exec.execCapture).mockResolvedValue(
+      response(["rel-valkey", "Opaque", "rel", "database-credentials", "", "", "", "123"]),
+    );
+
+    await expect(ensureValkeySecretHelmOwnership("rel")).rejects.toThrow(
+      /is not the adapter's legacy Valkey Secret/,
+    );
+    expect(vi.mocked(exec.execCapture)).toHaveBeenCalledOnce();
+  });
+
+  it("aborts on partial ownership instead of overwriting it", async () => {
+    vi.mocked(exec.execCapture).mockResolvedValue(
+      response(["rel-valkey", "Opaque", "rel", "valkey-secret", "Helm", "", "", "123"]),
+    );
+
+    await expect(ensureValkeySecretHelmOwnership("rel")).rejects.toThrow(
+      /foreign or incomplete ownership metadata/,
+    );
+    expect(vi.mocked(exec.execCapture)).toHaveBeenCalledOnce();
+  });
+
+  it("refuses an adoption patch without a resourceVersion precondition", async () => {
+    vi.mocked(exec.execCapture).mockResolvedValue(
+      response(["rel-valkey", "Opaque", "rel", "valkey-secret", "", "", "", ""]),
+    );
+
+    await expect(ensureValkeySecretHelmOwnership("rel")).rejects.toThrow(
+      /no resourceVersion.*optimistic-concurrency/s,
+    );
+    expect(vi.mocked(exec.execCapture)).toHaveBeenCalledOnce();
+  });
+
+  it("aborts when the Secret identity cannot be read", async () => {
+    vi.mocked(exec.execCapture).mockResolvedValue({
+      exitCode: 1,
+      stdout: "",
+      stderr: "secrets is forbidden",
+    });
+
+    await expect(ensureValkeySecretHelmOwnership("rel")).rejects.toThrow(
+      /Could not inspect cache Secret.*secrets is forbidden/s,
+    );
+    expect(vi.mocked(exec.execCapture)).toHaveBeenCalledOnce();
+  });
+
+  it("aborts when the validated Secret cannot be patched", async () => {
+    vi.mocked(exec.execCapture)
+      .mockResolvedValueOnce(
+        response(["rel-valkey", "Opaque", "rel", "valkey-secret", "", "", "", "123"]),
+      )
+      .mockResolvedValueOnce({ exitCode: 1, stdout: "", stderr: "forbidden" });
+
+    await expect(ensureValkeySecretHelmOwnership("rel")).rejects.toThrow(
+      /Could not attach Helm ownership.*forbidden/s,
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

- detect Helm upgrade capabilities and use client-side upgrades when server-side apply flags are unavailable
- adopt only the validated legacy Valkey Secret instead of taking ownership of every colliding resource
- document why application rollback must use the adapter transaction instead of raw Helm revisions

## Testing

- `npm run build`
- `TMPDIR=/private/tmp npm test`
- `npm run typecheck`
- `npm run lint`
- `npm run fmt`
- `git diff --check`
- live home-cluster deployment completed with Helm 4 server-side apply