### PR TITLE
Preserve serving capacity during deploys

### DIFF
--- a/src/cli/deploy.ts
+++ b/src/cli/deploy.ts
@@ -2646,21 +2646,20 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
     // reconciles the manual scale below straight back down within one control loop, and the
     // gate at 7b then waits for a count that can NEVER be reached: the deploy burned the
     // whole health budget and aborted BEFORE cutover, i.e. the capacity gate blocked every
-    // such deploy. So raise the ceiling for the warm-up, remember the chart-rendered value,
-    // and put it back on EVERY exit path (success AND abort) — an aborted deploy must not
-    // leave a widened autoscaler behind on the build it abandoned.
-    //
-    // Only `maxReplicas` is touched. `minReplicas` cannot undo the scale-up inside this
-    // window: HPA scale-DOWN is gated by `behavior.scaleDown.stabilizationWindowSeconds`
-    // (300s by default) while the gate below is bounded at 120s, so widening the floor too
-    // would be a second mutation to restore for no reachability gain — and after cutover
-    // real load, under the chart's own bounds, is exactly what should decide the count.
-    const widenedHpas: { name: string; max: number }[] = [];
-    let widenedHpasRestored = false;
-    const restoreWidenedHpas = async (): Promise<void> => {
-      if (widenedHpasRestored) return;
-      widenedHpasRestored = true; // idempotent: every exit path calls this
-      for (const { name, max } of widenedHpas) {
+    // such deploy. Raising only maxReplicas is not enough: an idle new build has no load,
+    // so the HPA's desired count remains its configured minReplicas and it can reconcile a
+    // manual `kubectl scale` straight back to that floor. Do not assume a scale-down
+    // stabilization window protects the warm-up — that behavior is configurable and is not
+    // part of the generated HPA. Temporarily lift BOTH bounds around the capacity gate,
+    // remember their exact chart-rendered values, and put both back on EVERY exit path
+    // (success AND abort). After cutover, real load under the chart's own bounds decides the
+    // count again.
+    const warmedHpas: { name: string; min: number; max: number }[] = [];
+    let warmedHpasRestored = false;
+    const restoreWarmedHpas = async (): Promise<void> => {
+      if (warmedHpasRestored) return;
+      warmedHpasRestored = true; // idempotent: every exit path calls this
+      for (const { name, min, max } of warmedHpas) {
         const restore = await execCapture("kubectl", [
           "patch",
           "hpa",
@@ -2672,27 +2671,34 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
           // chart-rendered HPA, so the next `helm upgrade` must not conflict here.
           "--field-manager=helm",
           "-p",
-          JSON.stringify({ spec: { maxReplicas: max } }),
+          JSON.stringify({ spec: { minReplicas: min, maxReplicas: max } }),
         ]);
         if (restore.exitCode === 0) {
-          console.log(`  → Restored ${name} to the chart's maxReplicas=${max}`);
+          console.log(`  → Restored ${name} to the chart's minReplicas=${min}, maxReplicas=${max}`);
         } else {
           console.warn(
-            `  ! Could not restore ${name} to the chart's maxReplicas=${max} ` +
-              `(${restore.stderr.trim() || `exit ${restore.exitCode}`}) — it is STILL widened ` +
-              `for the pre-cutover warm-up, so this pool may autoscale above its configured ` +
-              `ceiling until the next \`helm upgrade\` re-renders it. Fix it with: kubectl -n ` +
+            `  ! Could not restore ${name} to the chart's minReplicas=${min}, ` +
+              `maxReplicas=${max} (${restore.stderr.trim() || `exit ${restore.exitCode}`}) — ` +
+              `it still has the temporary pre-cutover bounds, so this pool may retain warm-up ` +
+              `capacity until the next \`helm upgrade\` re-renders it. Fix it with: kubectl -n ` +
               `${namespace} patch hpa ${name} --type=merge -p ` +
-              `'{"spec":{"maxReplicas":${max}}}'`,
+              `'{"spec":{"minReplicas":${min},"maxReplicas":${max}}}'`,
           );
         }
       }
     };
 
-    // N67: the per-pool count the gate at 7b requires. Starts at the outgoing build's live
-    // count and is only ever LOWERED — to a ceiling we could not raise, because asking for
-    // more than the autoscaler permits is unreachable by construction.
-    //
+    // A partial warm-up setup cannot safely continue. If the HPA cannot be read, its
+    // original bounds cannot be restored; if the temporary patch is rejected, it may
+    // immediately lower the idle Deployment again. Restore every pool already prepared and
+    // put ext_proc back on the serving build before failing, without waiting out the health
+    // budget for a capacity target that is not stable.
+    const abortWarmupSetup = async (message: string): Promise<never> => {
+      const edge = await restoreEdgeToPreviousBuild();
+      await restoreWarmedHpas();
+      throw new Error([message, ...edgeStatusLines(edge)].join("\n"));
+    };
+
     // S18: seeded from EVERY configured pool at a floor of one, not only from pools with a
     // live predecessor. previousReplicasByPool has no entry for a pool that is new in this
     // build, nor for any pool on a first deploy, so those pools used to contribute no
@@ -2708,11 +2714,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
 
     const shortfalls: string[] = [];
     for (const [poolName, outgoing] of previousReplicasByPool) {
-      const { deployment: newDeployName, hpa: newHpaName } = poolResourceNames(
-        releaseName,
-        poolName,
-        buildId,
-      );
+      const { hpa: newHpaName } = poolResourceNames(releaseName, poolName, buildId);
 
       // N67: machine-readable HPA probe — `--ignore-not-found` makes a genuinely absent
       // HPA (autoscaling disabled for the pool) exit 0 with empty stdout, so a non-zero
@@ -2728,26 +2730,43 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
         "jsonpath={.metadata.name}|{.spec.minReplicas}|{.spec.maxReplicas}",
       ]);
       if (hpaRead.exitCode !== 0) {
-        console.warn(
-          `  ! Could not read the new build's HPA ${newHpaName} (kubectl exited ` +
-            `${hpaRead.exitCode}${hpaRead.stderr.trim() ? `: ${hpaRead.stderr.trim()}` : ""}) — ` +
-            `if its maxReplicas is below ${outgoing} it will undo the scale-up below and the ` +
-            `capacity gate cannot be satisfied.`,
+        await abortWarmupSetup(
+          `Could not read the new build's HPA ${newHpaName} (kubectl exited ` +
+            `${hpaRead.exitCode}${hpaRead.stderr.trim() ? `: ${hpaRead.stderr.trim()}` : ""}). ` +
+            `Refusing to warm pool "${poolName}" because its original bounds cannot be ` +
+            `preserved or its capacity kept stable. Nothing was cut over.`,
         );
-      } else {
-        const [hpaFound, hpaMinField, hpaMaxField] = hpaRead.stdout.trim().split("|");
-        const hpaMin = parseInt(hpaMinField ?? "", 10);
-        const hpaMax = parseInt(hpaMaxField ?? "", 10);
-        if (hpaFound && Number.isFinite(hpaMax) && hpaMax < outgoing) {
-          // maxReplicas must stay >= minReplicas (the API server rejects otherwise); an
-          // unset minReplicas defaults to 1, which is also what the chart renders.
-          const widened = Math.max(outgoing, Number.isFinite(hpaMin) ? hpaMin : 1);
-          console.log(
-            `  → Widening ${newHpaName} maxReplicas ${hpaMax} → ${widened} so the warm-up to ` +
-              `the outgoing build's ${outgoing} replicas is not autoscaled back down ` +
-              `(restored to ${hpaMax} after cutover)`,
+      }
+
+      const [hpaFound, hpaMinField, hpaMaxField] = hpaRead.stdout.trim().split("|");
+      if (hpaFound) {
+        const hpaMin = Number(hpaMinField);
+        const hpaMax = Number(hpaMaxField);
+        if (
+          !Number.isInteger(hpaMin) ||
+          hpaMin < 1 ||
+          !Number.isInteger(hpaMax) ||
+          hpaMax < hpaMin
+        ) {
+          await abortWarmupSetup(
+            `Could not parse the new build's HPA ${newHpaName} bounds ` +
+              `(minReplicas=${JSON.stringify(hpaMinField ?? "")}, ` +
+              `maxReplicas=${JSON.stringify(hpaMaxField ?? "")}). Refusing to warm pool ` +
+              `"${poolName}" because its original bounds cannot be restored safely. ` +
+              `Nothing was cut over.`,
           );
-          const widen = await execCapture("kubectl", [
+        }
+
+        if (hpaMin < outgoing) {
+          const warmMin = outgoing;
+          const warmMax = Math.max(hpaMax, warmMin);
+          console.log(
+            `  → Warming ${newHpaName} at minReplicas=${warmMin}, ` +
+              `maxReplicas=${warmMax} so the idle new pool keeps the outgoing build's ` +
+              `${outgoing} replicas (restored to minReplicas=${hpaMin}, ` +
+              `maxReplicas=${hpaMax} after cutover)`,
+          );
+          const warm = await execCapture("kubectl", [
             "patch",
             "hpa",
             newHpaName,
@@ -2756,29 +2775,27 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
             "--type=merge",
             "--field-manager=helm",
             "-p",
-            JSON.stringify({ spec: { maxReplicas: widened } }),
+            JSON.stringify({ spec: { minReplicas: warmMin, maxReplicas: warmMax } }),
           ]);
-          if (widen.exitCode === 0) {
-            widenedHpas.push({ name: newHpaName, max: hpaMax });
-          } else {
-            // The ceiling stands, so asking the gate for more than it allows would hang the
-            // deploy until the health budget expired and then abort — a deploy-blocking
-            // failure for a pool that simply cannot exceed its configured maximum. Lower
-            // the target to what the autoscaler permits and say so.
-            capacityTargets.set(poolName, hpaMax);
-            console.warn(
-              `  ! Could not widen ${newHpaName} to maxReplicas=${widened} ` +
-                `(${widen.stderr.trim() || `exit ${widen.exitCode}`}). That HPA caps pool ` +
-                `"${poolName}" at ${hpaMax} replicas, below the outgoing build's ${outgoing} — ` +
-                `cutting over at ${hpaMax} (the configured ceiling, the most this pool can ` +
-                `ever run under this chart) instead of waiting for a count the autoscaler ` +
-                `forbids. Raise pools.${poolName}.replicas.max in adapter config if the ` +
-                `outgoing capacity is what this pool actually needs.`,
+          if (warm.exitCode !== 0) {
+            await abortWarmupSetup(
+              `Could not set temporary warm-up bounds on ${newHpaName} ` +
+                `(minReplicas=${warmMin}, maxReplicas=${warmMax}; ` +
+                `${warm.stderr.trim() || `kubectl exited ${warm.exitCode}`}). Refusing to ` +
+                `scale or cut over pool "${poolName}" because its HPA could immediately ` +
+                `remove the required capacity. Nothing was cut over.`,
             );
           }
+          warmedHpas.push({ name: newHpaName, min: hpaMin, max: hpaMax });
         }
       }
+    }
 
+    // Prepare every autoscaler before scaling any Deployment. A read or admission failure
+    // on a later pool then restores the earlier HPA patches without leaving part of the new
+    // build manually scaled above its chart state.
+    for (const [poolName, outgoing] of previousReplicasByPool) {
+      const { deployment: newDeployName } = poolResourceNames(releaseName, poolName, buildId);
       const expected = capacityTargets.get(poolName) ?? outgoing;
       const cur = await execCapture("kubectl", [
         "get",
@@ -2873,9 +2890,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
           if (component) readyByPool.set(component, (readyByPool.get(component) ?? 0) + 1);
         }
       }
-      // Per-pool capacity check against the build being replaced (N67: against the
-      // possibly-lowered target, so an autoscaler ceiling we could not raise aborts the
-      // deploy here only when the pods really are short of that ceiling).
+      // Per-pool capacity check against the build being replaced.
       const missing: string[] = [];
       for (const [poolName, expected] of capacityTargets) {
         const ready = readyByPool.get(poolName) ?? 0;
@@ -2897,9 +2912,9 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
       // `helm upgrade` (stable manifest ConfigMap + in-place routing Deployment), so
       // "no cutover performed" was only ever true of the POOLS.
       const edge = await restoreEdgeToPreviousBuild();
-      // N67: and the warm-up widening goes back before we leave — this build is being
-      // abandoned, so it must not keep the right to autoscale past its chart ceiling.
-      await restoreWidenedHpas();
+      // N67: and both temporary warm-up bounds go back before we leave — this build is
+      // being abandoned, so it must not keep the raised replica floor.
+      await restoreWarmedHpas();
       console.error(`\n  DEPLOY FAILED: New build did not become healthy within 2 minutes.`);
       console.error(
         `  The previous build's pools are still serving traffic. No pool cutover was performed.`,
@@ -3079,8 +3094,8 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
       }
       // N25: the pools stay on the previous build, so the edge must too.
       const edge = await restoreEdgeToPreviousBuild();
-      // N67: restore the chart's autoscaling ceiling on the build we are abandoning.
-      await restoreWidenedHpas();
+      // N67: restore the chart's autoscaling bounds on the build we are abandoning.
+      await restoreWarmedHpas();
       console.error(`\n  DEPLOY FAILED: traffic was NOT switched to the new build.`);
       console.error(
         `  ${patchFailures.length} of ${pools.length} pool Service selector patch(es) failed:`,
@@ -3167,10 +3182,10 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
         namespace,
       );
     } catch (err) {
-      // N67: the warm-up widening is scoped to the warm-up on this path too — traffic HAS
+      // N67: the temporary warm-up bounds are scoped to the warm-up on this path too — traffic HAS
       // switched, so the chart's own bounds are the right ones to autoscale under, and a
-      // deploy that exits here must not leave a widened autoscaler for the operator to find.
-      await restoreWidenedHpas();
+      // deploy that exits here must not leave a raised replica floor for the operator to find.
+      await restoreWarmedHpas();
       console.error(`\n  Cutover succeeded, but persisting deploy state failed:`);
       // L14: the error wraps cluster-sourced write/read failures.
       console.error(`  ${sanitizeForTerminal(err instanceof Error ? err.message : String(err))}`);
@@ -3189,7 +3204,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
     // never be able to lose a confirmed cutover) and BEFORE the best-effort steps below, so
     // the HPA is chart-intended on every path out of this function. Scaling DOWN from here
     // is the autoscaler's decision under real load, bounded by the operator's config.
-    await restoreWidenedHpas();
+    await restoreWarmedHpas();
 
     // 7e. State is durable. Now invalidate the PREVIOUS build's Cloud CDN entries
     // (best-effort, non-fatal; TTL self-heals) so its stale content stops serving.

--- a/src/cli/deploy.ts
+++ b/src/cli/deploy.ts
@@ -17,7 +17,7 @@ import { readState, writeState, StateUnavailableError, type AdapterState } from 
 import { invalidateCdnBuildTag } from "./cdn-invalidate.js";
 import { cdnTagForBuildId } from "../cdn-tags.js";
 import { retainLiveRoutingManifest, revertRoutingServiceToBuild } from "./rollback.js";
-import { renderDeployment, POOL_READINESS_PATH } from "../emit/templates/deployment.js";
+import { POOL_READINESS_PATH } from "../emit/templates/deployment.js";
 
 /**
  * The liveness path, used ONLY as the one-cycle fallback for the stable HealthCheckPolicy when
@@ -52,8 +52,6 @@ import { sanitizeK8sName } from "../emit/templates/utils.js";
 import {
   assertSafeBuildId,
   assertSafePoolName as assertSafePoolNameCharset,
-  assertSafeQuantity,
-  assertSafeImageReference,
   findBuildIdNameCollision,
   findEmittedNameCollision,
   assertSafeImageRegistry,
@@ -125,20 +123,6 @@ export interface DeployOptions {
    */
   yes?: boolean;
 }
-
-// N66: a plain URL path, the only shape safe to splice into the rendered pod spec's
-// `path:` scalar. Used to vet the readiness path read back from a LIVE Deployment before
-// it is mirrored into the retained manifest (renderDeployment interpolates it bare).
-const LIVE_PROBE_PATH_RE = /^\/[A-Za-z0-9._~/-]{0,128}$/;
-
-/**
- * N87. Charset gate for the live pod template's INTERNAL_HEADER_SECRET secretKeyRef name,
- * mirrored into the retained previous-build render. Same reason as LIVE_PROBE_PATH_RE: the
- * value comes from the cluster and reaches a bare YAML scalar. DNS-1123 subdomain minus dots
- * (every name this adapter emits goes through sanitizeK8sName), matching the validator the
- * template itself applies.
- */
-const LIVE_SECRET_NAME_RE = /^[a-z0-9]([a-z0-9-]{0,251}[a-z0-9])?$/;
 
 // N29: same shape as destroy's confirmation prompt (that file's copy is not exported).
 function promptConfirmation(question: string): Promise<string> {
@@ -1856,8 +1840,8 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
   // The build-time collision guard (adapter.ts) can't see deploy-time state: if any of
   // this build's COMPOSED resource names sanitizes to the SAME K8s name as the
   // currently-serving build's, the two builds' resources become indistinguishable —
-  // pods carry identical version labels (split-brain cutover), retained previous-build
-  // manifests overwrite the serving ones, and cleanup deletes the wrong build.
+  // pods carry identical version labels (split-brain cutover), the keep transfer can target
+  // the wrong Deployment, and cleanup can delete the serving build.
   // Comparing the bare sanitized build ids is NOT enough: names collide on the COMPOSED
   // truncated form — a long `<release>-<pool>-` prefix can push the differing part of
   // the build id past the 63-char boundary even when the ids differ well inside their
@@ -1990,49 +1974,28 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
   // have no live capacity to match.
   const previousReplicasByPool = new Map<string, number>();
 
-  // Inject the previous build's Deployment+Service into the chart so Helm doesn't delete them.
-  // Its HPA remains LIVE but is deliberately omitted from the new release manifest: before the
-  // upgrade we annotate the object `keep`, so Helm stops owning it without deleting or mutating
-  // it. That preserves autoscaling for the build carrying traffic throughout warm-up (and every
-  // pre-cutover abort), while making deploy solely responsible for deleting the HPA before it
-  // parks the rollback Deployment at zero after a durable cutover. This also adopts the same
-  // lifecycle for an HPA created imperatively by rollback.
+  // Preserve the previous build's LIVE Deployment without rendering it into the new chart.
+  // Re-rendering can never be lossless: a build may carry arbitrary user env/envFrom and a pod
+  // template emitted by an older adapter. Every field we failed to copy made Helm see a template
+  // change and roll the build still serving 100% of traffic. Instead, annotate the top-level
+  // Deployment with Helm's keep policy before omitting it from the next release manifest. Helm
+  // then neither patches nor deletes it; in particular `.spec.template` stays byte-for-byte the
+  // live object and no ReplicaSet is created. Deploy still owns the post-cutover scale-to-zero and
+  // old-build cleanup, both of which address the object by its exact versioned name.
+  //
+  // The versioned Service remains rendered: unlike a Deployment it has no executable template,
+  // and retaining it in the release keeps Helm's ordinary lifecycle for a resource whose shape is
+  // fully canonical. The HPA follows the same keep transfer as the Deployment so it remains active
+  // throughout warm-up and every pre-cutover abort.
   if (previousBuildId && previousBuildId !== buildId) {
     for (const poolName of pools) {
       const poolPrevName = sanitizeK8sName(`${releaseName}-${poolName}-${previousBuildId}`);
 
-      // The "previous" build is the one CURRENTLY SERVING traffic. Render its Deployment at
-      // its current replica count — NOT 0 — so `helm upgrade` doesn't scale it to zero while
-      // the active Service still selects it, which would black-hole the origin on every
-      // deploy until the new pods are ready and the selector switches. It keeps serving
-      // through the rollout; it is scaled to 0 only after state is committed (step 7f).
-      // Default replica count: used for dry-run (no cluster read) and for a previous
-      // Deployment that no longer exists (NotFound branch below).
-      let prevReplicas = 2;
-      // N66: everything the retained render must reproduce from the LIVE object instead of
-      // resolving from the NEW build's `.Values`. Left EMPTY for dry-run and for the
-      // NotFound self-heal, where there is no live pod template to mirror and the `.Values`
-      // fallback is the only option (and is the documented behavior there).
-      let prevSnapshot: {
-        image?: string;
-        resources?: {
-          cpu?: string;
-          memory?: string;
-          cpuLimit?: string;
-          memoryLimit?: string;
-          ephemeralStorage?: string;
-        };
-        readinessPath?: string;
-        internalSecretRef?: string;
-      } = {};
       if (!dryRun) {
-        // N28: ONE machine-readable probe. `--ignore-not-found` makes a genuinely absent
-        // Deployment exit 0 with empty stdout, and the name field distinguishes "absent"
-        // from "present with an unreadable replica count". The previous version keyed off
-        // `isAlreadyGoneError(stderr)`, which matches a bare "404"/"no such" ANYWHERE in
-        // stderr — so any proxy/auth/wrong-project error whose text contains 404 took the
-        // lenient branch and scaled a build serving N≫2 down to 2 mid-deploy, the exact
-        // regression the abort below was added to prevent.
+        // Read the complete object rather than selecting pod-template fields. The JSON is never
+        // rendered back into YAML: it only supplies the live capacity target. That is the key
+        // invariant — unfamiliar fields, every env/valueFrom entry, sidecars, scheduling policy,
+        // security context, and volumes survive because this process never serializes the spec.
         const r = await execCapture("kubectl", [
           "get",
           "deployment",
@@ -2041,62 +2004,25 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
           namespace,
           "--ignore-not-found",
           "-o",
-          // N66: one probe, one round trip — every field the retained manifest must
-          // reproduce byte-for-byte. `ephemeral-storage` needs the bracket form (a hyphen
-          // is not a legal dotted jsonpath segment).
-          "jsonpath={.metadata.name}|{.spec.replicas}" +
-            "|{.spec.template.spec.containers[0].image}" +
-            "|{.spec.template.spec.containers[0].resources.requests.cpu}" +
-            "|{.spec.template.spec.containers[0].resources.requests.memory}" +
-            "|{.spec.template.spec.containers[0].resources.requests['ephemeral-storage']}" +
-            "|{.spec.template.spec.containers[0].resources.limits.cpu}" +
-            "|{.spec.template.spec.containers[0].resources.limits.memory}" +
-            "|{.spec.template.spec.containers[0].readinessProbe.httpGet.path}|" +
-            // N87: WHICH internal dispatch Secret the live pod template resolves. Per-build
-            // now, but a build deployed by an older adapter references the legacy stable name
-            // — re-rendering it with the derived name would repoint the SERVING build's pods
-            // at a Secret nobody rendered. The `range` form tolerates a container with no such
-            // env (an even older build) instead of failing the whole jsonpath.
-            '{range .spec.template.spec.containers[0].env[?(@.name=="INTERNAL_HEADER_SECRET")]}' +
-            "{.valueFrom.secretKeyRef.name}{end}",
+          "json",
         ]);
         if (r.exitCode !== 0) {
-          // Abort rather than guess: the probe previously defaulted to 2 on ANY failure,
-          // so a serving build at 5 replicas would be silently scaled DOWN to 2 by the
-          // retained manifest mid-deploy.
           throw new Error(
-            `Could not read the live replica count for the currently-serving deployment ` +
+            `Could not read the currently-serving deployment ` +
               `${poolPrevName} (kubectl exited ${r.exitCode}: ${r.stderr.trim()}). ` +
-              `The retained manifest must mirror the live count; refusing to guess. Fix ` +
-              `kubectl access and re-run the deploy.`,
+              `It must be transferred out of Helm's release manifest without changing its ` +
+              `pod template; refusing to guess. Fix kubectl access and re-run the deploy.`,
           );
         }
-        const [
-          foundName,
-          replicasField,
-          imageField,
-          cpuReqField,
-          memReqField,
-          ephReqField,
-          cpuLimField,
-          memLimField,
-          readinessPathField,
-          internalSecretRefField,
-        ] = r.stdout.trim().split("|");
-        if (!foundName) {
+        if (!r.stdout.trim()) {
           // N31: no Deployment for this pool in the previous build. Two very different
           // causes — tell them apart by whether the pool's STABLE active Service exists
           // (helm creates it with the pool; it outlives individual builds):
           //   * Service exists  → the pool existed before and its previous Deployment was
-          //     deleted (manually / partial cluster recovery). Keep the historical
-          //     self-heal: warn and render the retained manifest at the default, rather
-          //     than bricking every future deploy of the release.
+          //     deleted (manually / partial cluster recovery). Do NOT recreate it from the
+          //     incoming build's template: that is different code/config under an old identity.
           //   * Service absent  → the pool is NEW in this build, so there is nothing to
-          //     retain. Rendering anything here fabricated a previous-build Deployment
-          //     with `imageTag: previousBuildId` — a tag that was never built — giving the
-          //     whole deploy an ImagePullBackOff (step 7a only waits on the new build's
-          //     label) and turning the next rollback's clean "Previous deployment missing"
-          //     abort into a 120 s timeout.
+          //     retain.
           const activeServiceName = sanitizeK8sName(`${releaseName}-${poolName}`);
           const svc = await execCapture("kubectl", [
             "get",
@@ -2113,9 +2039,8 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
               `Could not determine whether pool "${poolName}" existed in the previous build ` +
                 `${previousBuildId}: neither its Deployment (${poolPrevName}) nor its active ` +
                 `Service (${activeServiceName}) could be read (kubectl exited ` +
-                `${svc.exitCode}: ${svc.stderr.trim()}). Refusing to guess — retaining a ` +
-                `manifest for a pool that never existed renders an image tag that was never ` +
-                `built. Fix kubectl access and re-run the deploy.`,
+                `${svc.exitCode}: ${svc.stderr.trim()}). Refusing to guess. Fix kubectl access ` +
+                `and re-run the deploy.`,
             );
           }
           if (!svc.stdout.trim()) {
@@ -2127,120 +2052,72 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
           }
           console.warn(
             `  ! Previous deployment ${poolPrevName} (build ${previousBuildId}) not found — ` +
-              `it appears to have been deleted. Nothing is serving from it; rendering its ` +
-              `retained manifest at the default ${prevReplicas} replicas.`,
+              `it appears to have been deleted. Nothing is serving from it; it will not be ` +
+              `recreated from the incoming build's pod template.`,
           );
         } else {
-          const n = parseInt(replicasField ?? "", 10);
-          if (!Number.isFinite(n) || n <= 0) {
+          let live: { metadata?: { name?: unknown }; spec?: { replicas?: unknown } };
+          try {
+            live = JSON.parse(r.stdout) as typeof live;
+          } catch (err) {
+            throw new Error(
+              `Could not parse the live deployment ${poolPrevName}: ` +
+                `${err instanceof Error ? err.message : String(err)}. Refusing to run ` +
+                `\`helm upgrade\` without proving which Deployment will be retained.`,
+            );
+          }
+          if (live.metadata?.name !== poolPrevName) {
+            throw new Error(
+              `The live Deployment probe for ${poolPrevName} returned ` +
+                `${JSON.stringify(live.metadata?.name)}. Refusing to retain a different object.`,
+            );
+          }
+          const n = live.spec?.replicas;
+          if (typeof n !== "number" || !Number.isInteger(n) || n <= 0) {
             throw new Error(
               `Could not read the live replica count for the currently-serving deployment ` +
-                `${poolPrevName} (replicas=${JSON.stringify(replicasField ?? "")}). ` +
-                `The retained manifest must mirror the live count; refusing to guess. Fix ` +
+                `${poolPrevName} (replicas=${JSON.stringify(n)}). Refusing to guess. Fix ` +
                 `kubectl access and re-run the deploy.`,
             );
           }
-          prevReplicas = n;
           previousReplicasByPool.set(poolName, n);
-          // N66: snapshot the live container spec. A field the live object does not carry
-          // (an older build predating ephemeral-storage, say) is simply omitted, which
-          // leaves that ONE field on the `.Values` fallback rather than inventing a value —
-          // omitting it is what the running object has, so the render still matches.
-          // Every literal is cluster-sourced and lands in the rendered pod spec, so it is
-          // validated HERE, at the point of consumption (AGENTS.md), not only inside the
-          // template: a value that fails validation aborts the deploy rather than being
-          // dropped (silently reverting that field to the new build's values would
-          // reintroduce exactly the skew this snapshot exists to prevent).
-          if (imageField) {
-            assertSafeImageReference(imageField);
-          }
-          const liveQuantity = (value: string, field: string): string => {
-            assertSafeQuantity(value, `live ${poolPrevName} ${field}`);
-            return value;
-          };
-          prevSnapshot = {
-            ...(imageField ? { image: imageField } : {}),
-            resources: {
-              ...(cpuReqField ? { cpu: liveQuantity(cpuReqField, "requests.cpu") } : {}),
-              ...(memReqField ? { memory: liveQuantity(memReqField, "requests.memory") } : {}),
-              ...(ephReqField
-                ? { ephemeralStorage: liveQuantity(ephReqField, "requests.ephemeral-storage") }
-                : {}),
-              ...(cpuLimField ? { cpuLimit: liveQuantity(cpuLimField, "limits.cpu") } : {}),
-              ...(memLimField ? { memoryLimit: liveQuantity(memLimField, "limits.memory") } : {}),
-            },
-            // N66: the readiness PATH is part of "what is running" too. The retained build
-            // may predate the pool server's `/readyz` endpoint, and stamping the current
-            // default onto it would change the SERVING build's pod template into a probe
-            // its pods cannot satisfy (a stalled RollingUpdate on the build carrying 100%
-            // of traffic). `renderDeployment` interpolates this as a BARE YAML scalar with
-            // no validation of its own, so a cluster-sourced value must be charset-checked
-            // here; anything unexpected falls back to the template default.
-            ...(readinessPathField && LIVE_PROBE_PATH_RE.test(readinessPathField)
-              ? { readinessPath: readinessPathField }
-              : {}),
-            // N87: mirror the live secretKeyRef. Cluster-sourced and spliced into a bare YAML
-            // scalar, so it is charset-checked here; anything unexpected falls back to the
-            // derived per-build name rather than aborting the deploy (same posture as the
-            // readiness path above).
-            ...(internalSecretRefField && LIVE_SECRET_NAME_RE.test(internalSecretRefField)
-              ? { internalSecretRef: internalSecretRefField }
-              : {}),
-          };
-          if (internalSecretRefField && !LIVE_SECRET_NAME_RE.test(internalSecretRefField)) {
-            console.warn(
-              `  ! Live INTERNAL_HEADER_SECRET secretKeyRef ${JSON.stringify(
-                internalSecretRefField,
-              )} on ${poolPrevName} is not a plain Secret name — the retained manifest will use ` +
-                `the per-build default instead of mirroring it.`,
+
+          const keptDeployment = await execCapture("kubectl", [
+            "annotate",
+            "deployment",
+            poolPrevName,
+            "-n",
+            namespace,
+            "helm.sh/resource-policy=keep",
+            "--overwrite",
+          ]);
+          if (keptDeployment.exitCode !== 0) {
+            throw new Error(
+              `Could not transfer the outgoing Deployment ${poolPrevName} out of Helm ` +
+                `ownership (${keptDeployment.stderr.trim() || `kubectl exited ${keptDeployment.exitCode}`}). ` +
+                `Refusing to run \`helm upgrade\`: re-rendering it would change the serving ` +
+                `pod template and omitting it without keep would delete it. Fix kubectl access ` +
+                `and re-run.`,
             );
           }
-          if (readinessPathField && !LIVE_PROBE_PATH_RE.test(readinessPathField)) {
-            console.warn(
-              `  ! Live readiness path ${JSON.stringify(readinessPathField)} on ` +
-                `${poolPrevName} is not a plain URL path — the retained manifest will use ` +
-                `the template default instead of mirroring it.`,
-            );
-          }
+          console.log(`  → Preserved outgoing Deployment (${poolPrevName}) without re-rendering`);
         }
+      } else {
+        console.log(
+          `    [dry-run] kubectl annotate deployment ${poolPrevName} -n ${namespace} ` +
+            `helm.sh/resource-policy=keep --overwrite (if it exists)`,
+        );
       }
 
-      // Render retained resources through the same canonical templates as a normal build.
-      // Hand-copying this Deployment previously omitted resources, changing the serving pod
-      // template and rolling the old build during every upgrade. Do not render its HPA into the
-      // new release: the live object remains active under the explicit keep transfer below, so
-      // Helm cannot rewrite its scaling policy from the incoming build's values.
-      // L13: dry-run must not write into the chart — report the planned writes instead.
-      const retainedFiles: [string, string][] = [
-        [
-          `${poolName}-prev-deployment.yaml`,
-          renderDeployment({
-            poolName,
-            buildId: previousBuildId,
-            releaseName,
-            imageTag: previousBuildId,
-            replicas: prevReplicas,
-            // N66: literals win over the `.Values` expressions, so changing `resources` in
-            // next.config — or flipping `containerStrategy`, which repoints the repository
-            // at `nextjs-app-<pool>` vs `nextjs-app` — cannot mutate (and therefore roll)
-            // the pod template of the build still serving 100% of traffic. Flipping
-            // containerStrategy previously pointed the retained manifest at a tag that was
-            // never pushed: ImagePullBackOff on the SERVING build, before cutover.
-            ...prevSnapshot,
-          }),
-        ],
-        [
-          `${poolName}-prev-service.yaml`,
+      // L13: dry-run must not write into the chart — report the planned Service write instead.
+      const retainedService = path.join(chartTemplatesDir, `${poolName}-prev-service.yaml`);
+      if (dryRun) {
+        console.log(`    [dry-run] would write ${retainedService}`);
+      } else {
+        writeFileSync(
+          retainedService,
           renderService({ poolName, buildId: previousBuildId, releaseName }),
-        ],
-      ];
-      for (const [fileName, content] of retainedFiles) {
-        const target = path.join(chartTemplatesDir, fileName);
-        if (dryRun) {
-          console.log(`    [dry-run] would write ${target}`);
-        } else {
-          writeFileSync(target, content);
-        }
+        );
       }
 
       // Keep the outgoing HPA active and byte-for-byte unchanged while its Deployment still

--- a/src/emit/helm.ts
+++ b/src/emit/helm.ts
@@ -117,9 +117,7 @@ export function generateHelmChart({
    * Nothing supplies these at BUILD time and nothing can: `next build` runs before
    * `docker build`/`docker push`, so no digest exists yet. This is the seam for the
    * deploy-side resolve-after-push step (see the handoff note in adapter.ts) — the chart
-   * must be re-rendered, or the digests injected, only once the images are pushed. A
-   * retained previous-build render must reuse the digest RECORDED FOR THAT BUILD; never
-   * re-resolve it from the tag, which is the very thing that may have moved.
+   * must be re-rendered, or the digests injected, only once the images are pushed.
    */
   imageDigests?: Record<string, string>;
 }): Record<string, string> {

--- a/src/emit/metadata.ts
+++ b/src/emit/metadata.ts
@@ -2,7 +2,7 @@
 //
 // build-metadata.json — the hand-off from build to `adapter-k8s deploy` (which reads
 // cacheEnabled/cacheManaged to provision or tear down the managed Memorystore, and pools
-// to render the previous build's templates).
+// to coordinate versioned resources across a cutover).
 //
 // N50 (review, Medium): every field used to be optional with a `??` default HERE:
 //   - `failureModeAllow ?? true` defaulted to fail-OPEN — the middleware-BYPASS direction —

--- a/src/emit/templates/deployment.ts
+++ b/src/emit/templates/deployment.ts
@@ -101,24 +101,12 @@ export function renderDeployment({
    * so a cached layer can never silently outlive a retag.
    */
   imageDigest?: string;
-  /**
-   * N66. A COMPLETE literal image reference, overriding registry/repository/tag. Used for
-   * a RETAINED previous-build render: see `resources` below.
-   */
+  /** A COMPLETE literal image reference, overriding registry/repository/tag. */
   image?: string;
   /**
-   * N66. Literal resource quantities, overriding the `.Values`-derived defaults per field.
-   *
-   * The retained previous Deployment is re-rendered by cli/deploy.ts through this same
-   * function, and everything resolved from `.Values` resolves against the NEW build's
-   * values. So changing `resources` in `next.config` between deploys mutated the pod
-   * template of the build still serving 100% of traffic → default RollingUpdate rolled it
-   * (previously with no preStop at all, see N63); flipping `containerStrategy` repointed
-   * the retained manifest at `nextjs-app-<pool>:<previousBuildId>`, a tag never pushed, so
-   * the serving build rolled into ImagePullBackOff BEFORE cutover. Passing literals
-   * snapshotted from what is actually running makes a retained render a byte-for-byte
-   * reproduction. (An earlier fix addressed the OMISSION of `resources` here; it did not
-   * address the SKEW.)
+   * Literal resource quantities, overriding the `.Values`-derived defaults per field.
+   * Outgoing live Deployments are deliberately never reconstructed with these overrides:
+   * deploy transfers the complete object to Helm's keep lifecycle instead.
    */
   resources?: DeploymentResourceLiterals;
   replicas?: number | undefined;
@@ -129,16 +117,7 @@ export function renderDeployment({
    * `/healthz` — a readiness endpoint that can legitimately 503 must never restart a pod.
    */
   readinessPath?: string;
-  /**
-   * N87. The internal dispatch Secret this pod template resolves INTERNAL_HEADER_SECRET from,
-   * as a LITERAL. Same rationale as `resources`/`readinessPath` above: for a RETAINED
-   * previous-build render, deploy mirrors what the live pod template actually references. A
-   * build deployed before per-build Secret names references the legacy stable name, and
-   * stamping the derived per-build name onto it would point the SERVING build's pods at a
-   * Secret nobody rendered (CreateContainerConfigError on every new pod, before cutover).
-   * Omitted ⇒ the name derived from this render's own build id, which is what a normal build
-   * wants.
-   */
+  /** Literal Secret name override. Omitted means the name derived from this build id. */
   internalSecretRef?: string;
   /** User-supplied runtime environment, already merged (top-level config + this pool). */
   env?: Record<string, EnvValue>;
@@ -174,8 +153,7 @@ export function renderDeployment({
   );
   // Always emit the Valkey env — the secret refs are `optional: true`, so this is inert when no
   // cache is configured (the pool only registers the handler when VALKEY_URL is actually set).
-  // Emitting it unconditionally keeps the pod template identical whether or not the cache is on,
-  // so toggling `cache.enabled` between deploys never rolls the retained previous deployment.
+  // Emitting it unconditionally keeps the generated pod template independent of cache.enabled.
   const valkeyEnv = "\n" + renderValkeyEnv(releaseName, "            ");
   // Built-in, so it renders BEFORE user env (user config can never shadow it). Quoted via
   // JSON + Helm-action escaping like every other user-shaped scalar in this template.
@@ -195,8 +173,7 @@ export function renderDeployment({
   const { userEnv, userEnvFrom } = renderUserEnvBlocks(env, envFrom);
 
   // N60. Literal quantities are validated here too: a `.Values`-sourced quantity is
-  // already checked in values-yaml.ts, but a literal from deploy's per-build snapshot
-  // reaches the pod spec through this template and nowhere else.
+  // already checked in values-yaml.ts, but a direct literal reaches the pod spec here.
   const valuesRef = (field: string) =>
     `{{ (index .Values.pools "${poolName}").resources.${field} }}`;
   const quantity = (literal: string | undefined, field: string, valuesPath: string): string => {
@@ -210,9 +187,8 @@ export function renderDeployment({
   const memoryLimit = quantity(resources?.memoryLimit, "resources.memoryLimit", "limits.memory");
   const ephemeralStorage = resources?.ephemeralStorage ?? EPHEMERAL_STORAGE_REQUEST;
   assertSafeQuantity(ephemeralStorage, `pool "${poolName}" resources.ephemeralStorage`);
-  // N85: same sink class as the quantities above. This value is no longer always a constant —
-  // deploy snapshots the LIVE pod template's probe path for a retained build (N66), so a
-  // cluster-sourced string reaches this bare YAML scalar. Validate at the consumption point.
+  // N85: same sink class as the quantities above. Validate this bare YAML scalar at the
+  // consumption point even when a direct caller supplies it.
   assertSafeProbePath(readinessPath, `pool "${poolName}" readinessPath`);
 
   // S7 (SECURITY). The digest can arrive two ways, and BOTH must be honored:
@@ -275,9 +251,8 @@ metadata:
     app.kubernetes.io/component: "${poolName}"
     app.kubernetes.io/version: "${safeBuildId}"
 spec:
-${replicaLine}  # N63. The other half of the 502/503 fix: a pool Deployment DOES get rolled — by an
-  # image/pod-template change, and (because deploy.ts re-renders the retained previous
-  # build through this same template) by any change to this file. With the default
+${replicaLine}  # N63. The other half of the 502/503 fix: a pool Deployment DOES get rolled by an
+  # image/pod-template change. With the default
   # RollingUpdate 25%/25% the pool can dip BELOW its live replica count while the active
   # Service still selects it. maxUnavailable: 0 + maxSurge: 1 never dips, and
   # minReadySeconds gives the GFE time to health-check each new pod into the NEG before the

--- a/src/emit/templates/internal-secret.ts
+++ b/src/emit/templates/internal-secret.ts
@@ -151,12 +151,8 @@ stringData:
 //
 // N87: the referenced NAME is build-scoped, so this pod template can only ever resolve the
 // secret of ITS OWN build — including on a restart inside another build's deploy window.
-// `secretName` overrides the derived name with a LITERAL one. Used only for a retained
-// previous-build render (cli/deploy.ts, the N66 live-pod-template snapshot): a build deployed
-// before per-build names references the legacy stable Secret, and re-rendering it with the
-// derived name would change the pod template of the build still serving 100% of traffic —
-// pointing it at a Secret that does not exist, so `helm upgrade` would roll it into
-// CreateContainerConfigError BEFORE cutover. Same failure shape as N66's containerStrategy flip.
+// `secretName` overrides the derived name with a validated LITERAL one. Deploy never uses this
+// to reconstruct an outgoing build: that live Deployment is kept without touching its template.
 export function renderInternalSecretEnv(
   releaseName: string,
   buildId: string,

--- a/src/emit/templates/utils.ts
+++ b/src/emit/templates/utils.ts
@@ -273,8 +273,7 @@ export function assertSafeImageRegistry(registry: string): void {
   }
 }
 
-// N66. A COMPLETE OCI image reference, as read back from a running Deployment's container
-// spec and re-interpolated into a double-quoted YAML scalar for a retained render:
+// A COMPLETE OCI image reference for a direct Deployment render:
 // `<registry>/<repo>[:tag][@sha256:…]`. Deliberately excludes the `"`/`\`/whitespace that
 // could break the scalar, and any scheme.
 const IMAGE_REFERENCE_RE =
@@ -504,10 +503,8 @@ export function assertSafeQuantity(value: string, field: string): void {
 }
 
 // N85. `readinessProbe.httpGet.path: ${readinessPath}` (deployment.ts) is another BARE YAML
-// scalar sink, and its value is no longer a constant: deploy snapshots the LIVE pod template's
-// probe path so a retained previous build keeps a probe its pods can satisfy (N66), which means
-// a cluster-sourced string reaches this interpolation. Same posture as the quantities above —
-// a narrow charset, rejected rather than escaped. Absolute path, no whitespace, no YAML
+// scalar sink. Same posture as the quantities above — a narrow charset, rejected rather than
+// escaped. Absolute path, no whitespace, no YAML
 // metacharacters; query strings are allowed because the pool matches on the parsed pathname.
 const PROBE_PATH_RE = /^\/[A-Za-z0-9._~\-/]*(\?[A-Za-z0-9._~\-/=&%]*)?$/;
 

--- a/tests/cli/deploy-orchestration.test.ts
+++ b/tests/cli/deploy-orchestration.test.ts
@@ -413,13 +413,13 @@ function happyCluster(
         }
         return ok("");
       }
-      // N67: the new build's HPA — read (min|max), widened for the warm-up, restored after.
+      // N67: the new build's HPA — read (min|max), raised for the warm-up, restored after.
       // MUST come before the generic `patch` branch below, which assumes a Service.
       if (args.includes("patch")) {
         const body = JSON.parse(args[args.length - 1]!) as {
           spec: { maxReplicas?: number; minReplicas?: number };
         };
-        events.push(`hpa-max:${hpaName}:${body.spec.maxReplicas}`);
+        events.push(`hpa-bounds:${hpaName}:${body.spec.minReplicas}:${body.spec.maxReplicas}`);
         if (overrides.newBuildHpaPatchFails) {
           return { exitCode: 1, stdout: "", stderr: "hpa patch denied by webhook" };
         }
@@ -2324,25 +2324,26 @@ describe("runDeploy — N67: the new build's HPA must not undo the pre-cutover w
     vi.restoreAllMocks();
   });
 
-  it("widens maxReplicas above the chart ceiling, warms up, then restores the ceiling after cutover", async () => {
-    // The outgoing build runs 6; the new chart caps the pool at 3. helm already installed
-    // that HPA, so the N64 scale-up to 6 was reconciled straight back down to 3 and the
-    // capacity gate waited for a count that could never be reached — every such deploy
-    // hung for the full health budget and aborted BEFORE cutover.
+  it("raises the HPA floor before warm-up even when its ceiling already covers capacity", async () => {
+    // This is the live failure shape: maxReplicas allowed the outgoing count, but the idle
+    // new pool's desired count was still minReplicas. The autoscaler undid kubectl scale
+    // before the capacity gate could pass.
     vi.mocked(execCapture).mockImplementation(
       happyCluster(events, {
         prevLive: { replicas: 6 },
         newBuildReplicas: 1,
-        newBuildHpa: { min: 1, max: 3 },
+        newBuildHpa: { min: 1, max: 10 },
         readyPerPool: { ssr: 6 },
       }) as never,
     );
 
     await runDeploy({ projectDir: PROJECT, releaseName: RELEASE, skipBuild: true });
 
-    // Widened to the warm-up target BEFORE the scale-up, and the scale-up asked for 6.
-    expect(events).toContain(`hpa-max:${NEW_HPA}:6`);
-    expect(events.indexOf(`hpa-max:${NEW_HPA}:6`)).toBeLessThan(
+    // The floor was raised while the already-sufficient ceiling stayed exact, BEFORE scale.
+    const warmBounds = `hpa-bounds:${NEW_HPA}:6:10`;
+    const chartBounds = `hpa-bounds:${NEW_HPA}:1:10`;
+    expect(events).toContain(warmBounds);
+    expect(events.indexOf(warmBounds)).toBeLessThan(
       events.indexOf("scaleup:deployment/rel-ssr-buildn"),
     );
     const scaleUp = vi
@@ -2352,29 +2353,48 @@ describe("runDeploy — N67: the new build's HPA must not undo the pre-cutover w
     // Cutover happened (the gate was satisfiable) and state was committed.
     expect(events).toContain("patch:rel-ssr");
     expect(events).toContain("writeState");
-    // ...and the chart's ceiling is back, AFTER the cutover was committed.
-    expect(events).toContain(`hpa-max:${NEW_HPA}:3`);
-    expect(events.indexOf("writeState")).toBeLessThan(events.indexOf(`hpa-max:${NEW_HPA}:3`));
-    // The LAST thing done to that HPA is the restore — no widened HPA is left behind.
-    const hpaEvents = events.filter((e) => e.startsWith("hpa-max:"));
-    expect(hpaEvents).toEqual([`hpa-max:${NEW_HPA}:6`, `hpa-max:${NEW_HPA}:3`]);
+    // ...and BOTH exact chart bounds are back after the cutover was committed.
+    expect(events).toContain(chartBounds);
+    expect(events.indexOf("writeState")).toBeLessThan(events.indexOf(chartBounds));
+    const hpaEvents = events.filter((e) => e.startsWith("hpa-bounds:"));
+    expect(hpaEvents).toEqual([warmBounds, chartBounds]);
     // The restore patch impersonates helm, which owns the chart-rendered HPA.
     const restore = vi
       .mocked(execCapture)
       .mock.calls.filter(([, a]) => a.includes("patch") && a.includes("hpa"))
       .at(-1)!;
     expect(restore[1]).toContain("--field-manager=helm");
-    expect(JSON.parse(restore[1].at(-1)!)).toEqual({ spec: { maxReplicas: 3 } });
+    expect(JSON.parse(restore[1].at(-1)!)).toEqual({
+      spec: { minReplicas: 1, maxReplicas: 10 },
+    });
   });
 
-  it("restores the chart ceiling when the deploy ABORTS mid-warm-up", async () => {
-    // A deploy that aborts before cutover must not leave a widened autoscaler behind:
-    // the abandoned build would keep the right to autoscale past its configured ceiling.
+  it("raises maxReplicas with the floor when the chart ceiling is below capacity", async () => {
     vi.mocked(execCapture).mockImplementation(
       happyCluster(events, {
         prevLive: { replicas: 6 },
         newBuildReplicas: 1,
-        newBuildHpa: { min: 1, max: 3 },
+        newBuildHpa: { min: 2, max: 3 },
+        readyPerPool: { ssr: 6 },
+      }) as never,
+    );
+
+    await runDeploy({ projectDir: PROJECT, releaseName: RELEASE, skipBuild: true });
+
+    expect(events.filter((e) => e.startsWith("hpa-bounds:"))).toEqual([
+      `hpa-bounds:${NEW_HPA}:6:6`,
+      `hpa-bounds:${NEW_HPA}:2:3`,
+    ]);
+  });
+
+  it("restores both exact chart bounds when the deploy aborts mid-warm-up", async () => {
+    // A deploy that aborts before cutover must not leave a raised floor on its abandoned
+    // build. Non-default original bounds prove the restore does not guess chart defaults.
+    vi.mocked(execCapture).mockImplementation(
+      happyCluster(events, {
+        prevLive: { replicas: 6 },
+        newBuildReplicas: 1,
+        newBuildHpa: { min: 2, max: 9 },
         readyPerPool: { ssr: 3 }, // never reaches 6 → the gate expires
       }) as never,
     );
@@ -2387,12 +2407,12 @@ describe("runDeploy — N67: the new build's HPA must not undo the pre-cutover w
 
     expect(events.some((e) => e.startsWith("patch:rel-ssr"))).toBe(false);
     expect(vi.mocked(writeState)).not.toHaveBeenCalled();
-    const hpaEvents = events.filter((e) => e.startsWith("hpa-max:"));
-    expect(hpaEvents).toEqual([`hpa-max:${NEW_HPA}:6`, `hpa-max:${NEW_HPA}:3`]);
+    const hpaEvents = events.filter((e) => e.startsWith("hpa-bounds:"));
+    expect(hpaEvents).toEqual([`hpa-bounds:${NEW_HPA}:6:9`, `hpa-bounds:${NEW_HPA}:2:9`]);
     expect(printedErrors()).toContain("ssr: 3/6 ready");
   });
 
-  it("restores the chart ceiling when the selector cutover fails", async () => {
+  it("restores both chart bounds when the selector cutover fails", async () => {
     vi.mocked(execCapture).mockImplementation(
       happyCluster(events, {
         prevLive: { replicas: 6 },
@@ -2408,13 +2428,13 @@ describe("runDeploy — N67: the new build's HPA must not undo the pre-cutover w
     ).rejects.toThrow(/process\.exit:1/);
 
     expect(vi.mocked(writeState)).not.toHaveBeenCalled();
-    expect(events.filter((e) => e.startsWith("hpa-max:"))).toEqual([
-      `hpa-max:${NEW_HPA}:6`,
-      `hpa-max:${NEW_HPA}:3`,
+    expect(events.filter((e) => e.startsWith("hpa-bounds:"))).toEqual([
+      `hpa-bounds:${NEW_HPA}:6:6`,
+      `hpa-bounds:${NEW_HPA}:1:3`,
     ]);
   });
 
-  it("restores the chart ceiling when the post-cutover state commit fails", async () => {
+  it("restores both chart bounds when the post-cutover state commit fails", async () => {
     // The third exit path: traffic HAS switched but state could not be persisted. The
     // process still leaves here, so the HPA must be chart-intended before it does.
     vi.mocked(execCapture).mockImplementation(
@@ -2431,16 +2451,16 @@ describe("runDeploy — N67: the new build's HPA must not undo the pre-cutover w
       runDeploy({ projectDir: PROJECT, releaseName: RELEASE, skipBuild: true }),
     ).rejects.toThrow(/process\.exit:1/);
 
-    expect(events.filter((e) => e.startsWith("hpa-max:"))).toEqual([
-      `hpa-max:${NEW_HPA}:6`,
-      `hpa-max:${NEW_HPA}:3`,
+    expect(events.filter((e) => e.startsWith("hpa-bounds:"))).toEqual([
+      `hpa-bounds:${NEW_HPA}:6:6`,
+      `hpa-bounds:${NEW_HPA}:1:3`,
     ]);
     expect(printedErrors()).toContain("persisting deploy state failed");
   });
 
-  it("warns with a repair command when the ceiling cannot be restored", async () => {
-    // Never silent: an HPA left widened outlives the deploy, so name it and the fix.
-    let widenSeen = false;
+  it("warns with an exact repair command when the chart bounds cannot be restored", async () => {
+    // Never silent: a raised HPA floor outlives the deploy, so name it and both exact bounds.
+    let warmSeen = false;
     const cluster = happyCluster(events, {
       prevLive: { replicas: 6 },
       newBuildReplicas: 1,
@@ -2449,8 +2469,8 @@ describe("runDeploy — N67: the new build's HPA must not undo the pre-cutover w
     });
     vi.mocked(execCapture).mockImplementation((async (cmd: string, args: string[]) => {
       if (args.includes("patch") && args.includes("hpa")) {
-        if (widenSeen) return { exitCode: 1, stdout: "", stderr: "etcdserver: leader changed" };
-        widenSeen = true;
+        if (warmSeen) return { exitCode: 1, stdout: "", stderr: "etcdserver: leader changed" };
+        warmSeen = true;
       }
       return cluster(cmd, args);
     }) as never);
@@ -2458,16 +2478,19 @@ describe("runDeploy — N67: the new build's HPA must not undo the pre-cutover w
     await runDeploy({ projectDir: PROJECT, releaseName: RELEASE, skipBuild: true });
 
     const warned = printedWarnings();
-    expect(warned).toContain(`Could not restore ${NEW_HPA} to the chart's maxReplicas=3`);
+    expect(warned).toContain(
+      `Could not restore ${NEW_HPA} to the chart's minReplicas=1, maxReplicas=3`,
+    );
     expect(warned).toContain(`patch hpa ${NEW_HPA}`);
+    expect(warned).toContain('"minReplicas":1,"maxReplicas":3');
   });
 
-  it("leaves the HPA alone when its ceiling already covers the outgoing capacity", async () => {
+  it("leaves the HPA alone when its floor already covers the outgoing capacity", async () => {
     vi.mocked(execCapture).mockImplementation(
       happyCluster(events, {
         prevLive: { replicas: 3 },
         newBuildReplicas: 1,
-        newBuildHpa: { min: 1, max: 10 },
+        newBuildHpa: { min: 3, max: 10 },
         readyPerPool: { ssr: 3 },
       }) as never,
     );
@@ -2475,35 +2498,32 @@ describe("runDeploy — N67: the new build's HPA must not undo the pre-cutover w
     await runDeploy({ projectDir: PROJECT, releaseName: RELEASE, skipBuild: true });
 
     expect(events).toContain("scaleup:deployment/rel-ssr-buildn");
-    expect(events.some((e) => e.startsWith("hpa-max:"))).toBe(false);
+    expect(events.some((e) => e.startsWith("hpa-bounds:"))).toBe(false);
   });
 
-  it("cuts over at the ceiling it could not raise instead of waiting for an unreachable count", async () => {
-    // An un-widenable HPA (RBAC, webhook) must not turn into a hung deploy: the ceiling
-    // IS the most capacity this pool can have under this chart, so the gate asks for it.
+  it("aborts before scale or cutover when the temporary HPA bounds are rejected", async () => {
     vi.mocked(execCapture).mockImplementation(
       happyCluster(events, {
         prevLive: { replicas: 6 },
         newBuildReplicas: 1,
         newBuildHpa: { min: 1, max: 3 },
         newBuildHpaPatchFails: true,
-        readyPerPool: { ssr: 3 },
+        readyPerPool: { ssr: 6 },
       }) as never,
     );
 
-    await runDeploy({ projectDir: PROJECT, releaseName: RELEASE, skipBuild: true });
+    await expect(
+      runDeploy({ projectDir: PROJECT, releaseName: RELEASE, skipBuild: true }),
+    ).rejects.toThrow(/Could not set temporary warm-up bounds.*Nothing was cut over/s);
 
-    expect(events).toContain("patch:rel-ssr");
-    const scaleUp = vi
-      .mocked(execCapture)
-      .mock.calls.find(([, a]) => a.includes("scale") && a.includes("deployment/rel-ssr-buildn"))!;
-    expect(scaleUp[1]).toContain("--replicas=3");
-    expect(printedWarnings()).toContain("caps pool");
-    // Nothing to restore — the widen never took effect.
-    expect(events.filter((e) => e.startsWith("hpa-max:"))).toEqual([`hpa-max:${NEW_HPA}:6`]);
+    expect(events).toContain(`hpa-bounds:${NEW_HPA}:6:6`);
+    expect(events).toContain("revert-edge");
+    expect(events.some((e) => e.startsWith("scaleup:"))).toBe(false);
+    expect(events.some((e) => e.startsWith("patch:rel-ssr"))).toBe(false);
+    expect(vi.mocked(writeState)).not.toHaveBeenCalled();
   });
 
-  it("warns but still scales up when the HPA cannot be read", async () => {
+  it("aborts before scale or cutover when the HPA cannot be read", async () => {
     vi.mocked(execCapture).mockImplementation(
       happyCluster(events, {
         prevLive: { replicas: 6 },
@@ -2513,13 +2533,124 @@ describe("runDeploy — N67: the new build's HPA must not undo the pre-cutover w
       }) as never,
     );
 
-    await runDeploy({ projectDir: PROJECT, releaseName: RELEASE, skipBuild: true });
+    await expect(
+      runDeploy({ projectDir: PROJECT, releaseName: RELEASE, skipBuild: true }),
+    ).rejects.toThrow(/Could not read the new build's HPA.*Nothing was cut over/s);
 
-    expect(events).toContain("scaleup:deployment/rel-ssr-buildn");
-    expect(printedWarnings()).toContain(`Could not read the new build's HPA ${NEW_HPA}`);
+    expect(events).toContain("revert-edge");
+    expect(events.some((e) => e.startsWith("scaleup:"))).toBe(false);
+    expect(events.some((e) => e.startsWith("patch:rel-ssr"))).toBe(false);
+    expect(vi.mocked(writeState)).not.toHaveBeenCalled();
   });
 
-  it("needs no widening when the pool has no HPA at all", async () => {
+  it("restores earlier pools and scales none when a later HPA read fails", async () => {
+    setupFs({
+      metadata: { buildId: "buildn", pools: ["ssr", "heavy"], cacheEnabled: false },
+    });
+    const heavyHpa = poolResourceNames(RELEASE, "heavy", "buildn").hpa;
+    const cluster = happyCluster(events, {
+      prevLive: { replicas: 6 },
+      newBuildReplicas: 1,
+      newBuildHpa: { min: 1, max: 3 },
+    });
+    vi.mocked(execCapture).mockImplementation((async (cmd: string, args: string[]) => {
+      if (args[0] === "get" && args[1] === "hpa" && args[2] === heavyHpa) {
+        return { exitCode: 1, stdout: "", stderr: "horizontalpodautoscalers is forbidden" };
+      }
+      return cluster(cmd, args);
+    }) as never);
+
+    await expect(
+      runDeploy({ projectDir: PROJECT, releaseName: RELEASE, skipBuild: true }),
+    ).rejects.toThrow(new RegExp(`Could not read the new build's HPA ${heavyHpa}`));
+
+    expect(events.filter((e) => e.startsWith("hpa-bounds:"))).toEqual([
+      `hpa-bounds:${NEW_HPA}:6:6`,
+      `hpa-bounds:${NEW_HPA}:1:3`,
+    ]);
+    expect(events.some((e) => e.startsWith("scaleup:"))).toBe(false);
+    expect(events).toContain("revert-edge");
+    expect(vi.mocked(writeState)).not.toHaveBeenCalled();
+  });
+
+  it("restores earlier pools and scales none when a later HPA patch fails", async () => {
+    setupFs({
+      metadata: { buildId: "buildn", pools: ["ssr", "heavy"], cacheEnabled: false },
+    });
+    const heavyHpa = poolResourceNames(RELEASE, "heavy", "buildn").hpa;
+    const cluster = happyCluster(events, {
+      prevLive: { replicas: 6 },
+      newBuildReplicas: 1,
+      newBuildHpa: { min: 1, max: 3 },
+    });
+    vi.mocked(execCapture).mockImplementation((async (cmd: string, args: string[]) => {
+      if (args[0] === "patch" && args[1] === "hpa" && args[2] === heavyHpa) {
+        return { exitCode: 1, stdout: "", stderr: "hpa patch denied by webhook" };
+      }
+      return cluster(cmd, args);
+    }) as never);
+
+    await expect(
+      runDeploy({ projectDir: PROJECT, releaseName: RELEASE, skipBuild: true }),
+    ).rejects.toThrow(new RegExp(`Could not set temporary warm-up bounds on ${heavyHpa}`));
+
+    expect(events.filter((e) => e.startsWith("hpa-bounds:"))).toEqual([
+      `hpa-bounds:${NEW_HPA}:6:6`,
+      `hpa-bounds:${NEW_HPA}:1:3`,
+    ]);
+    expect(events.some((e) => e.startsWith("scaleup:"))).toBe(false);
+    expect(events).toContain("revert-edge");
+    expect(vi.mocked(writeState)).not.toHaveBeenCalled();
+  });
+
+  it("aborts safely when an existing HPA returns malformed bounds", async () => {
+    const cluster = happyCluster(events, { prevLive: { replicas: 6 } });
+    vi.mocked(execCapture).mockImplementation((async (cmd: string, args: string[]) => {
+      if (args[0] === "get" && args[1] === "hpa" && args[2] === NEW_HPA) {
+        return { exitCode: 0, stdout: `${NEW_HPA}|unknown|3`, stderr: "" };
+      }
+      return cluster(cmd, args);
+    }) as never);
+
+    await expect(
+      runDeploy({ projectDir: PROJECT, releaseName: RELEASE, skipBuild: true }),
+    ).rejects.toThrow(/Could not parse.*minReplicas="unknown".*Nothing was cut over/s);
+
+    expect(events.some((e) => e.startsWith("hpa-bounds:"))).toBe(false);
+    expect(events.some((e) => e.startsWith("scaleup:"))).toBe(false);
+    expect(events).toContain("revert-edge");
+  });
+
+  it("uses the configured namespace for every warm-up HPA read and patch", async () => {
+    setupFs({
+      infra: { ...BASE_INFRA, namespace: "prod" },
+      metadata: {
+        buildId: "buildn",
+        pools: ["ssr"],
+        cacheEnabled: false,
+        namespace: "prod",
+      },
+    });
+    vi.mocked(execCapture).mockImplementation(
+      happyCluster(events, {
+        prevLive: { replicas: 6 },
+        newBuildHpa: { min: 1, max: 3 },
+        readyPerPool: { ssr: 6 },
+      }) as never,
+    );
+
+    await runDeploy({ projectDir: PROJECT, releaseName: RELEASE, skipBuild: true });
+
+    const warmupCalls = vi
+      .mocked(execCapture)
+      .mock.calls.filter(([, args]) => args.includes("hpa") && args.includes(NEW_HPA));
+    expect(warmupCalls).toHaveLength(3); // read, temporary bounds, exact restore
+    for (const [, args] of warmupCalls) {
+      expect(args).toEqual(expect.arrayContaining(["-n", "prod"]));
+    }
+  });
+
+  it("needs no temporary bounds when the pool has no HPA at all", async () => {
     vi.mocked(execCapture).mockImplementation(
       happyCluster(events, {
         prevLive: { replicas: 6 },
@@ -2532,7 +2663,7 @@ describe("runDeploy — N67: the new build's HPA must not undo the pre-cutover w
     await runDeploy({ projectDir: PROJECT, releaseName: RELEASE, skipBuild: true });
 
     expect(events).toContain("scaleup:deployment/rel-ssr-buildn");
-    expect(events.some((e) => e.startsWith("hpa-max:"))).toBe(false);
+    expect(events.some((e) => e.startsWith("hpa-bounds:"))).toBe(false);
   });
 });
 

--- a/tests/cli/deploy-orchestration.test.ts
+++ b/tests/cli/deploy-orchestration.test.ts
@@ -115,23 +115,56 @@ function setupFs({
   });
 }
 
-/**
- * What the previous build's LIVE Deployment reports — deliberately DIFFERENT from the new
- * build's `.Values` (a smaller pool, the shared-image repository, and the pre-/readyz
- * readiness path), so a retained render that resolved from `.Values` is detectable (N66).
- */
+/** What the previous build's LIVE Deployment reports to the capacity gate. */
 const DEFAULT_PREV_LIVE = {
   replicas: 2,
   image: `${REGISTRY}/nextjs-app-ssr:buildm`,
-  cpu: "750m",
-  memory: "1536Mi",
-  ephemeralStorage: "3Gi",
-  cpuLimit: "1500m",
-  memoryLimit: "3Gi",
-  readinessPath: "/healthz",
-  // N87: a previous build deployed BEFORE per-build Secret names — it references the legacy
-  // stable name, which the retained render must mirror rather than repoint.
   internalSecretRef: legacyInternalSecretName(RELEASE),
+};
+
+// Deliberately richer than the current emitter. Retention must preserve unknown/custom pod
+// fields as well as every env form because it must not serialize this template at all.
+const DEFAULT_PREV_POD_TEMPLATE = {
+  metadata: {
+    labels: { "app.kubernetes.io/version": "buildm", "example.com/variant": "legacy" },
+    annotations: { "example.com/injected": "kept" },
+  },
+  spec: {
+    serviceAccountName: "legacy-runtime",
+    nodeSelector: { "kubernetes.io/arch": "arm64" },
+    tolerations: [{ key: "dedicated", operator: "Equal", value: "nextjs", effect: "NoSchedule" }],
+    containers: [
+      {
+        name: "pool-server",
+        image: DEFAULT_PREV_LIVE.image,
+        env: [
+          { name: "APP_VARIANT", value: "catalog" },
+          { name: "POOL_ROLE", value: "legacy-pages" },
+          {
+            name: "INTERNAL_HEADER_SECRET",
+            valueFrom: {
+              secretKeyRef: { name: DEFAULT_PREV_LIVE.internalSecretRef, key: "secret" },
+            },
+          },
+          {
+            name: "DATABASE_URL",
+            valueFrom: { secretKeyRef: { name: "runtime-database", key: "url", optional: false } },
+          },
+          {
+            name: "POD_NAME",
+            valueFrom: { fieldRef: { apiVersion: "v1", fieldPath: "metadata.name" } },
+          },
+        ],
+        envFrom: [
+          { configMapRef: { name: "runtime-config", optional: true } },
+          { secretRef: { name: "runtime-secrets", optional: false } },
+        ],
+        volumeMounts: [{ name: "runtime", mountPath: "/runtime", readOnly: true }],
+      },
+      { name: "telemetry-sidecar", image: "example.invalid/telemetry@sha256:abc" },
+    ],
+    volumes: [{ name: "runtime", secret: { secretName: "runtime-files" } }],
+  },
 };
 
 /**
@@ -151,7 +184,7 @@ function happyCluster(
     activeServices?: string; // jsonpath rows: name|component|versionSelector
     activeServicesFail?: boolean;
     servingImages?: string; // jsonpath rows: name|image
-    // N66: the previous build's LIVE pod template, as the retained render must mirror it.
+    // The previous build's live replica count; its pod template is never re-rendered.
     prevLive?: Partial<typeof DEFAULT_PREV_LIVE>;
     // N64: the new build's rendered replica count, and how many of its pods are Ready.
     newBuildReplicas?: number;
@@ -172,6 +205,7 @@ function happyCluster(
     outgoingHpaProbeFails?: boolean;
     outgoingHpaAnnotateFails?: boolean;
     outgoingHpaDeleteFails?: boolean;
+    outgoingDeploymentAnnotateFails?: boolean;
     // N87: internal dispatch Secret lifecycle. The legacy stable-named Secret (migrated past
     // helm upgrade), and the per-build ones the post-cutover sweep prunes.
     legacySecretPresent?: boolean;
@@ -275,10 +309,14 @@ function happyCluster(
     if (args.includes("deployments") && j.includes("containers[0].image")) {
       return ok(overrides.servingImages ?? `rel-ssr-buildm|${REGISTRY}/nextjs-app-ssr:buildm\n`);
     }
-    // N66: retained-manifest probe — ONE call returning name|replicas plus the live pod
-    // template fields the retained render must reproduce (image, four quantities, readiness
-    // path). The N64 capacity probe below asks the same resource with the SHORT jsonpath.
-    if (j.includes("containers[0].image") && j.includes("{.spec.replicas}")) {
+    // Complete outgoing Deployment read. Deploy extracts only replicas; the pod template is
+    // deliberately unknown to it and must never be re-rendered into the incoming chart.
+    if (
+      args[0] === "get" &&
+      args[1] === "deployment" &&
+      args.includes("--ignore-not-found") &&
+      args[args.indexOf("-o") + 1] === "json"
+    ) {
       if (overrides.replicasProbeGone) return ok("");
       if (overrides.replicasProbeFails) {
         return { exitCode: 1, stdout: "", stderr: "connection refused" };
@@ -286,19 +324,22 @@ function happyCluster(
       const name = args[args.indexOf("deployment") + 1]!;
       const live = { ...DEFAULT_PREV_LIVE, ...overrides.prevLive };
       return ok(
-        [
-          name,
-          String(live.replicas),
-          live.image,
-          live.cpu,
-          live.memory,
-          live.ephemeralStorage,
-          live.cpuLimit,
-          live.memoryLimit,
-          live.readinessPath,
-          live.internalSecretRef,
-        ].join("|"),
+        JSON.stringify({
+          apiVersion: "apps/v1",
+          kind: "Deployment",
+          metadata: { name, namespace: "default", annotations: { "example.com/live": "yes" } },
+          spec: { replicas: live.replicas, template: DEFAULT_PREV_POD_TEMPLATE },
+        }),
       );
+    }
+    if (args[0] === "annotate" && args[1] === "deployment") {
+      events.push(
+        `annotate-deployment:${args[2]}:${args.find((a) => a.includes("resource-policy"))}`,
+      );
+      if (overrides.outgoingDeploymentAnnotateFails) {
+        return { exitCode: 1, stdout: "", stderr: "deployment annotation denied" };
+      }
+      return ok();
     }
     // N64: pre-cutover capacity probe on the NEW build's Deployment (short jsonpath).
     if (j.includes("jsonpath={.metadata.name}|{.spec.replicas}")) {
@@ -565,14 +606,15 @@ describe("runDeploy — orchestration", () => {
       .mocked(writeFileSync)
       .mock.calls.filter(([p]) => String(p).includes("-prev-"));
     const retainedNames = retainedWrites.map(([p]) => path.basename(String(p)));
-    expect(retainedNames).toContain("ssr-prev-deployment.yaml");
+    expect(retainedNames).not.toContain("ssr-prev-deployment.yaml");
     expect(retainedNames).toContain("ssr-prev-service.yaml");
     expect(retainedNames).not.toContain("ssr-prev-hpa.yaml");
 
-    const retainedDeployment = retainedWrites.find(([p]) =>
-      String(p).endsWith("ssr-prev-deployment.yaml"),
+    const keepDeployment = events.indexOf(
+      "annotate-deployment:rel-ssr-buildm:helm.sh/resource-policy=keep",
     );
-    expect(String(retainedDeployment?.[1])).toContain("replicas: 5");
+    expect(keepDeployment).toBeGreaterThanOrEqual(0);
+    expect(keepDeployment).toBeLessThan(events.indexOf("helm"));
 
     const keepHpa = events.indexOf("annotate-hpa:rel-ssr-buildm-hpa:helm.sh/resource-policy=keep");
     expect(keepHpa).toBeGreaterThanOrEqual(0);
@@ -825,11 +867,11 @@ describe("runDeploy — guards and teardown", () => {
 
     await expect(
       runDeploy({ projectDir: PROJECT, releaseName: RELEASE, skipBuild: true }),
-    ).rejects.toThrow(/replica count/);
+    ).rejects.toThrow(/currently-serving deployment/);
     expect(events).not.toContain("helm");
   });
 
-  it("self-heals when the previous Deployment is NotFound: warns, renders default replicas, deploy proceeds", async () => {
+  it("self-heals when the previous Deployment is NotFound without fabricating it", async () => {
     // Regression: the retention probe aborted on ANY kubectl failure, including
     // NotFound (state names a build whose Deployment was deleted manually), which
     // bricked every future deploy of the release. N31: the pool's stable active Service
@@ -867,12 +909,13 @@ describe("runDeploy — guards and teardown", () => {
           (c) => String(c[0]).includes("rel-ssr-buildm") && String(c[0]).includes("not found"),
         ),
     ).toBe(true);
-    // ...and the retained manifest fell back to the default replica count.
-    const prevDeploymentWrite = vi
-      .mocked(writeFileSync)
-      .mock.calls.find(([p]) => String(p).endsWith("ssr-prev-deployment.yaml"));
-    expect(prevDeploymentWrite).toBeDefined();
-    expect(String(prevDeploymentWrite![1])).toContain("replicas: 2");
+    // ...and no incoming template was applied under the old build's identity.
+    expect(
+      vi
+        .mocked(writeFileSync)
+        .mock.calls.some(([p]) => String(p).endsWith("ssr-prev-deployment.yaml")),
+    ).toBe(false);
+    expect(events.some((event) => event.startsWith("annotate-deployment:"))).toBe(false);
   });
 
   it("aborts when COMPOSED truncated names collide even though the bare build ids differ", async () => {
@@ -1332,11 +1375,10 @@ describe("runDeploy — N20: unreadable deploy state must never read as a first 
     // helm was told about the live build, not "no previous build".
     expect(helmArgLine()).toContain("previousBuildId=buildm");
     expect(helmArgLine()).toContain("activeBuildId=buildm");
-    // ...and the serving build's Deployment was retained so helm cannot prune it.
-    const retained = vi
-      .mocked(writeFileSync)
-      .mock.calls.find(([p]) => String(p).endsWith("ssr-prev-deployment.yaml"));
-    expect(retained).toBeDefined();
+    // ...and the serving build's live Deployment was kept before Helm could prune it.
+    const keep = events.indexOf("annotate-deployment:rel-ssr-buildm:helm.sh/resource-policy=keep");
+    expect(keep).toBeGreaterThanOrEqual(0);
+    expect(keep).toBeLessThan(events.indexOf("helm"));
     expect(printedWarnings()).toContain('Recovered the currently-serving build "buildm"');
   });
 
@@ -1557,7 +1599,12 @@ describe("runDeploy — N28/N31: retained-manifest classification without free-t
     // serving N≫2 down to 2 mid-deploy.
     const cluster = happyCluster(events);
     vi.mocked(execCapture).mockImplementation((async (cmd: string, args: string[]) => {
-      if (args.join(" ").includes("jsonpath={.metadata.name}|{.spec.replicas}")) {
+      if (
+        args[0] === "get" &&
+        args[1] === "deployment" &&
+        args.includes("--ignore-not-found") &&
+        args[args.indexOf("-o") + 1] === "json"
+      ) {
         return {
           exitCode: 1,
           stdout: "",
@@ -1569,7 +1616,7 @@ describe("runDeploy — N28/N31: retained-manifest classification without free-t
 
     await expect(
       runDeploy({ projectDir: PROJECT, releaseName: RELEASE, skipBuild: true }),
-    ).rejects.toThrow(/Could not read the live replica count/);
+    ).rejects.toThrow(/Could not read the currently-serving deployment/);
     expect(events).not.toContain("helm");
     // Nothing was rendered at the dangerous default.
     expect(vi.mocked(writeFileSync).mock.calls.some(([p]) => String(p).includes("-prev-"))).toBe(
@@ -1589,10 +1636,14 @@ describe("runDeploy — N28/N31: retained-manifest classification without free-t
       readyPerPool: { ssr: 3, api: 1 },
     });
     vi.mocked(execCapture).mockImplementation((async (cmd: string, args: string[]) => {
-      const j = args.join(" ");
-      // The retained probe (long jsonpath) for the pool that is ABSENT in the previous
-      // build: exit 0 + empty stdout, the --ignore-not-found absence signal.
-      if (j.includes("containers[0].image") && j.includes("{.spec.replicas}")) {
+      // The complete Deployment read for the pool that is ABSENT in the previous build:
+      // exit 0 + empty stdout, the --ignore-not-found absence signal.
+      if (
+        args[0] === "get" &&
+        args[1] === "deployment" &&
+        args.includes("--ignore-not-found") &&
+        args[args.indexOf("-o") + 1] === "json"
+      ) {
         const name = args[args.indexOf("deployment") + 1];
         if (name !== "rel-ssr-buildm") return { exitCode: 0, stdout: "", stderr: "" };
       }
@@ -1611,14 +1662,11 @@ describe("runDeploy — N28/N31: retained-manifest classification without free-t
       .mocked(writeFileSync)
       .mock.calls.map(([p]) => String(p))
       .filter((p) => p.includes("-prev-"));
-    expect(retainedFiles.some((p) => p.endsWith("ssr-prev-deployment.yaml"))).toBe(true);
+    expect(retainedFiles.some((p) => p.endsWith("ssr-prev-deployment.yaml"))).toBe(false);
+    expect(retainedFiles.some((p) => p.endsWith("ssr-prev-service.yaml"))).toBe(true);
     expect(retainedFiles.some((p) => p.includes("api-prev-"))).toBe(false);
     expect(printedLogs()).toContain('Pool "api" is new in this build');
-    // The pool that DID exist was still retained at its live count.
-    const ssrDeployment = vi
-      .mocked(writeFileSync)
-      .mock.calls.find(([p]) => String(p).endsWith("ssr-prev-deployment.yaml"))!;
-    expect(String(ssrDeployment[1])).toContain("replicas: 3");
+    expect(events).toContain("annotate-deployment:rel-ssr-buildm:helm.sh/resource-policy=keep");
   });
 
   it("aborts when the pool-existed-before probe itself fails", async () => {
@@ -1819,11 +1867,12 @@ describe("runDeploy — N32: stale *-prev-*.yaml never survives into another dep
     expect(unlinked).toContain(path.join(chartTemplatesDir, "ssr-prev-deployment.yaml"));
     expect(unlinked).toContain(path.join(chartTemplatesDir, "reaped-prev-service.yaml"));
     expect(unlinked).not.toContain(path.join(chartTemplatesDir, "deployment.yaml"));
-    // The wipe happens BEFORE the fresh retained render (which writes the same name).
-    const rewritten = vi
-      .mocked(writeFileSync)
-      .mock.calls.findIndex(([p]) => String(p).endsWith("ssr-prev-deployment.yaml"));
-    expect(rewritten).toBeGreaterThanOrEqual(0);
+    // A live Deployment is retained by annotation, never re-created from this stale file.
+    expect(
+      vi
+        .mocked(writeFileSync)
+        .mock.calls.some(([p]) => String(p).endsWith("ssr-prev-deployment.yaml")),
+    ).toBe(false);
   });
 
   it("runs unconditionally, even on a first deploy with no previous build", async () => {
@@ -2010,14 +2059,8 @@ describe("runDeploy — N33: domain checks run before the completion banner", ()
   });
 });
 
-describe("runDeploy — N66: the retained previous Deployment mirrors what is RUNNING", () => {
+describe("runDeploy — N66: the outgoing Deployment pod template is never re-rendered", () => {
   let events: string[];
-  const retainedYaml = (): string =>
-    String(
-      vi
-        .mocked(writeFileSync)
-        .mock.calls.find(([p]) => String(p).endsWith("ssr-prev-deployment.yaml"))![1],
-    );
 
   beforeEach(() => {
     events = [];
@@ -2025,165 +2068,97 @@ describe("runDeploy — N66: the retained previous Deployment mirrors what is RU
   });
   afterEach(() => vi.restoreAllMocks());
 
-  // N87. The previous build may predate per-build Secret names, in which case its pods resolve
-  // the legacy stable-named Secret. Stamping the derived per-build name onto the retained render
-  // would repoint the pod template of the build serving 100% of traffic at a Secret nobody
-  // rendered — CreateContainerConfigError on every new pod, before cutover. Same failure shape
-  // as the containerStrategy flip this suite exists for.
-  it("mirrors the live INTERNAL_HEADER_SECRET secretKeyRef instead of deriving it", async () => {
+  it("keeps every env/valueFrom and pod-spec field by omitting the Deployment from the chart", async () => {
+    const before = structuredClone(DEFAULT_PREV_POD_TEMPLATE);
     vi.mocked(execCapture).mockImplementation(happyCluster(events) as never);
 
     await runDeploy({ projectDir: PROJECT, releaseName: RELEASE, skipBuild: true });
 
-    const yaml = retainedYaml();
-    expect(yaml).toContain(`name: ${legacyInternalSecretName(RELEASE)}`);
-    expect(yaml).not.toContain(internalSecretName(RELEASE, "buildm"));
+    expect(DEFAULT_PREV_POD_TEMPLATE).toEqual(before);
+    expect(
+      vi
+        .mocked(writeFileSync)
+        .mock.calls.some(([p]) => String(p).endsWith("ssr-prev-deployment.yaml")),
+    ).toBe(false);
+    expect(events).toContain("annotate-deployment:rel-ssr-buildm:helm.sh/resource-policy=keep");
+    expect(events).not.toContain("rollout:deployment/rel-ssr-buildm");
   });
 
-  it("derives the per-build Secret name when the live template already carries one", async () => {
-    vi.mocked(execCapture).mockImplementation(
-      happyCluster(events, {
-        prevLive: { internalSecretRef: internalSecretName(RELEASE, "buildm") },
-      }) as never,
-    );
-
-    await runDeploy({ projectDir: PROJECT, releaseName: RELEASE, skipBuild: true });
-
-    expect(retainedYaml()).toContain(`name: ${internalSecretName(RELEASE, "buildm")}`);
-  });
-
-  it("falls back to the derived name (with a warning) for an unusable live ref", async () => {
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    vi.mocked(execCapture).mockImplementation(
-      happyCluster(events, {
-        prevLive: { internalSecretRef: 'x"\n              hostNetwork: true' },
-      }) as never,
-    );
-
-    await runDeploy({ projectDir: PROJECT, releaseName: RELEASE, skipBuild: true });
-
-    const yaml = retainedYaml();
-    expect(yaml).toContain(`name: ${internalSecretName(RELEASE, "buildm")}`);
-    expect(yaml).not.toContain("hostNetwork");
-    expect(warn.mock.calls.flat().join(" ")).toMatch(/not a plain Secret name/);
-  });
-
-  it("renders the live image + all four quantities as LITERALS, with no .Values left", async () => {
-    // Everything the retained render resolved from `.Values` resolved against the NEW
-    // build's values: changing `resources` in next.config mutated the pod template of the
-    // build serving 100% of traffic (→ RollingUpdate rolled it), and flipping
-    // containerStrategy repointed it at a tag that was never pushed (ImagePullBackOff on
-    // the SERVING build, before cutover).
+  it("retains only through top-level metadata before Helm, so no ReplicaSet rollout is requested", async () => {
     vi.mocked(execCapture).mockImplementation(happyCluster(events) as never);
 
     await runDeploy({ projectDir: PROJECT, releaseName: RELEASE, skipBuild: true });
 
-    const yaml = retainedYaml();
-    expect(yaml).not.toContain(".Values");
-    expect(yaml).not.toContain("{{");
-    expect(yaml).toContain(`image: "${DEFAULT_PREV_LIVE.image}"`);
-    expect(yaml).toContain(`cpu: "${DEFAULT_PREV_LIVE.cpu}"`);
-    expect(yaml).toContain(`memory: "${DEFAULT_PREV_LIVE.memory}"`);
-    expect(yaml).toContain(`ephemeral-storage: "${DEFAULT_PREV_LIVE.ephemeralStorage}"`);
-    expect(yaml).toContain(`cpu: "${DEFAULT_PREV_LIVE.cpuLimit}"`);
-    expect(yaml).toContain(`memory: "${DEFAULT_PREV_LIVE.memoryLimit}"`);
-    // ...and the live replica count, as before.
-    expect(yaml).toContain(`replicas: ${DEFAULT_PREV_LIVE.replicas}`);
+    const keep = events.indexOf("annotate-deployment:rel-ssr-buildm:helm.sh/resource-policy=keep");
+    expect(keep).toBeGreaterThanOrEqual(0);
+    expect(keep).toBeLessThan(events.indexOf("helm"));
+
+    const mutations = vi
+      .mocked(execCapture)
+      .mock.calls.filter(
+        ([, args]) =>
+          args.includes("deployment") &&
+          args.includes("rel-ssr-buildm") &&
+          ["apply", "patch", "replace", "set"].includes(args[0] ?? ""),
+      );
+    expect(mutations).toEqual([]);
   });
 
-  it("keeps the OLD repository when containerStrategy flips between builds", async () => {
-    // shared-image renders `nextjs-app`; the serving build was built per-pool
-    // (`nextjs-app-ssr`). The retained manifest must name what is running, not what this
-    // build would produce.
+  it("passes the configured namespace to both the read and keep annotation", async () => {
     setupFs({
+      infra: { ...BASE_INFRA, namespace: "tenant-apps" },
       metadata: {
         buildId: "buildn",
         pools: ["ssr"],
         cacheEnabled: false,
-        containerStrategy: "shared-image",
+        namespace: "tenant-apps",
       },
     });
     vi.mocked(execCapture).mockImplementation(happyCluster(events) as never);
 
     await runDeploy({ projectDir: PROJECT, releaseName: RELEASE, skipBuild: true });
 
-    const yaml = retainedYaml();
-    expect(yaml).toContain(`${REGISTRY}/nextjs-app-ssr:buildm`);
-    expect(yaml).not.toContain("nextjs-app:buildn");
-    expect(yaml).not.toContain(".Values");
+    const deploymentCalls = vi
+      .mocked(execCapture)
+      .mock.calls.filter(
+        ([, args]) => args.includes("rel-ssr-buildm") && args.includes("deployment"),
+      );
+    expect(deploymentCalls).toHaveLength(2);
+    for (const [, args] of deploymentCalls) {
+      expect(args.slice(args.indexOf("-n"), args.indexOf("-n") + 2)).toEqual(["-n", "tenant-apps"]);
+    }
   });
 
-  it("mirrors the live readiness path so the SERVING build's probe never changes", async () => {
-    // The retained build may predate /readyz; stamping the current default onto it would
-    // change the serving build's pod template into a probe its pods cannot satisfy.
-    vi.mocked(execCapture).mockImplementation(happyCluster(events) as never);
-
-    await runDeploy({ projectDir: PROJECT, releaseName: RELEASE, skipBuild: true });
-
-    const yaml = retainedYaml();
-    // Scope to the readinessProbe block itself: the startup/liveness probes are /healthz
-    // too, so a substring search over the whole document would pass vacuously.
-    expect(yaml).toMatch(
-      new RegExp(
-        `readinessProbe:\\s*\\n\\s*httpGet:\\s*\\n\\s*path: ${DEFAULT_PREV_LIVE.readinessPath}\\b`,
-      ),
-    );
-    // The current default must appear NOWHERE in a manifest that mirrors an older build.
-    expect(yaml).not.toContain("/readyz");
-  });
-
-  it("falls back to .Values only where there is no live object to mirror (NotFound self-heal)", async () => {
+  it("aborts before Helm when keep cannot be applied", async () => {
     vi.mocked(execCapture).mockImplementation(
-      happyCluster(events, { replicasProbeGone: true }) as never,
-    );
-
-    await runDeploy({ projectDir: PROJECT, releaseName: RELEASE, skipBuild: true });
-
-    const yaml = retainedYaml();
-    expect(yaml).toContain("replicas: 2");
-    // Nothing was invented: the template's own .Values expressions remain.
-    expect(yaml).toContain(".Values");
-  });
-
-  it("omits only the fields the live object lacks (an older build with no limits)", async () => {
-    vi.mocked(execCapture).mockImplementation(
-      happyCluster(events, {
-        prevLive: { cpuLimit: "", memoryLimit: "", ephemeralStorage: "" },
-      }) as never,
-    );
-
-    await runDeploy({ projectDir: PROJECT, releaseName: RELEASE, skipBuild: true });
-
-    const yaml = retainedYaml();
-    // Requests were mirrored...
-    expect(yaml).toContain(`cpu: "${DEFAULT_PREV_LIVE.cpu}"`);
-    // ...and exactly the absent fields stayed on the .Values fallback.
-    expect(yaml).toContain('(index .Values.pools "ssr").resources.limits.cpu');
-    expect(yaml).toContain('(index .Values.pools "ssr").resources.limits.memory');
-  });
-
-  it("aborts when a live quantity is not a valid Kubernetes quantity (never spliced raw)", async () => {
-    vi.mocked(execCapture).mockImplementation(
-      happyCluster(events, {
-        prevLive: { memory: '1Gi"\n      hostNetwork: true\n      _pad: "' },
-      }) as never,
+      happyCluster(events, { outgoingDeploymentAnnotateFails: true }) as never,
     );
 
     await expect(
       runDeploy({ projectDir: PROJECT, releaseName: RELEASE, skipBuild: true }),
-    ).rejects.toThrow(/Invalid Kubernetes quantity/);
+    ).rejects.toThrow(
+      /Could not transfer the outgoing Deployment.*Refusing to run `helm upgrade`/s,
+    );
     expect(events).not.toContain("helm");
   });
 
-  it("warns and uses the template default when the live readiness path is not a plain path", async () => {
-    vi.mocked(execCapture).mockImplementation(
-      happyCluster(events, { prevLive: { readinessPath: '/x"\n            port: 22' } }) as never,
-    );
+  it("rejects malformed live JSON rather than falling back to a generated Deployment", async () => {
+    const cluster = happyCluster(events);
+    vi.mocked(execCapture).mockImplementation((async (cmd: string, args: string[]) => {
+      if (
+        args[0] === "get" &&
+        args[1] === "deployment" &&
+        args[args.indexOf("-o") + 1] === "json"
+      ) {
+        return { exitCode: 0, stdout: "{not-json", stderr: "" };
+      }
+      return cluster(cmd, args);
+    }) as never);
 
-    await runDeploy({ projectDir: PROJECT, releaseName: RELEASE, skipBuild: true });
-
-    expect(printedWarnings()).toContain("is not a plain URL path");
-    expect(retainedYaml()).not.toContain("port: 22");
+    await expect(
+      runDeploy({ projectDir: PROJECT, releaseName: RELEASE, skipBuild: true }),
+    ).rejects.toThrow(/Could not parse the live deployment/);
+    expect(events).not.toContain("helm");
   });
 });
 

--- a/tests/emit/internal-secret-build-scope.test.ts
+++ b/tests/emit/internal-secret-build-scope.test.ts
@@ -255,10 +255,8 @@ describe("N87: a restarted build-A pod cannot trust build B's middleware verdict
     }
   });
 
-  it("mirrors a legacy Secret name when the retained render passes one, and validates it", () => {
-    // The literal override exists for exactly one caller: deploy's retained previous-build
-    // render, mirroring a live pod template that predates per-build names (see
-    // renderInternalSecretEnv). It is cluster-sourced, so the charset is enforced here.
+  it("accepts and validates a literal legacy Secret name override", () => {
+    // Direct template callers can preserve a legacy Secret ref without opening a YAML sink.
     const legacy = legacyInternalSecretName(RELEASE);
     expect(renderInternalSecretEnv(RELEASE, A.buildId, "  ", legacy)).toContain(`name: ${legacy}`);
     expect(renderInternalSecretEnv(RELEASE, A.buildId, "  ")).toContain(

--- a/tests/emit/templates/deployment.test.ts
+++ b/tests/emit/templates/deployment.test.ts
@@ -115,7 +115,7 @@ describe("renderDeployment", () => {
     expect(yaml).toMatch(/spec:\n {2}replicas:/);
   });
 
-  it("N64: an explicit replicas literal still wins (retained previous-build render)", () => {
+  it("N64: an explicit replicas literal still wins", () => {
     const yaml = renderDeployment({
       poolName: "ssr",
       buildId: "b1",
@@ -198,9 +198,9 @@ describe("renderDeployment", () => {
   });
 
   // ---------------------------------------------------------------------------
-  // N66 — retained render must not resolve from the NEW build's .Values
+  // Direct literal overrides
   // ---------------------------------------------------------------------------
-  it("N66: literal resources + image reproduce a retained build byte-for-byte, with no .Values lookups", () => {
+  it("literal resources + image render with no .Values lookups", () => {
     const yaml = renderDeployment({
       poolName: "ssr",
       buildId: "old123",
@@ -209,9 +209,7 @@ describe("renderDeployment", () => {
       image: "us-central1-docker.pkg.dev/p/r/nextjs-app-ssr:old123",
       resources: { cpu: "500m", memory: "1Gi", cpuLimit: "2", memoryLimit: "2Gi" },
     });
-    // The whole point: NOTHING in the retained pod template is resolved by helm from the
-    // new build's values, so changing `resources` or flipping `containerStrategy` between
-    // deploys cannot mutate (and therefore roll) the build serving 100% of traffic.
+    // A fully literal direct render contains no deferred Helm values.
     expect(yaml).not.toContain(".Values");
     expect(yaml).not.toContain("{{");
     expect(yaml).toContain('image: "us-central1-docker.pkg.dev/p/r/nextjs-app-ssr:old123"');
@@ -222,7 +220,7 @@ describe("renderDeployment", () => {
     expect(yaml).toContain("replicas: 4");
   });
 
-  it("N66: rejects an unsafe literal image reference", () => {
+  it("rejects an unsafe literal image reference", () => {
     expect(() =>
       renderDeployment({
         poolName: "ssr",
@@ -440,10 +438,8 @@ describe("N60: pod-spec injection through pools.*.resources (values.yaml -> helm
 describe("renderDeployment rollout safety (N63, the other half of the 502/503 fix)", () => {
   it("never dips below the live replica count during a roll", () => {
     const yaml = renderDeployment({ poolName: "ssr", buildId: "b1", releaseName: "my-app" });
-    // A pool Deployment IS rolled in practice: deploy.ts re-renders the RETAINED previous
-    // build through this template, so any pod-template change here rolls the build that is
-    // still serving 100% of traffic (the active Service still selects it until cutover).
-    // The default 25%/25% would dip below the live count while that is true.
+    // Any ordinary pool rollout must preserve available capacity; the default 25%/25% can
+    // dip below the live count for small pools.
     expect(yaml).toMatch(
       /strategy:\n\s+type: RollingUpdate\n\s+rollingUpdate:\n\s+maxUnavailable: 0\n\s+maxSurge: 1/,
     );

--- a/tests/emit/templates/service.test.ts
+++ b/tests/emit/templates/service.test.ts
@@ -110,8 +110,8 @@ describe("renderActiveService (stable)", () => {
   });
 
   it("N65: the PDB lives here (rendered once per pool), never in the per-build templates", () => {
-    // deploy.ts re-renders renderDeployment/renderService for the RETAINED previous build.
-    // A PDB in one of those would either duplicate a resource name or
+    // deploy.ts retains the previous versioned Service during cutover. A PDB there would
+    // either duplicate a resource name or
     // need per-build cleanup; renderActiveService is emitted exactly once per pool.
     const versioned = renderService({ poolName: "ssr", buildId: "b1", releaseName: "my-app" });
     expect(versioned).not.toContain("PodDisruptionBudget");

--- a/tests/emit/templates/utils.test.ts
+++ b/tests/emit/templates/utils.test.ts
@@ -427,7 +427,7 @@ describe("assertSafeYamlScalar (N67)", () => {
   });
 });
 
-describe("assertSafeImageReference (N66)", () => {
+describe("assertSafeImageReference", () => {
   it("accepts a registry/repo:tag and a digest form", () => {
     expect(() =>
       assertSafeImageReference("us-central1-docker.pkg.dev/p/r/nextjs-app-ssr:build1"),


### PR DESCRIPTION
## Summary

- transfer outgoing Deployments out of the Helm release without reconstructing their pod templates
- hold incoming HPAs at the outgoing replica count until the capacity gate completes; #28 keeps the outgoing HPAs active
- restore exact autoscaling bounds on success and every pre-cutover abort path

## Testing

- `npm run build`
- `TMPDIR=/private/tmp npm test`
- `npm run typecheck`
- `npm run lint`
- `npm run fmt`
- `git diff --check`
- live home-cluster rollout under sustained mixed traffic
- 40/40 adapter conformance checks