### PR TITLE
Drive operational commands from the deployment plan

### DIFF
--- a/src/cli/composition-plan.ts
+++ b/src/cli/composition-plan.ts
@@ -1,0 +1,1096 @@
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import {
+  assertKubernetesServerVersion,
+  parseAndVerifyCompositionPlan,
+  type CompositionPlan,
+  type CompositionPlanDigest,
+  type DiagnosticSource,
+  type KubernetesApiRequirement,
+  type KubernetesObjectRef,
+  type RoutingReadiness,
+} from "../composition-plan/index.js";
+import { compositionPlanConfigMapName } from "../emit/templates/composition-plan-configmap.js";
+import { outputDirName } from "./infrastructure-validation.js";
+import { sanitizeForTerminal } from "./terminal.js";
+import { execCapture, execOrThrow } from "./exec.js";
+
+const PLAN_FILE = "composition-plan.json";
+const PLAN_DIGEST_ANNOTATION = "adapter-k8s.dev/composition-digest";
+const DEFAULT_GCP_READINESS_TIMEOUT_SECONDS = 600;
+
+export interface CompositionPlanMetadata {
+  compositionPlan?:
+    | {
+        digest?: unknown;
+        targetFingerprint?: unknown;
+      }
+    | undefined;
+  buildId?: unknown;
+}
+
+export interface LoadedCompositionPlan {
+  plan: CompositionPlan;
+  digest: CompositionPlanDigest;
+  source: string;
+}
+
+export interface CompositionPlanCheck {
+  name: string;
+  status: "pass" | "fail" | "warn";
+  message: string;
+  fix?: string;
+}
+
+export interface CompositionPlanDescription {
+  resources: Array<{
+    ref: KubernetesObjectRef;
+    lifecycle: "helm" | "retain-with-build" | "retain-with-pool" | "apply";
+  }>;
+  logs: Array<{
+    namespace: string;
+    selector: string;
+    containers: "all";
+  }>;
+  cleanup: {
+    kubernetes: CompositionPlan["operations"]["cleanup"]["kubernetes"]["contributedObjects"];
+    external: CompositionPlan["operations"]["cleanup"]["external"];
+    retained: CompositionPlan["operations"]["cleanup"]["retained"];
+  };
+}
+
+interface KubernetesObject {
+  metadata?: { generation?: number };
+  spec?: Record<string, unknown>;
+  status?: Record<string, unknown>;
+}
+
+interface ReadinessEvaluation {
+  ready: boolean;
+  final: boolean;
+  message: string;
+}
+
+function readJson(text: string, source: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    throw new Error(
+      `Failed to parse ${source}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+function digest(value: unknown, source: string): CompositionPlanDigest {
+  if (typeof value !== "string" || !/^sha256:[a-f0-9]{64}$/.test(value)) {
+    throw new Error(`${source} must be sha256:<64 lowercase hex characters>`);
+  }
+  return value as CompositionPlanDigest;
+}
+
+function sameLocation(
+  a: { kind: string; name: string },
+  b: { kind: string; name: string },
+): boolean {
+  return a.kind === b.kind && a.name === b.name;
+}
+
+/**
+ * Load the build's immutable operational plan. Legacy artifacts have neither the plan file nor
+ * its metadata pointer and return null; a half-present pair is corruption and fails closed.
+ */
+export function loadLocalCompositionPlan(
+  outputDir: string,
+  metadata: CompositionPlanMetadata,
+): LoadedCompositionPlan | null {
+  const filePath = path.join(outputDir, PLAN_FILE);
+  const pointer = metadata.compositionPlan;
+  if (!pointer && !existsSync(filePath)) return null;
+  if (!pointer) {
+    throw new Error(
+      `${filePath} exists but build-metadata.json has no compositionPlan digest. Refusing to ` +
+        `execute an unauthenticated leftover plan; rebuild the adapter output.`,
+    );
+  }
+  if (!existsSync(filePath)) {
+    throw new Error(
+      `build-metadata.json references a composition plan, but ${filePath} is missing. Rebuild ` +
+        `the adapter output.`,
+    );
+  }
+  const expectedDigest = digest(pointer.digest, "build-metadata.json compositionPlan.digest");
+  const plan = parseAndVerifyCompositionPlan(
+    readJson(readFileSync(filePath, "utf8"), filePath),
+    expectedDigest,
+  );
+  const expectedFingerprint = digest(
+    pointer.targetFingerprint,
+    "build-metadata.json compositionPlan.targetFingerprint",
+  );
+  if (plan.target.fingerprint !== expectedFingerprint) {
+    throw new Error(
+      `Composition-plan target fingerprint mismatch: build metadata records ` +
+        `${expectedFingerprint}, but the verified plan records ${plan.target.fingerprint}.`,
+    );
+  }
+  if (typeof metadata.buildId === "string" && plan.metadata.buildId !== metadata.buildId) {
+    throw new Error(
+      `Composition-plan build mismatch: build metadata records ${metadata.buildId}, but the ` +
+        `verified plan records ${plan.metadata.buildId}.`,
+    );
+  }
+  return { plan, digest: expectedDigest, source: filePath };
+}
+
+/** Load a command's local build artifact when one is available. */
+export function loadProjectCompositionPlan(projectDir: string): LoadedCompositionPlan | null {
+  const outputDir = path.join(projectDir, ".k8s-adapter", outputDirName());
+  const metadataPath = path.join(outputDir, "build-metadata.json");
+  if (!existsSync(metadataPath)) return null;
+  const metadata = readJson(
+    readFileSync(metadataPath, "utf8"),
+    metadataPath,
+  ) as CompositionPlanMetadata;
+  return loadLocalCompositionPlan(outputDir, metadata);
+}
+
+/** Load the exact retained ConfigMap for a deployed build and verify its own digest annotation. */
+export async function loadDeployedCompositionPlan(options: {
+  releaseName: string;
+  namespace: string;
+  buildId: string;
+  expected?: {
+    digest: CompositionPlanDigest;
+    targetFingerprint: CompositionPlanDigest;
+  };
+}): Promise<LoadedCompositionPlan | null> {
+  const name = compositionPlanConfigMapName(options.releaseName, options.buildId);
+  const result = await execCapture("kubectl", [
+    "get",
+    "configmap",
+    name,
+    "-n",
+    options.namespace,
+    "-o",
+    "json",
+    "--ignore-not-found",
+  ]);
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `Could not read deployed composition plan ConfigMap ${options.namespace}/${name}: ` +
+        sanitizeForTerminal(result.stderr.trim() || `kubectl exited ${result.exitCode}`),
+    );
+  }
+  if (!result.stdout.trim()) {
+    // `--ignore-not-found` is the machine-readable absence signal: missing returns exit 0 with
+    // an empty body, while authentication, connectivity and authorization failures stay nonzero.
+    return null;
+  }
+  const object = readJson(result.stdout, `ConfigMap ${options.namespace}/${name}`) as {
+    metadata?: { annotations?: Record<string, unknown> };
+    data?: Record<string, unknown>;
+  };
+  const expectedDigest = digest(
+    object.metadata?.annotations?.[PLAN_DIGEST_ANNOTATION],
+    `ConfigMap ${options.namespace}/${name} annotation ${PLAN_DIGEST_ANNOTATION}`,
+  );
+  if (options.expected && expectedDigest !== options.expected.digest) {
+    throw new Error(
+      `Deployed composition-plan digest does not match committed deploy state: ConfigMap ` +
+        `${options.namespace}/${name} records ${expectedDigest}, state records ` +
+        `${options.expected.digest}.`,
+    );
+  }
+  const planJson = object.data?.["plan.json"];
+  if (typeof planJson !== "string") {
+    throw new Error(`ConfigMap ${options.namespace}/${name} has no string data["plan.json"]`);
+  }
+  const plan = parseAndVerifyCompositionPlan(
+    readJson(planJson, `ConfigMap ${options.namespace}/${name} data["plan.json"]`),
+    expectedDigest,
+  );
+  if (options.expected && plan.target.fingerprint !== options.expected.targetFingerprint) {
+    throw new Error(
+      `Deployed composition-plan target fingerprint does not match committed deploy state: ` +
+        `plan records ${plan.target.fingerprint}, state records ` +
+        `${options.expected.targetFingerprint}.`,
+    );
+  }
+  if (
+    plan.metadata.releaseName !== options.releaseName ||
+    plan.metadata.namespace !== options.namespace ||
+    plan.metadata.buildId !== options.buildId
+  ) {
+    throw new Error(
+      `Deployed composition-plan identity mismatch: requested ` +
+        `${options.namespace}/${options.releaseName}@${options.buildId}, found ` +
+        `${plan.metadata.namespace}/${plan.metadata.releaseName}@${plan.metadata.buildId}.`,
+    );
+  }
+  return { plan, digest: expectedDigest, source: `ConfigMap ${options.namespace}/${name}` };
+}
+
+export function assertCompositionPlanInvocation(
+  plan: CompositionPlan,
+  expected: { releaseName: string; namespace: string; buildId: string },
+): void {
+  for (const [field, actual, wanted] of [
+    ["release", plan.metadata.releaseName, expected.releaseName],
+    ["namespace", plan.metadata.namespace, expected.namespace],
+    ["build", plan.metadata.buildId, expected.buildId],
+  ] as const) {
+    if (actual !== wanted) {
+      throw new Error(
+        `Composition-plan ${field} mismatch: plan records ${JSON.stringify(actual)}, ` +
+          `but this deploy targets ${JSON.stringify(wanted)}. Rebuild for the selected target.`,
+      );
+    }
+  }
+}
+
+export function compositionPlanNeedsExplicitConfirmation(plan: CompositionPlan): boolean {
+  return (
+    plan.target.identity.kind === "unverified" ||
+    plan.target.access.kind === "kubeconfig-current-context"
+  );
+}
+
+async function readCurrentKubeContext(): Promise<string | null> {
+  const result = await execCapture("kubectl", ["config", "current-context"]).catch(() => null);
+  if (!result || result.exitCode !== 0) return null;
+  return result.stdout.trim() || null;
+}
+
+export async function currentKubeContext(): Promise<string | null> {
+  const current = await readCurrentKubeContext();
+  return current ? sanitizeForTerminal(current) : null;
+}
+
+async function establishClusterAccess(plan: CompositionPlan): Promise<void> {
+  const access = plan.target.access;
+  switch (access.kind) {
+    case "gke-get-credentials": {
+      const locationFlag = access.location.kind === "zone" ? "--zone" : "--region";
+      await execOrThrow("gcloud", [
+        "container",
+        "clusters",
+        "get-credentials",
+        access.clusterName,
+        locationFlag,
+        access.location.name,
+        "--project",
+        access.projectId,
+        "--quiet",
+      ]);
+      return;
+    }
+    case "kubeconfig-context": {
+      const current = await readCurrentKubeContext();
+      if (current !== access.context) {
+        throw new Error(
+          `Composition plan requires kubeconfig context ${JSON.stringify(access.context)}, but ` +
+            `the current context is ${JSON.stringify(current ? sanitizeForTerminal(current) : "unavailable")}. Select the ` +
+            `required context before deploying.`,
+        );
+      }
+      return;
+    }
+    case "kubeconfig-current-context":
+      return;
+  }
+}
+
+async function rawKubernetes(pathname: string): Promise<unknown> {
+  const result = await execCapture("kubectl", ["get", "--raw", pathname]);
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `Kubernetes API read ${pathname} failed: ` +
+        sanitizeForTerminal(result.stderr.trim() || `kubectl exited ${result.exitCode}`),
+    );
+  }
+  return readJson(result.stdout, `Kubernetes API response ${pathname}`);
+}
+
+function apiRoot(apiVersion: string): string {
+  if (apiVersion === "v1") return "/api/v1";
+  const slash = apiVersion.lastIndexOf("/");
+  return `/apis/${apiVersion.slice(0, slash)}/${apiVersion.slice(slash + 1)}`;
+}
+
+function objectPath(ref: KubernetesObjectRef): string {
+  const root = apiRoot(ref.apiVersion);
+  const namespace = ref.namespace ? `/namespaces/${encodeURIComponent(ref.namespace)}` : "";
+  return `${root}${namespace}/${ref.resource}/${encodeURIComponent(ref.name)}`;
+}
+
+async function verifyClusterIdentity(
+  plan: CompositionPlan,
+  explicitlyConfirmed: boolean,
+): Promise<string> {
+  const identity = plan.target.identity;
+  switch (identity.kind) {
+    case "unverified":
+      if (!explicitlyConfirmed) {
+        throw new Error(
+          "The composition plan cannot verify the cluster identity. Re-run with --yes only " +
+            "after confirming the printed kubectl context is the intended cluster.",
+        );
+      }
+      return `explicitly confirmed current context (${(await currentKubeContext()) ?? "unknown"})`;
+    case "kubernetes-namespace-uid": {
+      const namespace = (await rawKubernetes(
+        `/api/v1/namespaces/${encodeURIComponent(identity.namespace)}`,
+      )) as { metadata?: { uid?: unknown } };
+      if (namespace.metadata?.uid !== identity.uid) {
+        throw new Error(
+          `Cluster identity mismatch: ${identity.namespace} UID is ` +
+            `${JSON.stringify(namespace.metadata?.uid ?? "missing")}, expected ` +
+            `${JSON.stringify(identity.uid)}.`,
+        );
+      }
+      return `${identity.namespace} uid ${identity.uid}`;
+    }
+    case "gke-resource": {
+      const access = plan.target.access;
+      const accessBindsIdentity =
+        access.kind === "gke-get-credentials" &&
+        access.projectId === identity.projectId &&
+        access.clusterName === identity.clusterName &&
+        sameLocation(access.location, identity.location);
+      if (!accessBindsIdentity && !identity.expectedKubeSystemUid) {
+        throw new Error(
+          `The GKE composition-plan identity ${identity.projectId}/${identity.clusterName} is ` +
+            `not bound to its cluster access operation and has no expected kube-system UID. ` +
+            `Refusing to infer that the current kubectl context names the same cluster.`,
+        );
+      }
+      if (identity.expectedKubeSystemUid) {
+        const namespace = (await rawKubernetes("/api/v1/namespaces/kube-system")) as {
+          metadata?: { uid?: unknown };
+        };
+        if (namespace.metadata?.uid !== identity.expectedKubeSystemUid) {
+          throw new Error(
+            `Cluster identity mismatch: kube-system UID is ` +
+              `${JSON.stringify(namespace.metadata?.uid ?? "missing")}, expected ` +
+              `${JSON.stringify(identity.expectedKubeSystemUid)}.`,
+          );
+        }
+      }
+      return `${identity.projectId}/${identity.clusterName} (${identity.location.kind} ${identity.location.name})`;
+    }
+  }
+}
+
+function implicitRequirements(plan: CompositionPlan): KubernetesApiRequirement[] {
+  const readiness = compositionPlanReadiness(plan);
+  return [
+    ...plan.operations.resources.objects.map((object) => ({
+      apiVersion: object.apiVersion,
+      resource: object.resource,
+      optional: false as const,
+    })),
+    ...readiness.flatMap((entry): KubernetesApiRequirement[] => {
+      if (entry.kind === "gcp-traffic-extension") return [];
+      if (entry.kind === "kubernetes-service-endpoints") {
+        return [
+          { apiVersion: "v1", resource: "services", optional: false },
+          { apiVersion: "discovery.k8s.io/v1", resource: "endpointslices", optional: false },
+        ];
+      }
+      return [
+        { apiVersion: entry.object.apiVersion, resource: entry.object.resource, optional: false },
+      ];
+    }),
+  ];
+}
+
+export async function inspectKubernetesRequirements(
+  plan: CompositionPlan,
+): Promise<{ serverVersion: string; missingOptional: KubernetesApiRequirement[] }> {
+  const version = (await rawKubernetes("/version")) as { gitVersion?: unknown };
+  if (typeof version.gitVersion !== "string") {
+    throw new Error("Kubernetes /version response has no string gitVersion");
+  }
+  assertKubernetesServerVersion(version.gitVersion, plan.requirements.kubernetes.minimumVersion);
+
+  const requirements = new Map<string, KubernetesApiRequirement>();
+  for (const requirement of [
+    ...plan.requirements.kubernetes.resources,
+    ...implicitRequirements(plan),
+  ]) {
+    const key = `${requirement.apiVersion}/${requirement.resource}`;
+    const prior = requirements.get(key);
+    requirements.set(key, {
+      ...requirement,
+      optional: prior ? prior.optional && requirement.optional : requirement.optional,
+    });
+  }
+  const byVersion = new Map<string, KubernetesApiRequirement[]>();
+  for (const requirement of requirements.values()) {
+    const entries = byVersion.get(requirement.apiVersion) ?? [];
+    entries.push(requirement);
+    byVersion.set(requirement.apiVersion, entries);
+  }
+  const missingRequired: KubernetesApiRequirement[] = [];
+  const missingOptional: KubernetesApiRequirement[] = [];
+  const kindMismatches: string[] = [];
+  const expectedKinds = new Map<string, Set<string>>();
+  for (const object of plan.operations.resources.objects) {
+    const key = `${object.apiVersion}/${object.resource}`;
+    const kinds = expectedKinds.get(key) ?? new Set<string>();
+    kinds.add(object.kind);
+    expectedKinds.set(key, kinds);
+  }
+  for (const [apiVersion, entries] of byVersion) {
+    let discovered = new Map<string, string>();
+    try {
+      const discovery = (await rawKubernetes(apiRoot(apiVersion))) as {
+        resources?: Array<{ name?: unknown; kind?: unknown }>;
+      };
+      discovered = new Map(
+        (discovery.resources ?? []).flatMap((entry) =>
+          typeof entry.name === "string" && typeof entry.kind === "string"
+            ? [[entry.name, entry.kind] as const]
+            : [],
+        ),
+      );
+    } catch (error) {
+      const allOptional = entries.every((entry) => entry.optional);
+      if (!allOptional) throw error;
+    }
+    for (const requirement of entries) {
+      const actualKind = discovered.get(requirement.resource);
+      if (!actualKind) {
+        (requirement.optional ? missingOptional : missingRequired).push(requirement);
+        continue;
+      }
+      const expected = expectedKinds.get(`${apiVersion}/${requirement.resource}`);
+      if (expected && !expected.has(actualKind)) {
+        kindMismatches.push(
+          `${apiVersion}/${requirement.resource} reports kind ${actualKind}, expected ${[...expected].join(" or ")}`,
+        );
+      }
+    }
+  }
+  if (missingRequired.length > 0) {
+    throw new Error(
+      `Kubernetes cluster is missing required APIs: ${missingRequired
+        .map((entry) => `${entry.apiVersion}/${entry.resource}`)
+        .join(", ")}. Install the corresponding CRDs/controllers before deploying.`,
+    );
+  }
+  if (kindMismatches.length > 0) {
+    throw new Error(
+      `Kubernetes API discovery does not match the composition plan: ${kindMismatches.join(
+        "; ",
+      )}. Fix the component's resource/kind pair before deploying.`,
+    );
+  }
+  return { serverVersion: version.gitVersion, missingOptional };
+}
+
+export async function preflightCompositionPlan(
+  plan: CompositionPlan,
+  options: { explicitlyConfirmed: boolean },
+): Promise<{
+  clusterIdentity: string;
+  serverVersion: string;
+  missingOptional: KubernetesApiRequirement[];
+}> {
+  if (compositionPlanNeedsExplicitConfirmation(plan) && !options.explicitlyConfirmed) {
+    throw new Error(
+      "This composition plan requires explicit confirmation of the current kubectl context. " +
+        "Re-run with --yes only after verifying that context.",
+    );
+  }
+  await establishClusterAccess(plan);
+  const clusterIdentity = await verifyClusterIdentity(plan, options.explicitlyConfirmed);
+  const requirements = await inspectKubernetesRequirements(plan);
+  return { clusterIdentity, ...requirements };
+}
+
+function records(value: unknown): Array<Record<string, unknown>> {
+  return Array.isArray(value)
+    ? value.filter(
+        (entry): entry is Record<string, unknown> =>
+          entry !== null && typeof entry === "object" && !Array.isArray(entry),
+      )
+    : [];
+}
+
+function conditionStatus(
+  object: KubernetesObject,
+  readiness: Extract<RoutingReadiness, { kind: "kubernetes-condition" }>,
+): ReadinessEvaluation {
+  const generation = object.metadata?.generation;
+  const status = object.status ?? {};
+  let owners: Array<Record<string, unknown>>;
+  switch (readiness.conditionsAt.kind) {
+    case "object":
+      owners = [status];
+      break;
+    case "parents": {
+      const parents = records(status.parents);
+      const controllerName = readiness.conditionsAt.controllerName;
+      owners = controllerName
+        ? parents.filter((entry) => entry.controllerName === controllerName)
+        : parents;
+      break;
+    }
+    case "ancestors": {
+      const controllerName = readiness.conditionsAt.controllerName;
+      owners = records(status.ancestors).filter((entry) => entry.controllerName === controllerName);
+      break;
+    }
+  }
+  if (owners.length === 0) {
+    return { ready: false, final: false, message: "condition owner has not been reported" };
+  }
+  const conditions = owners.map((owner) =>
+    records(owner.conditions).find((entry) => entry.type === readiness.condition.type),
+  );
+  if (conditions.some((condition) => condition === undefined)) {
+    return {
+      ready: false,
+      final: false,
+      message: `${readiness.condition.type} has not been reported for every matching status entry`,
+    };
+  }
+  for (const condition of conditions as Array<Record<string, unknown>>) {
+    if (condition.status === "False") {
+      return {
+        ready: false,
+        final: false,
+        message: sanitizeForTerminal(
+          String(condition.message ?? condition.reason ?? `${readiness.condition.type}=False`),
+        ),
+      };
+    }
+    if (condition.status !== readiness.condition.status) {
+      return {
+        ready: false,
+        final: false,
+        message: `${readiness.condition.type}=${String(condition.status ?? "Unknown")}`,
+      };
+    }
+    if (generation === undefined || condition.observedGeneration !== generation) {
+      return {
+        ready: false,
+        final: false,
+        message: `${readiness.condition.type} is stale for generation ${String(generation ?? "unknown")}`,
+      };
+    }
+  }
+  return {
+    ready: true,
+    final: true,
+    message: `${readiness.condition.type}=True for generation ${generation}`,
+  };
+}
+
+async function evaluateKubernetesReadiness(
+  readiness: Exclude<RoutingReadiness, { kind: "gcp-traffic-extension" }>,
+): Promise<ReadinessEvaluation> {
+  if (readiness.kind === "kubernetes-service-endpoints") {
+    const root = apiRoot("discovery.k8s.io/v1");
+    const selector = encodeURIComponent(`kubernetes.io/service-name=${readiness.service.name}`);
+    const response = (await rawKubernetes(
+      `${root}/namespaces/${encodeURIComponent(readiness.service.namespace)}/endpointslices?labelSelector=${selector}`,
+    )) as {
+      items?: Array<{
+        endpoints?: Array<{ conditions?: { ready?: unknown; terminating?: unknown } }>;
+      }>;
+    };
+    const ready = (response.items ?? [])
+      .flatMap((item) => item.endpoints ?? [])
+      // EndpointSlice defines nil `ready` as true. A terminating endpoint can still be
+      // serving during drain, but it is not durable capacity for a cutover readiness gate.
+      .filter(
+        (endpoint) =>
+          endpoint.conditions?.ready !== false && endpoint.conditions?.terminating !== true,
+      ).length;
+    return {
+      ready: ready >= readiness.minimumReady,
+      final: false,
+      message: `${ready}/${readiness.minimumReady} ready service endpoints`,
+    };
+  }
+
+  const object = (await rawKubernetes(objectPath(readiness.object))) as KubernetesObject;
+  if (readiness.kind === "kubernetes-condition") {
+    return conditionStatus(object, readiness);
+  }
+  if (readiness.kind === "kubernetes-job-complete") {
+    const complete = records(object.status?.conditions).find((entry) => entry.type === "Complete");
+    const failed = records(object.status?.conditions).find(
+      (entry) => entry.type === "Failed" && entry.status === "True",
+    );
+    if (failed) {
+      return {
+        ready: false,
+        final: true,
+        message: sanitizeForTerminal(String(failed.message ?? failed.reason ?? "Job failed")),
+      };
+    }
+    return {
+      ready: complete?.status === "True",
+      final: false,
+      message: complete?.status === "True" ? "Job Complete=True" : "Job is not complete",
+    };
+  }
+
+  const generation = object.metadata?.generation;
+  const observed = object.status?.observedGeneration;
+  const desired = typeof object.spec?.replicas === "number" ? Math.max(1, object.spec.replicas) : 1;
+  const available =
+    typeof object.status?.availableReplicas === "number" ? object.status.availableReplicas : 0;
+  const current =
+    typeof observed === "number" && generation !== undefined && observed >= generation;
+  return {
+    ready: current && available >= desired,
+    final: false,
+    message: `${available}/${desired} available replicas${current ? "" : "; controller status is stale"}`,
+  };
+}
+
+async function evaluateGcpTrafficExtension(
+  readiness: Extract<RoutingReadiness, { kind: "gcp-traffic-extension" }>,
+): Promise<ReadinessEvaluation> {
+  const extension = await execCapture("gcloud", [
+    "service-extensions",
+    "lb-traffic-extensions",
+    "describe",
+    readiness.extensionName,
+    "--location=global",
+    "--project",
+    readiness.projectId,
+    "--format=json",
+  ]);
+  if (extension.exitCode !== 0) {
+    return {
+      ready: false,
+      final: false,
+      message: sanitizeForTerminal(extension.stderr.trim() || "traffic extension not found"),
+    };
+  }
+  const extensionObject = readJson(extension.stdout, "gcloud traffic-extension response") as {
+    forwardingRules?: unknown;
+  };
+  const covered = new Set(
+    (Array.isArray(extensionObject.forwardingRules) ? extensionObject.forwardingRules : [])
+      .filter((entry): entry is string => typeof entry === "string")
+      .map((entry) => entry.split("/").pop()!),
+  );
+  const address = await execCapture("gcloud", [
+    "compute",
+    "addresses",
+    "describe",
+    readiness.addressName,
+    "--global",
+    "--project",
+    readiness.projectId,
+    "--format=value(address)",
+  ]);
+  const ip = address.exitCode === 0 ? address.stdout.trim() : "";
+  if (!ip) return { ready: false, final: false, message: "release address is not ready" };
+  const rules = await execCapture("gcloud", [
+    "compute",
+    "forwarding-rules",
+    "list",
+    "--project",
+    readiness.projectId,
+    "--filter",
+    `IPAddress=${ip}`,
+    "--format=value(name)",
+  ]);
+  if (rules.exitCode !== 0) {
+    return {
+      ready: false,
+      final: false,
+      message: sanitizeForTerminal(rules.stderr.trim() || "forwarding rules are unavailable"),
+    };
+  }
+  const expected = rules.stdout
+    .split("\n")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+  if (expected.length === 0) {
+    return { ready: false, final: false, message: "release has no forwarding rules yet" };
+  }
+  const missing = expected.filter((name) => !covered.has(name));
+  return {
+    ready: missing.length === 0,
+    final: false,
+    message:
+      missing.length === 0
+        ? `traffic extension covers all ${expected.length} forwarding rules`
+        : `traffic extension is missing forwarding rules: ${missing.join(", ")}`,
+  };
+}
+
+function readinessKey(readiness: RoutingReadiness): string {
+  return JSON.stringify(readiness);
+}
+
+export function compositionPlanReadiness(plan: CompositionPlan): RoutingReadiness[] {
+  const routingReadiness = plan.operations.routing.dataplane.readiness;
+  const unique = new Map<string, RoutingReadiness>();
+  for (const readiness of [...plan.operations.resources.readiness, ...routingReadiness]) {
+    unique.set(readinessKey(readiness), readiness);
+  }
+  return [...unique.values()];
+}
+
+export async function evaluateCompositionPlanReadiness(
+  plan: CompositionPlan,
+): Promise<CompositionPlanCheck[]> {
+  const results: CompositionPlanCheck[] = [];
+  for (const readiness of compositionPlanReadiness(plan)) {
+    let result: ReadinessEvaluation;
+    try {
+      result =
+        readiness.kind === "gcp-traffic-extension"
+          ? await evaluateGcpTrafficExtension(readiness)
+          : await evaluateKubernetesReadiness(readiness);
+    } catch (error) {
+      result = {
+        ready: false,
+        final: false,
+        message: sanitizeForTerminal(error instanceof Error ? error.message : String(error)),
+      };
+    }
+    results.push({
+      name: readinessLabel(readiness),
+      status: result.ready ? "pass" : "fail",
+      message: result.message,
+      ...(!result.ready && readiness.kind !== "gcp-traffic-extension"
+        ? { fix: readinessFix(readiness) }
+        : {}),
+    });
+  }
+  return results;
+}
+
+export async function evaluateCompositionPlanDiagnostics(
+  plan: CompositionPlan,
+): Promise<CompositionPlanCheck[]> {
+  const checks: CompositionPlanCheck[] = [];
+  for (const diagnostic of plan.operations.diagnostics) {
+    let status: CompositionPlanCheck["status"] = "fail";
+    let message = "not available";
+    try {
+      switch (diagnostic.kind) {
+        case "kubernetes-condition": {
+          const result = await evaluateKubernetesReadiness(diagnostic.check);
+          status = result.ready ? "pass" : "fail";
+          message = result.message;
+          break;
+        }
+        case "kubernetes-gateway-address": {
+          const object = (await rawKubernetes(objectPath(diagnostic.gateway))) as {
+            status?: { addresses?: Array<{ value?: unknown }> };
+          };
+          const addresses = (object.status?.addresses ?? [])
+            .map((entry) => entry.value)
+            .filter((entry): entry is string => typeof entry === "string" && entry.length > 0);
+          status = addresses.length > 0 ? "pass" : "warn";
+          message = addresses.length > 0 ? addresses.join(", ") : "address is pending";
+          break;
+        }
+        case "gcp-auth": {
+          const result = await execCapture("gcloud", [
+            "auth",
+            "print-access-token",
+            `--project=${diagnostic.projectId}`,
+            "--quiet",
+          ]);
+          status = result.exitCode === 0 ? "pass" : "fail";
+          message = result.exitCode === 0 ? "authenticated" : result.stderr.trim();
+          break;
+        }
+        case "gcp-global-address": {
+          const result = await execCapture("gcloud", [
+            "compute",
+            "addresses",
+            "describe",
+            diagnostic.name,
+            "--global",
+            `--project=${diagnostic.projectId}`,
+            "--format=value(address)",
+          ]);
+          const address = result.exitCode === 0 ? result.stdout.trim() : "";
+          status = address ? "pass" : "fail";
+          message = address || result.stderr.trim() || "address not found";
+          break;
+        }
+        case "gcp-storage-bucket": {
+          const result = await execCapture("gcloud", [
+            "storage",
+            "buckets",
+            "describe",
+            `gs://${diagnostic.bucket}`,
+            `--project=${diagnostic.projectId}`,
+            "--format=value(name)",
+          ]);
+          status = result.exitCode === 0 ? "pass" : "fail";
+          message = result.stdout.trim() || result.stderr.trim() || "bucket not found";
+          break;
+        }
+        case "gcp-artifact-registry": {
+          const result = await execCapture("gcloud", [
+            "artifacts",
+            "repositories",
+            "describe",
+            diagnostic.repository,
+            `--location=${diagnostic.region}`,
+            `--project=${diagnostic.projectId}`,
+            "--format=value(name)",
+          ]);
+          status = result.exitCode === 0 ? "pass" : "fail";
+          message = result.stdout.trim() || result.stderr.trim() || "repository not found";
+          break;
+        }
+        case "gcp-backend-health": {
+          const result = await execCapture("gcloud", [
+            "compute",
+            "backend-services",
+            "get-health",
+            `${diagnostic.releasePrefix}-routing-service`,
+            "--global",
+            `--project=${diagnostic.projectId}`,
+            "--format=json",
+          ]);
+          status = result.exitCode === 0 ? "pass" : "fail";
+          message = result.exitCode === 0 ? "backend health is readable" : result.stderr.trim();
+          break;
+        }
+        case "gcp-traffic-extension": {
+          const result = await evaluateGcpTrafficExtension({
+            kind: "gcp-traffic-extension",
+            projectId: diagnostic.projectId,
+            extensionName: diagnostic.extensionName,
+            addressName: diagnostic.addressName,
+            requireEveryForwardingRule: true,
+          });
+          status = result.ready ? "pass" : "fail";
+          message = result.message;
+          break;
+        }
+        case "gcp-backend-service-shape": {
+          const result = await execCapture("gcloud", [
+            "compute",
+            "backend-services",
+            "describe",
+            diagnostic.name,
+            "--global",
+            `--project=${diagnostic.projectId}`,
+            "--format=json",
+          ]);
+          if (result.exitCode !== 0) {
+            message = result.stderr.trim() || "backend service not found";
+            break;
+          }
+          const object = readJson(result.stdout, "gcloud backend-service response") as {
+            loadBalancingScheme?: unknown;
+            backends?: unknown;
+          };
+          const schemeMatches = object.loadBalancingScheme === diagnostic.loadBalancingScheme;
+          const hasBackend =
+            !diagnostic.requireBackend ||
+            (Array.isArray(object.backends) && object.backends.length > 0);
+          status = schemeMatches && hasBackend ? "pass" : "fail";
+          message = schemeMatches
+            ? hasBackend
+              ? "backend service shape is valid"
+              : "backend service has no backends"
+            : `loadBalancingScheme=${String(object.loadBalancingScheme ?? "missing")}`;
+          break;
+        }
+        case "gcp-health-check-shape": {
+          const result = await execCapture("gcloud", [
+            "compute",
+            "health-checks",
+            "describe",
+            diagnostic.name,
+            "--global",
+            `--project=${diagnostic.projectId}`,
+            "--format=value(type)",
+          ]);
+          const actual = result.exitCode === 0 ? result.stdout.trim().toUpperCase() : "";
+          status = actual === diagnostic.expectedType ? "pass" : "fail";
+          message = actual || result.stderr.trim() || "health check not found";
+          break;
+        }
+        case "gcp-certificate": {
+          const result = await execCapture("gcloud", [
+            "certificate-manager",
+            "certificates",
+            "describe",
+            diagnostic.name,
+            `--project=${diagnostic.projectId}`,
+            "--format=value(managed.state)",
+          ]);
+          const state = result.exitCode === 0 ? result.stdout.trim().toUpperCase() : "";
+          status = state === "ACTIVE" ? "pass" : state === "PROVISIONING" ? "warn" : "fail";
+          message = state || result.stderr.trim() || "certificate not found";
+          break;
+        }
+      }
+    } catch (error) {
+      status = "fail";
+      message = error instanceof Error ? error.message : String(error);
+    }
+    checks.push({
+      name: diagnosticLabel(diagnostic),
+      status,
+      message: sanitizeForTerminal(message),
+    });
+  }
+  return checks;
+}
+
+function diagnosticLabel(diagnostic: DiagnosticSource): string {
+  switch (diagnostic.kind) {
+    case "kubernetes-condition":
+      return diagnostic.label;
+    case "kubernetes-gateway-address":
+      return `${refLabel(diagnostic.gateway)} address`;
+    case "gcp-auth":
+      return `GCP authentication ${diagnostic.projectId}`;
+    case "gcp-global-address":
+      return `GCP address ${diagnostic.name}`;
+    case "gcp-storage-bucket":
+      return `GCS bucket ${diagnostic.bucket}`;
+    case "gcp-artifact-registry":
+      return `Artifact Registry ${diagnostic.repository}`;
+    case "gcp-backend-health":
+      return `GCP backend health ${diagnostic.releasePrefix}`;
+    case "gcp-traffic-extension":
+      return `GCP traffic extension ${diagnostic.extensionName}`;
+    case "gcp-backend-service-shape":
+      return `GCP backend service ${diagnostic.name}`;
+    case "gcp-health-check-shape":
+      return `GCP health check ${diagnostic.name}`;
+    case "gcp-certificate":
+      return `GCP certificate ${diagnostic.name}`;
+  }
+}
+
+function timeoutSeconds(readiness: RoutingReadiness): number {
+  return readiness.kind === "kubernetes-service-endpoints"
+    ? 120
+    : readiness.kind === "gcp-traffic-extension"
+      ? DEFAULT_GCP_READINESS_TIMEOUT_SECONDS
+      : readiness.timeoutSeconds;
+}
+
+export async function waitForCompositionPlanReadiness(
+  plan: CompositionPlan,
+  options: { pollIntervalMs?: number } = {},
+): Promise<void> {
+  const pollIntervalMs = options.pollIntervalMs ?? 2_000;
+  for (const readiness of compositionPlanReadiness(plan)) {
+    const deadline = Date.now() + timeoutSeconds(readiness) * 1_000;
+    let last = "not reported";
+    let ready = false;
+    while (!ready && Date.now() <= deadline) {
+      let result: ReadinessEvaluation | null = null;
+      try {
+        result =
+          readiness.kind === "gcp-traffic-extension"
+            ? await evaluateGcpTrafficExtension(readiness)
+            : await evaluateKubernetesReadiness(readiness);
+        last = result.message;
+      } catch (error) {
+        last = sanitizeForTerminal(error instanceof Error ? error.message : String(error));
+      }
+      if (result?.ready) {
+        ready = true;
+        break;
+      }
+      if (result?.final) throw new Error(`${readinessLabel(readiness)} failed: ${last}`);
+      if (Date.now() > deadline) {
+        break;
+      }
+      await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+    }
+    if (!ready) {
+      throw new Error(
+        `${readinessLabel(readiness)} did not become ready within ` +
+          `${timeoutSeconds(readiness)}s (${last}).`,
+      );
+    }
+  }
+}
+
+function refLabel(ref: KubernetesObjectRef): string {
+  return `${ref.apiVersion}/${ref.resource} ${ref.namespace ? `${ref.namespace}/` : ""}${ref.name}`;
+}
+
+function readinessLabel(readiness: RoutingReadiness): string {
+  switch (readiness.kind) {
+    case "kubernetes-condition":
+      return `${refLabel(readiness.object)} ${readiness.condition.type}`;
+    case "kubernetes-job-complete":
+      return `${refLabel(readiness.object)} complete`;
+    case "kubernetes-deployment-available":
+      return `${refLabel(readiness.object)} available`;
+    case "kubernetes-service-endpoints":
+      return `v1/services ${readiness.service.namespace}/${readiness.service.name} endpoints`;
+    case "gcp-traffic-extension":
+      return `GCP traffic extension ${readiness.projectId}/${readiness.extensionName}`;
+  }
+}
+
+function readinessFix(
+  readiness: Exclude<RoutingReadiness, { kind: "gcp-traffic-extension" }>,
+): string {
+  if (readiness.kind === "kubernetes-service-endpoints") {
+    return `kubectl get endpointslice -n ${readiness.service.namespace} -l kubernetes.io/service-name=${readiness.service.name}`;
+  }
+  const namespace = readiness.object.namespace ? ` -n ${readiness.object.namespace}` : "";
+  return `kubectl describe ${readiness.object.resource} ${readiness.object.name}${namespace}`;
+}
+
+/** Exact, lossless operation inventory for describe/tail/destroy consumers. */
+export function describeCompositionPlan(plan: CompositionPlan): CompositionPlanDescription {
+  const lifecycle = new Map(
+    plan.operations.cleanup.kubernetes.contributedObjects.map((owned) => [
+      `${owned.ref.apiVersion}|${owned.ref.resource}|${owned.ref.namespace ?? ""}|${owned.ref.name}`,
+      owned.lifecycle,
+    ]),
+  );
+  return {
+    resources: plan.operations.resources.objects.map((object) => ({
+      ref: {
+        apiVersion: object.apiVersion,
+        resource: object.resource,
+        name: object.metadata.name,
+        ...(object.metadata.namespace ? { namespace: object.metadata.namespace } : {}),
+      },
+      lifecycle:
+        lifecycle.get(
+          `${object.apiVersion}|${object.resource}|${object.metadata.namespace ?? ""}|${object.metadata.name}`,
+        ) ?? "apply",
+    })),
+    logs: plan.operations.logs.map((source) => ({
+      namespace: source.namespace,
+      selector: `adapter-k8s.dev/release=${source.selector.releaseName}`,
+      containers: source.containers,
+    })),
+    cleanup: {
+      kubernetes: plan.operations.cleanup.kubernetes.contributedObjects.map((entry) => ({
+        ...entry,
+        ref: { ...entry.ref },
+        ownership: {
+          releaseLabel: { ...entry.ownership.releaseLabel },
+          ...(entry.ownership.helmRelease
+            ? { helmRelease: { ...entry.ownership.helmRelease } }
+            : {}),
+        },
+      })),
+      external: plan.operations.cleanup.external.map((entry) => ({ ...entry })),
+      retained: plan.operations.cleanup.retained.map((entry) => ({ ...entry })),
+    },
+  };
+}

--- a/src/cli/deploy.ts
+++ b/src/cli/deploy.ts
@@ -1,5 +1,6 @@
 // src/cli/deploy.ts
 import path from "node:path";
+import { isIP } from "node:net";
 import { infrastructurePath, outputDirName } from "./infrastructure-validation.js";
 import {
   chmodSync,
@@ -81,6 +82,15 @@ import {
   type TargetPlatform,
 } from "../target-platform.js";
 import type { GcloudCommand } from "./init.js";
+import type { RegistryAuthentication, RegistryDigestLookup } from "../composition-plan/index.js";
+import {
+  assertCompositionPlanInvocation,
+  compositionPlanNeedsExplicitConfirmation,
+  currentKubeContext,
+  loadLocalCompositionPlan,
+  preflightCompositionPlan,
+  waitForCompositionPlanReadiness,
+} from "./composition-plan.js";
 
 /**
  * How long to wait for a Deployment rollout.
@@ -306,6 +316,10 @@ export interface DockerCommandOptions {
   containerCli?: string;
   /** Platform recorded by the build artifact; never re-infer it from the deploy host. */
   targetPlatform?: TargetPlatform;
+  /** Exact authentication operation declared by a composed target. Omitted for legacy builds. */
+  registryAuthentication?: RegistryAuthentication;
+  /** Portable routing has no routing-service workload or image. */
+  includeRoutingService?: boolean;
 }
 
 /**
@@ -389,11 +403,22 @@ export function buildDockerCommands(options: DockerCommandOptions): GcloudComman
   // the registry's business: for anything non-Google we assume the operator's existing
   // credential setup (docker login, ECR credential helper, az acr login, a pull secret) — the
   // same assumption every other tool makes.
-  const registryHost = registry.split("/")[0];
-  const isGoogleRegistry =
-    !!registryHost &&
-    (registryHost.endsWith("-docker.pkg.dev") || /(^|\.)gcr\.io$/.test(registryHost));
-  if (registryHost && isGoogleRegistry) {
+  const registryHost = registry.split("/")[0]!;
+  const authentication = options.registryAuthentication;
+  const shouldConfigureGcloud = authentication
+    ? authentication.kind === "gcloud-docker-helper"
+    : registryHost.endsWith("-docker.pkg.dev") || /(^|\.)gcr\.io$/.test(registryHost);
+  if (
+    authentication?.kind === "gcloud-docker-helper" &&
+    authentication.registryHost !== registryHost
+  ) {
+    throw new Error(
+      `Composition plan registry authentication names host ` +
+        `${JSON.stringify(authentication.registryHost)}, but the image repository uses ` +
+        `${JSON.stringify(registryHost)}. Rebuild the target plan.`,
+    );
+  }
+  if (shouldConfigureGcloud) {
     commands.push({
       description: `Configure Docker authentication for ${registryHost}`,
       command: "gcloud",
@@ -429,26 +454,27 @@ export function buildDockerCommands(options: DockerCommandOptions): GcloudComman
     }
   }
 
-  // Always build routing service image
-  const routingTag = `${registry}/routing-service:${buildId}`;
-  commands.push({
-    description: "Build routing service image",
-    command: cli,
-    args: [
-      "build",
-      platformArg,
-      "-f",
-      `${outputDir}/routing-service/Dockerfile`,
-      "-t",
-      routingTag,
-      `${outputDir}/routing-service`,
-    ],
-  });
-  commands.push({
-    description: "Push routing service image",
-    command: cli,
-    args: ["push", routingTag],
-  });
+  if (options.includeRoutingService !== false) {
+    const routingTag = `${registry}/routing-service:${buildId}`;
+    commands.push({
+      description: "Build routing service image",
+      command: cli,
+      args: [
+        "build",
+        platformArg,
+        "-f",
+        `${outputDir}/routing-service/Dockerfile`,
+        "-t",
+        routingTag,
+        `${outputDir}/routing-service`,
+      ],
+    });
+    commands.push({
+      description: "Push routing service image",
+      command: cli,
+      args: ["push", routingTag],
+    });
+  }
 
   return commands;
 }
@@ -519,6 +545,7 @@ export async function resolveDeployImageDigests(opts: {
   allowMutableTags?: boolean;
   containerCli?: string;
   targetPlatform?: TargetPlatform;
+  digestLookup?: RegistryDigestLookup;
 }): Promise<Record<string, string>> {
   const digests: Record<string, string> = {};
   const unresolved: string[] = [];
@@ -544,8 +571,16 @@ export async function resolveDeployImageDigests(opts: {
     // can rewrite the manifest. An unreliable digest is worse than none — it deploys and then
     // ImagePullBackOffs at rollout, after cutover has started, whereas refusing fails at deploy
     // time with something actionable.
+    const artifactRegistryProject =
+      opts.digestLookup?.kind === "gcp-artifact-registry"
+        ? opts.digestLookup.projectId
+        : opts.digestLookup?.kind === "oci-distribution"
+          ? null
+          : opts.projectId;
     const digest =
-      (await resolveRegistryDigest(ref, opts.projectId, platform, cli)) ??
+      (artifactRegistryProject !== null
+        ? await resolveRegistryDigest(ref, artifactRegistryProject, platform, cli)
+        : null) ??
       (await resolveRegistryDigestAny(ref, cli, platform)) ??
       (cli === "docker" ? await resolveImageDigest(ref, cli, platform) : null);
     if (digest) digests[key] = digest;
@@ -1228,6 +1263,44 @@ export async function discoverNodeCidrsFromCluster(): Promise<string | null> {
   return seen.length > 0 ? seen.join(",") : null;
 }
 
+/** Discover the pod CIDRs declared by the Kubernetes Nodes, without assuming a cloud provider. */
+export async function discoverPodCidrsFromCluster(): Promise<string | null> {
+  const result = await execCapture("kubectl", ["get", "nodes", "-o", "json"]).catch(() => null);
+  if (!result || result.exitCode !== 0) return null;
+  let object: { items?: Array<{ spec?: { podCIDR?: unknown; podCIDRs?: unknown } }> };
+  try {
+    object = JSON.parse(result.stdout);
+  } catch {
+    return null;
+  }
+  const cidrs: string[] = [];
+  for (const node of object.items ?? []) {
+    const candidates = Array.isArray(node.spec?.podCIDRs)
+      ? node.spec.podCIDRs
+      : node.spec?.podCIDR !== undefined
+        ? [node.spec.podCIDR]
+        : [];
+    for (const candidate of candidates) {
+      if (typeof candidate !== "string") return null;
+      const [address, prefix, extra] = candidate.split("/");
+      const family = address ? isIP(address) : 0;
+      const bits = Number(prefix);
+      if (
+        extra !== undefined ||
+        family === 0 ||
+        !Number.isInteger(bits) ||
+        bits < 0 ||
+        (family === 4 && bits > 32) ||
+        (family === 6 && bits > 128)
+      ) {
+        return null;
+      }
+      if (!cidrs.includes(candidate)) cidrs.push(candidate);
+    }
+  }
+  return cidrs.length > 0 ? cidrs.join(",") : null;
+}
+
 /**
  * S22: discover the range(s) the cluster's NODES draw their IPs from, for the strict
  * NetworkPolicy posture's kubelet allowance. Same fail-closed contract as
@@ -1442,6 +1515,21 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
   // H2: the buildId comes from generateBuildId()/git refs and is spliced into helm
   // --set assignments and image tags — reject helm/shell metacharacters up front.
   assertSafeBuildId(buildId);
+  const compositionSnapshot = loadLocalCompositionPlan(outputDir, metadata);
+  if (compositionSnapshot) {
+    assertCompositionPlanInvocation(compositionSnapshot.plan, {
+      releaseName,
+      namespace,
+      buildId,
+    });
+    if (compositionSnapshot.plan.target.registry.repository !== infra.containerRegistry) {
+      throw new Error(
+        `Composition plan registry ${JSON.stringify(compositionSnapshot.plan.target.registry.repository)} ` +
+          `does not match infrastructure registry ${JSON.stringify(infra.containerRegistry)}. ` +
+          `Rebuild for the selected target.`,
+      );
+    }
+  }
   const pools: string[] = metadata.pools;
   const defaultPool: string | undefined =
     typeof metadata.defaultPool === "string" ? metadata.defaultPool : pools?.[0];
@@ -1527,53 +1615,30 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
   // GKE pinning and helm-upgraded whatever context was current; gke→generic pinned the GKE
   // cluster). Nothing here touches the cluster before this point, so ordering it after the build
   // costs nothing.
-  const targetsGke = buildProvider === "gke";
-  const canPinContext = Boolean(targetsGke && infra.projectId && infra.region && releaseName);
-  if (!dryRun && canPinContext) {
-    const clusterName = `${releaseName}-cluster`;
-    console.log(`\n  → Connecting to GKE cluster "${clusterName}"...`);
-    await execOrThrow("gcloud", [
-      "container",
-      "clusters",
-      "get-credentials",
-      clusterName,
-      "--region",
-      infra.region!,
-      "--project",
-      infra.projectId!,
-      "--quiet",
-    ]);
-  } else if (!canPinContext) {
-    // N29: context pinning is IMPOSSIBLE (no projectId/region in infrastructure.json), so
-    // EVERYTHING below — helm upgrade, the Service selector patches, the state ConfigMap
-    // write — would run against whatever kubectl context happens to be current. This
-    // silently-skipped get-credentials is the same hole destroy's C1 guard closed; deploy
-    // had no equivalent (invariant 6). Surface the context and require confirmation.
+  if (compositionSnapshot) {
     if (dryRun) {
       console.log(
-        `  [dry-run] infrastructure.json is missing projectId/region — kubectl context ` +
-          `pinning is impossible. A real deploy would target whatever kubectl context is ` +
-          `current (and ask you to confirm it).`,
+        `  [dry-run] verified composition plan ${compositionSnapshot.digest}; a real deploy ` +
+          `would verify cluster identity, Kubernetes ` +
+          `${compositionSnapshot.plan.requirements.kubernetes.minimumVersion}+, and every ` +
+          `required API before mutating the release.`,
       );
     } else {
-      const ctx = await execCapture("kubectl", ["config", "current-context"]).catch(() => null);
-      // L14: the context name is kubeconfig-sourced — strip terminal control chars.
-      const currentContext =
-        ctx && ctx.exitCode === 0 ? sanitizeForTerminal(ctx.stdout.trim()) : "";
-      console.warn(
-        `\n  !!! WARNING: infrastructure.json is missing projectId/region, so kubectl could ` +
-          `NOT be pinned to this release's cluster.\n` +
-          `      The ENTIRE deploy (helm upgrade, Service selector cutover, deploy-state ` +
-          `ConfigMap) will run against your CURRENT kubectl context:\n` +
-          `      ${currentContext || "(no current context / kubectl unavailable)"}\n`,
-      );
-      if (!yes) {
+      let explicitlyConfirmed = yes === true;
+      if (
+        compositionPlanNeedsExplicitConfirmation(compositionSnapshot.plan) &&
+        !explicitlyConfirmed
+      ) {
+        const context = await currentKubeContext();
+        console.warn(
+          `\n  !!! WARNING: the composition plan cannot prove that the current kubectl ` +
+            `context is the intended cluster:\n      ${context ?? "(no current context / kubectl unavailable)"}\n`,
+        );
         if (!process.stdin.isTTY) {
           throw new Error(
-            "Refusing to deploy against an unpinned kubectl context non-interactively. " +
-              "Restore projectId/region in .k8s-adapter/infrastructure.json (re-run " +
-              "`npx adapter-k8s init`) so the context can be pinned, or re-run with --yes " +
-              "only if the context above is the intended cluster.",
+            "Refusing to deploy an explicitly-unverified composition plan non-interactively. " +
+              "Use a verifiable cluster identity, or re-run with --yes only after confirming " +
+              "the context above.",
           );
         }
         const answer = await promptConfirmation(
@@ -1581,11 +1646,92 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
         );
         if (answer.trim() !== "yes") {
           throw new Error(
-            "Deploy aborted: the current kubectl context was not confirmed as the intended " +
-              "cluster. Nothing was changed.",
+            "Deploy aborted: the composition plan's cluster identity was not explicitly " +
+              "confirmed. Nothing was changed.",
           );
         }
+        explicitlyConfirmed = true;
         console.log("");
+      }
+      const preflight = await preflightCompositionPlan(compositionSnapshot.plan, {
+        explicitlyConfirmed,
+      });
+      console.log(
+        `\n  → Composition plan verified: ${preflight.clusterIdentity}; Kubernetes ` +
+          `${preflight.serverVersion}`,
+      );
+      if (preflight.missingOptional.length > 0) {
+        console.warn(
+          `  ! Optional Kubernetes APIs unavailable: ${preflight.missingOptional
+            .map((entry) => `${entry.apiVersion}/${entry.resource}`)
+            .join(", ")}`,
+        );
+      }
+    }
+  } else {
+    // Compatibility path for artifacts emitted before composition plans. New targets carry an
+    // exact access/identity operation above; legacy metadata still uses the historical provider
+    // marker until it is rebuilt.
+    const targetsGke = buildProvider === "gke";
+    const canPinContext = Boolean(targetsGke && infra.projectId && infra.region && releaseName);
+    if (!dryRun && canPinContext) {
+      const clusterName = `${releaseName}-cluster`;
+      console.log(`\n  → Connecting to GKE cluster "${clusterName}"...`);
+      await execOrThrow("gcloud", [
+        "container",
+        "clusters",
+        "get-credentials",
+        clusterName,
+        "--region",
+        infra.region!,
+        "--project",
+        infra.projectId!,
+        "--quiet",
+      ]);
+    } else if (!canPinContext) {
+      // N29: context pinning is IMPOSSIBLE (no projectId/region in infrastructure.json), so
+      // EVERYTHING below — helm upgrade, the Service selector patches, the state ConfigMap
+      // write — would run against whatever kubectl context happens to be current. This
+      // silently-skipped get-credentials is the same hole destroy's C1 guard closed; deploy
+      // had no equivalent (invariant 6). Surface the context and require confirmation.
+      if (dryRun) {
+        console.log(
+          `  [dry-run] infrastructure.json is missing projectId/region — kubectl context ` +
+            `pinning is impossible. A real deploy would target whatever kubectl context is ` +
+            `current (and ask you to confirm it).`,
+        );
+      } else {
+        const ctx = await execCapture("kubectl", ["config", "current-context"]).catch(() => null);
+        // L14: the context name is kubeconfig-sourced — strip terminal control chars.
+        const currentContext =
+          ctx && ctx.exitCode === 0 ? sanitizeForTerminal(ctx.stdout.trim()) : "";
+        console.warn(
+          `\n  !!! WARNING: infrastructure.json is missing projectId/region, so kubectl could ` +
+            `NOT be pinned to this release's cluster.\n` +
+            `      The ENTIRE deploy (helm upgrade, Service selector cutover, deploy-state ` +
+            `ConfigMap) will run against your CURRENT kubectl context:\n` +
+            `      ${currentContext || "(no current context / kubectl unavailable)"}\n`,
+        );
+        if (!yes) {
+          if (!process.stdin.isTTY) {
+            throw new Error(
+              "Refusing to deploy against an unpinned kubectl context non-interactively. " +
+                "Restore projectId/region in .k8s-adapter/infrastructure.json (re-run " +
+                "`npx adapter-k8s init`) so the context can be pinned, or re-run with --yes " +
+                "only if the context above is the intended cluster.",
+            );
+          }
+          const answer = await promptConfirmation(
+            `  Type "yes" to confirm this kubectl context is the intended cluster: `,
+          );
+          if (answer.trim() !== "yes") {
+            throw new Error(
+              "Deploy aborted: the current kubectl context was not confirmed as the intended " +
+                "cluster. Nothing was changed.",
+            );
+          }
+          console.log("");
+        }
       }
     }
   }
@@ -1616,7 +1762,68 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
   // entirely, so the secure posture is what an ordinary deploy gets.
   let podCidr: string | null = null;
   let nodeCidr: string | null = null;
-  if (!dryRun && infra.projectId && infra.region && releaseName) {
+  if (!dryRun && compositionSnapshot) {
+    const network = compositionSnapshot.plan.operations.network;
+    const resolvePlanSource = async (
+      source: typeof network.podCidrs,
+      purpose: "pod" | "node",
+    ): Promise<string | null> => {
+      switch (source.kind) {
+        case "not-required":
+          return null;
+        case "static":
+          return source.cidrs.join(",");
+        case "kubernetes-node-pod-cidrs":
+          return discoverPodCidrsFromCluster();
+        case "kubernetes-node-addresses":
+          return discoverNodeCidrsFromCluster();
+        case "gke-pod-range":
+          if (source.location.kind !== "region") {
+            throw new Error(
+              `Composition-plan ${purpose} CIDR discovery uses a zonal GKE location, but ` +
+                `the current GKE discovery operation requires a region. Rebuild with a ` +
+                `regional target or configure static CIDRs.`,
+            );
+          }
+          return discoverClusterPodCidr({
+            clusterName: source.clusterName,
+            region: source.location.name,
+            projectId: source.projectId,
+            allowNoNetworkPolicy: allowNoNetworkPolicy ?? false,
+          });
+        case "gke-node-subnet":
+          if (source.location.kind !== "region") {
+            throw new Error(
+              `Composition-plan ${purpose} CIDR discovery uses a zonal GKE location, but ` +
+                `the current GKE discovery operation requires a region. Rebuild with a ` +
+                `regional target or configure static CIDRs.`,
+            );
+          }
+          return discoverClusterNodeCidrs({
+            clusterName: source.clusterName,
+            region: source.location.name,
+            projectId: source.projectId,
+            allowNoNetworkPolicy: allowNoNetworkPolicy ?? false,
+          });
+      }
+    };
+    podCidr = await resolvePlanSource(network.podCidrs, "pod");
+    nodeCidr = await resolvePlanSource(network.nodeCidrs, "node");
+    for (const [purpose, source, resolved] of [
+      ["pod", network.podCidrs, podCidr],
+      ["node", network.nodeCidrs, nodeCidr],
+    ] as const) {
+      if (source.kind !== "not-required" && !resolved && !allowNoNetworkPolicy) {
+        throw new Error(
+          `Composition-plan ${purpose} CIDR source ${source.kind} returned no ranges. The ` +
+            `plan's missingSourcePolicy is fail, so refusing to deploy without network ` +
+            `isolation. Fix cluster access, configure static CIDRs, or explicitly pass ` +
+            `--allow-no-network-policy.`,
+        );
+      }
+    }
+  } else if (!dryRun && infra.projectId && infra.region && releaseName) {
+    // Legacy artifacts predate typed network sources and use the historical GKE convention.
     podCidr = await discoverClusterPodCidr({
       clusterName: `${releaseName}-cluster`,
       region: infra.region,
@@ -1756,7 +1963,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
     // its old mode, so a previously world-readable secret file would stay that way.
     chmodSync(secretPath, 0o600);
     console.log(`    Cache Secret ${releaseName}-valkey staged for Helm → ${url}`);
-  } else if (!cacheManaged && !dryRun) {
+  } else if (!compositionSnapshot && !cacheManaged && !dryRun) {
     // The current build is NOT using the managed cache (disabled entirely, or BYO via
     // cache.url). If a managed Memorystore was previously provisioned for this release
     // (infra.cacheRegion persisted at provision time), tear it down — otherwise the
@@ -1832,6 +2039,13 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
       containerStrategy,
       containerCli,
       targetPlatform: builtTargetPlatform,
+      ...(compositionSnapshot
+        ? {
+            registryAuthentication: compositionSnapshot.plan.target.registry.authentication,
+            includeRoutingService:
+              compositionSnapshot.plan.operations.routing.protocol !== "pool-local-v1",
+          }
+        : {}),
     });
 
     for (const cmd of dockerCommands) {
@@ -1859,7 +2073,12 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
       containerStrategy === "shared-image"
         ? pools.map((p) => [p, `${registry}/nextjs-app:${buildId}`])
         : pools.map((p) => [p, `${registry}/nextjs-app-${p}:${buildId}`]);
-    refs.push(["routingService", `${registry}/routing-service:${buildId}`]);
+    if (
+      !compositionSnapshot ||
+      compositionSnapshot.plan.operations.routing.protocol !== "pool-local-v1"
+    ) {
+      refs.push(["routingService", `${registry}/routing-service:${buildId}`]);
+    }
     Object.assign(
       imageDigests,
       await resolveDeployImageDigests({
@@ -1869,15 +2088,27 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
         allowMutableTags: allowMutableTags ?? false,
         containerCli,
         targetPlatform: builtTargetPlatform,
+        ...(compositionSnapshot
+          ? { digestLookup: compositionSnapshot.plan.target.registry.digestLookup }
+          : {}),
       }),
     );
     const pinned = Object.keys(imageDigests).length;
     if (pinned > 0) console.log(`    Pinned ${pinned} image(s) to immutable digests`);
   }
 
-  // 5. Pre-flight: ensure static IP exists (Gateway needs it)
-  if (!dryRun && infra.projectId) {
-    const ipName = `${releaseName}-ip`;
+  // 5. Pre-flight: ensure the exact address named by a GCP traffic-extension plan exists.
+  // Legacy artifacts retain their historical infrastructure-derived convention.
+  const plannedTrafficExtension = compositionSnapshot
+    ? compositionSnapshot.plan.operations.routing.dataplane.readiness.find(
+        (entry) => entry.kind === "gcp-traffic-extension",
+      )
+    : undefined;
+  const addressProject =
+    plannedTrafficExtension?.projectId ?? (!compositionSnapshot ? infra.projectId : undefined);
+  const addressName = plannedTrafficExtension?.addressName ?? `${releaseName}-ip`;
+  if (!dryRun && addressProject) {
+    const ipName = addressName;
     const ipCheck = await execCapture("gcloud", [
       "compute",
       "addresses",
@@ -1885,7 +2116,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
       ipName,
       "--global",
       "--project",
-      infra.projectId,
+      addressProject,
       "--format=value(address)",
     ]);
     if (ipCheck.exitCode !== 0) {
@@ -1897,7 +2128,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
         ipName,
         "--global",
         "--project",
-        infra.projectId,
+        addressProject,
         "--quiet",
       ]);
     }
@@ -2835,6 +3066,23 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
       console.log("  → ext_proc EnvoyExtensionPolicy accepted ✓");
     }
 
+    if (compositionSnapshot) {
+      console.log("  → Verifying composition-plan readiness...");
+      try {
+        await waitForCompositionPlanReadiness(compositionSnapshot.plan);
+      } catch (error) {
+        const edge = await restoreEdgeToPreviousBuild();
+        throw new Error(
+          [
+            `Composition-plan readiness failed; refusing traffic cutover: ` +
+              `${error instanceof Error ? error.message : String(error)}`,
+            ...edgeStatusLines(edge),
+          ].join("\n"),
+        );
+      }
+      console.log("  → Composition-plan resources are ready ✓");
+    }
+
     // 7a-ter. N64: match the outgoing build's CAPACITY before the gate below can pass.
     // The chart renders a new build at its HPA floor (`replicas.min`), while the build
     // being replaced may be sitting far above that after autoscaling under load. Cutting
@@ -3443,6 +3691,19 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
         ...(state?.unretainedManifestBuilds ?? []).filter((b) => b === previousBuildId),
         ...(unretainedManifestBuild ? [unretainedManifestBuild] : []),
       ].filter((b, i, all) => all.indexOf(b) === i);
+      const compositionPlans: NonNullable<AdapterState["compositionPlans"]> = {};
+      const previousCompositionPlan = previousBuildId
+        ? state?.compositionPlans?.[previousBuildId]
+        : undefined;
+      if (previousBuildId && previousCompositionPlan) {
+        compositionPlans[previousBuildId] = previousCompositionPlan;
+      }
+      if (compositionSnapshot) {
+        compositionPlans[buildId] = {
+          digest: compositionSnapshot.digest,
+          targetFingerprint: compositionSnapshot.plan.target.fingerprint,
+        };
+      }
       await writeState(
         projectDir,
         {
@@ -3468,6 +3729,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
               }
             : {}),
           targetPlatforms,
+          ...(Object.keys(compositionPlans).length > 0 ? { compositionPlans } : {}),
           // The build this deploy just installed serves /readyz, so the NEXT deploy can flip
           // the load balancer's HealthCheckPolicy to readiness without stranding it.
           readinessPathSupported: true,
@@ -3512,7 +3774,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
     // are dropped — but after the state commit (7d) so a failure here can't leave
     // cluster state pointing at the outgoing build.
     const cdnFilterPath = path.join(outputDir, "chart", "templates", "cdn-http-filter.yaml");
-    if (existsSync(cdnFilterPath) && infra.projectId) {
+    if (!compositionSnapshot && existsSync(cdnFilterPath) && infra.projectId) {
       try {
         await invalidateCdnBuildTag({
           projectId: infra.projectId,

--- a/src/cli/describe.ts
+++ b/src/cli/describe.ts
@@ -10,6 +10,13 @@ import {
   infrastructurePath,
   outputDirName,
 } from "./infrastructure-validation.js";
+import {
+  describeCompositionPlan,
+  loadDeployedCompositionPlan,
+  loadProjectCompositionPlan,
+  preflightCompositionPlan,
+} from "./composition-plan.js";
+import type { CompositionPlan } from "../composition-plan/index.js";
 
 // Name the file in parse errors — a bare SyntaxError from JSON.parse gives no clue
 // WHICH file is corrupt.
@@ -37,13 +44,25 @@ export async function runDescribe(options: {
     : null;
   // S13: validate before any of these reach a gcloud/kubectl argv.
   assertSafeInfrastructure(infra);
-  const namespace = resolveK8sNamespace(infra?.namespace);
+  const localComposition = loadProjectCompositionPlan(projectDir);
+  const namespace =
+    localComposition?.plan.metadata.namespace ?? resolveK8sNamespace(infra?.namespace);
 
   // Ensure kubectl is pointing at the right cluster BEFORE reading state — readState
   // prefers the cluster ConfigMap, and with kubectl still pinned to a stale context it
   // would read (or miss) state on the WRONG cluster (the bug class AGENTS.md invariant 6
   // covers; rollback was fixed for it, describe had the same ordering flaw).
-  if (infra?.projectId && infra?.region) {
+  if (localComposition) {
+    try {
+      await preflightCompositionPlan(localComposition.plan, { explicitlyConfirmed: true });
+    } catch (error) {
+      console.error(
+        `Failed to access composition target: ` +
+          `${sanitizeForTerminal(error instanceof Error ? error.message : String(error))}`,
+      );
+      process.exit(1);
+    }
+  } else if (infra?.projectId && infra?.region) {
     const credResult = await execCapture("gcloud", [
       "container",
       "clusters",
@@ -85,6 +104,40 @@ export async function runDescribe(options: {
   const previousBuildId = state?.previousBuildId
     ? sanitizeForTerminal(state.previousBuildId)
     : null;
+  // Style
+  const d = "\x1b[2m";
+  const b = "\x1b[1m";
+  const g = "\x1b[32m";
+  const y = "\x1b[33m";
+  const r = "\x1b[31m";
+  const c = "\x1b[36m";
+  const x = "\x1b[0m";
+  let compositionSummary = "";
+  let compositionPlan: CompositionPlan | null = null;
+  if (state?.buildId) {
+    try {
+      const snapshot = await loadDeployedCompositionPlan({
+        releaseName,
+        namespace,
+        buildId: state.buildId,
+        ...(state.compositionPlans?.[state.buildId]
+          ? { expected: state.compositionPlans[state.buildId] }
+          : {}),
+      });
+      if (snapshot) {
+        compositionPlan = snapshot.plan;
+        const description = describeCompositionPlan(snapshot.plan);
+        compositionSummary =
+          `\n${d}Plan:    ${snapshot.digest}  ${description.resources.length} resources, ` +
+          `${description.logs.length} log sources, ` +
+          `${description.cleanup.kubernetes.length + description.cleanup.external.length} cleanup operations${x}`;
+      }
+    } catch (error) {
+      compositionSummary =
+        `\n${r}Plan:    invalid deployed snapshot — ` +
+        `${sanitizeForTerminal(error instanceof Error ? error.message : String(error))}${x}`;
+    }
+  }
 
   // Read generated CEL expression from build output
   const celPath = path.join(projectDir, ".k8s-adapter", outputDirName(), "cel-expression.txt");
@@ -93,7 +146,8 @@ export async function runDescribe(options: {
   let gatewayIp = "pending";
   let certStatus = "unknown";
 
-  if (infra?.projectId) {
+  const compositionUsesGcp = compositionPlan?.target.identity.kind === "gke-resource";
+  if (infra?.projectId && (!localComposition || compositionUsesGcp)) {
     const ipResult = await execCapture("gcloud", [
       "compute",
       "addresses",
@@ -176,15 +230,6 @@ export async function runDescribe(options: {
     }
   }
 
-  // Style
-  const d = "\x1b[2m";
-  const b = "\x1b[1m";
-  const g = "\x1b[32m";
-  const y = "\x1b[33m";
-  const r = "\x1b[31m";
-  const c = "\x1b[36m";
-  const x = "\x1b[0m";
-
   function icon(dep: DeployInfo): string {
     const { status, role } = dep;
     // Scaled to 0 is expected for previous/old — not an error
@@ -212,7 +257,7 @@ export async function runDescribe(options: {
   console.log(`
 ${b}${c}${releaseName}${x} ${d}— @next-community/adapter-k8s${x}
 ${d}Project: ${projectId}  Region: ${region}${x}
-${d}Build:   ${buildId}${previousBuildId ? `  Previous: ${previousBuildId}` : ""}${x}
+${d}Build:   ${buildId}${previousBuildId ? `  Previous: ${previousBuildId}` : ""}${x}${compositionSummary}
 
 ${b}Request Flow${x}
 
@@ -238,23 +283,32 @@ ${b}Request Flow${x}
     `${c}${celDisplay}${x}`,
   ].join("\n");
 
-  const albContent = [
-    `${b}GCP Application Load Balancer${x}`,
-    `${d}IP: ${gatewayIp}   TLS: ${certStatus}${x}`,
-    ``,
-    boxen(celSection, {
-      padding: { left: 1, right: 1, top: 0, bottom: 0 },
-      borderStyle: "single",
-      dimBorder: true,
-    }),
-    ``,
-    `    ${d}matched${x}              ${d}skipped${x}`,
-    `       ${d}│${x}                     ${d}│${x}`,
-    `       ${d}▼${x}                     ${d}▼${x}`,
-    `  ${c}ext_proc${x} ${d}(gRPC)${x} ──▶ ${c}URL Map / HTTPRoute${x}`,
-    `                      ${d}x-upstream-pool → pool backend${x}`,
-    `                      ${d}path fallback → default pool${x}`,
-  ].join("\n");
+  const routing = compositionPlan?.operations.routing;
+  const albContent =
+    routing?.protocol === "pool-local-v1"
+      ? [
+          `${b}Kubernetes Exposure${x}`,
+          `${d}Portable HTTP origin; no Envoy or cloud routing service required${x}`,
+          ``,
+          `${c}${routing.dataplane.service.namespace}/${routing.dataplane.service.name}:${routing.dataplane.service.port}${x}`,
+          `${d}default pool: ${routing.dataplane.targetPool}${x}`,
+        ].join("\n")
+      : [
+          `${b}${compositionUsesGcp ? "GCP Application Load Balancer" : "Kubernetes Gateway"}${x}`,
+          ...(compositionUsesGcp ? [`${d}IP: ${gatewayIp}   TLS: ${certStatus}${x}`, ``] : []),
+          boxen(celSection, {
+            padding: { left: 1, right: 1, top: 0, bottom: 0 },
+            borderStyle: "single",
+            dimBorder: true,
+          }),
+          ``,
+          `    ${d}matched${x}              ${d}skipped${x}`,
+          `       ${d}│${x}                     ${d}│${x}`,
+          `       ${d}▼${x}                     ${d}▼${x}`,
+          `  ${c}ext_proc${x} ${d}(gRPC)${x} ──▶ ${c}HTTPRoute${x}`,
+          `                      ${d}x-upstream-pool → pool backend${x}`,
+          `                      ${d}path fallback → default pool${x}`,
+        ].join("\n");
 
   console.log(boxen(albContent, { padding: 1, borderStyle: "round" }));
 
@@ -279,7 +333,7 @@ ${b}Request Flow${x}
   ].join("\n");
 
   const gkeContent = [
-    `${b}GKE Cluster${x}`,
+    `${b}${compositionUsesGcp || !compositionPlan ? "GKE Cluster" : "Kubernetes Cluster"}${x}`,
     ``,
     boxen(routingSection, {
       padding: { left: 1, right: 1, top: 0, bottom: 0 },

--- a/src/cli/destroy.ts
+++ b/src/cli/destroy.ts
@@ -17,6 +17,19 @@ import {
   stablePoolResourceNames,
 } from "../emit/templates/utils.js";
 import { assertSafeInfrastructure, infrastructurePath } from "./infrastructure-validation.js";
+import { readState, StateUnavailableError } from "./state.js";
+import {
+  compositionPlanNeedsExplicitConfirmation,
+  loadDeployedCompositionPlan,
+  loadProjectCompositionPlan,
+  preflightCompositionPlan,
+  type LoadedCompositionPlan,
+} from "./composition-plan.js";
+import type {
+  ExternalCleanupOperation,
+  KubernetesOwnedObject,
+  RetainedExternalResource,
+} from "../composition-plan/index.js";
 
 export interface DestroyOptions {
   projectDir: string;
@@ -377,6 +390,207 @@ export function buildReleaseScopedGcpResources(
   ];
 }
 
+export function buildExternalCleanupCommand(operation: ExternalCleanupOperation): {
+  desc: string;
+  command: "gcloud";
+  args: string[];
+} {
+  switch (operation.kind) {
+    case "gcp-storage-bucket":
+      return {
+        desc: `GCS bucket "${operation.bucket}"`,
+        command: "gcloud",
+        args: [
+          "storage",
+          "rm",
+          "-r",
+          `gs://${operation.bucket}`,
+          `--project=${operation.projectId}`,
+          "--quiet",
+        ],
+      };
+    case "gcp-service-account":
+      return {
+        desc: `service account "${operation.email}"`,
+        command: "gcloud",
+        args: [
+          "iam",
+          "service-accounts",
+          "delete",
+          operation.email,
+          `--project=${operation.projectId}`,
+          "--quiet",
+        ],
+      };
+    case "gcp-memorystore":
+      return {
+        desc: `Memorystore instance "${operation.name}"`,
+        command: "gcloud",
+        args: [
+          "redis",
+          "instances",
+          "delete",
+          operation.name,
+          `--region=${operation.region}`,
+          `--project=${operation.projectId}`,
+          "--quiet",
+        ],
+      };
+    case "gcp-traffic-extension":
+      return {
+        desc: `traffic extension "${operation.name}"`,
+        command: "gcloud",
+        args: [
+          "service-extensions",
+          "lb-traffic-extensions",
+          "delete",
+          operation.name,
+          `--location=${operation.location}`,
+          `--project=${operation.projectId}`,
+          "--quiet",
+        ],
+      };
+    case "gcp-backend-service":
+      return {
+        desc: `backend service "${operation.name}"`,
+        command: "gcloud",
+        args: [
+          "compute",
+          "backend-services",
+          "delete",
+          operation.name,
+          `--${operation.scope}`,
+          `--project=${operation.projectId}`,
+          "--quiet",
+        ],
+      };
+    case "gcp-health-check":
+      return {
+        desc: `health check "${operation.name}"`,
+        command: "gcloud",
+        args: [
+          "compute",
+          "health-checks",
+          "delete",
+          operation.name,
+          `--${operation.scope}`,
+          `--project=${operation.projectId}`,
+          "--quiet",
+        ],
+      };
+    case "gcp-global-address":
+      return {
+        desc: `global address "${operation.name}"`,
+        command: "gcloud",
+        args: [
+          "compute",
+          "addresses",
+          "delete",
+          operation.name,
+          "--global",
+          `--project=${operation.projectId}`,
+          "--quiet",
+        ],
+      };
+    case "gcp-custom-iam-role":
+      return {
+        desc: `custom IAM role "${operation.roleId}"`,
+        command: "gcloud",
+        args: [
+          "iam",
+          "roles",
+          "delete",
+          operation.roleId,
+          `--project=${operation.projectId}`,
+          "--quiet",
+        ],
+      };
+  }
+}
+
+function retainedResourceGuidance(resource: RetainedExternalResource): {
+  description: string;
+  command: string;
+} {
+  switch (resource.kind) {
+    case "gke-cluster": {
+      const locationFlag = resource.location.kind === "zone" ? "--zone" : "--region";
+      return {
+        description: `GKE cluster "${resource.clusterName}"`,
+        command:
+          `gcloud container clusters delete ${resource.clusterName} ${locationFlag} ` +
+          `${resource.location.name} --project ${resource.projectId}`,
+      };
+    }
+    case "gcp-artifact-registry":
+      return {
+        description: `Artifact Registry "${resource.repository}"`,
+        command:
+          `gcloud artifacts repositories delete ${resource.repository} --location ` +
+          `${resource.region} --project ${resource.projectId}`,
+      };
+    case "gcp-certificate-manager":
+      return {
+        description: `Certificate Manager resources prefixed "${resource.releasePrefix}"`,
+        command:
+          `gcloud certificate-manager maps list --project ${resource.projectId} ` +
+          `--filter=name:${resource.releasePrefix}`,
+      };
+  }
+}
+
+export async function removePlannedKubernetesObject(
+  owned: KubernetesOwnedObject,
+  dryRun: boolean,
+): Promise<string | null> {
+  const ref = owned.ref;
+  const namespaceArgs = ref.namespace ? ["-n", ref.namespace] : [];
+  const getArgs = [
+    "get",
+    ref.resource,
+    ref.name,
+    ...namespaceArgs,
+    "--ignore-not-found",
+    "-o",
+    "json",
+  ];
+  if (dryRun) {
+    console.log(`  [dry-run] kubectl ${getArgs.join(" ")}`);
+    console.log(
+      `  [dry-run] would verify ${owned.ownership.releaseLabel.key}=` +
+        `${owned.ownership.releaseLabel.value} before exact deletion`,
+    );
+    return null;
+  }
+  const read = await execCapture("kubectl", getArgs);
+  if (read.exitCode !== 0) {
+    return `${ref.resource} ${ref.name}: ${sanitizeForTerminal(read.stderr.trim()) || `exit ${read.exitCode}`}`;
+  }
+  if (!read.stdout.trim()) return null;
+  let labels: Record<string, unknown> | undefined;
+  try {
+    labels = JSON.parse(read.stdout)?.metadata?.labels;
+  } catch {
+    return `${ref.resource} ${ref.name}: invalid Kubernetes object JSON`;
+  }
+  if (labels?.[owned.ownership.releaseLabel.key] !== owned.ownership.releaseLabel.value) {
+    return (
+      `${ref.resource} ${ref.name}: ownership label ` +
+      `${owned.ownership.releaseLabel.key} does not match ${owned.ownership.releaseLabel.value}`
+    );
+  }
+  const deleted = await execCapture("kubectl", [
+    "delete",
+    ref.resource,
+    ref.name,
+    ...namespaceArgs,
+    "--ignore-not-found",
+  ]);
+  return deleted.exitCode === 0
+    ? null
+    : `${ref.resource} ${ref.name}: ${sanitizeForTerminal(deleted.stderr.trim()) || `exit ${deleted.exitCode}`}`;
+}
+
 function promptConfirmation(question: string): Promise<string> {
   const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
   return new Promise((resolve) => {
@@ -398,6 +612,7 @@ export async function runDestroy(options: DestroyOptions): Promise<void> {
   const namespace = resolveK8sNamespace(infra?.namespace);
   const projectId: string | undefined = infra?.projectId;
   const region: string | undefined = infra?.region;
+  const localComposition = loadProjectCompositionPlan(projectDir);
 
   // L12: destroying is irreversible — gate it. --yes (or -y) skips the prompt and is
   // REQUIRED non-interactively; --dry-run never deletes and skips the gate entirely.
@@ -457,7 +672,34 @@ export async function runDestroy(options: DestroyOptions): Promise<void> {
   // current, and destroying the wrong cluster's release is unrecoverable. Every other
   // command (deploy/rollback/doctor) already does this; destroy historically did not.
   // Dry-run must not mutate the operator's kubeconfig (L13).
-  if (!dryRun && projectId && region) {
+  if (!dryRun && localComposition) {
+    let explicitlyConfirmed = yes === true;
+    if (compositionPlanNeedsExplicitConfirmation(localComposition.plan) && !explicitlyConfirmed) {
+      const ctx = await execCapture("kubectl", ["config", "current-context"]).catch(() => null);
+      const currentContext =
+        ctx && ctx.exitCode === 0 ? sanitizeForTerminal(ctx.stdout.trim()) : "";
+      console.warn(
+        `\n  !!! WARNING: the composition plan requires explicit confirmation of the ` +
+          `current kubectl context:\n      ${currentContext || "(unavailable)"}\n`,
+      );
+      const answer = await promptConfirmation(
+        `  Type "yes" to confirm this is the release's intended cluster: `,
+      );
+      if (answer.trim() !== "yes") {
+        throw new Error(
+          "Destroy aborted: the composition-plan cluster was not confirmed. No resources were deleted.",
+        );
+      }
+      explicitlyConfirmed = true;
+    }
+    const preflight = await preflightCompositionPlan(localComposition.plan, {
+      explicitlyConfirmed,
+    });
+    console.log(
+      `  → Composition plan verified: ${preflight.clusterIdentity}; Kubernetes ` +
+        `${preflight.serverVersion}`,
+    );
+  } else if (!dryRun && projectId && region) {
     const clusterName = `${releaseName}-cluster`;
     console.log(`  → Connecting to GKE cluster "${clusterName}"...`);
     const cred = await execCapture("gcloud", [
@@ -478,7 +720,12 @@ export async function runDestroy(options: DestroyOptions): Promise<void> {
       );
     }
   } else if (dryRun) {
-    if (projectId && region) {
+    if (localComposition) {
+      console.log(
+        `  [dry-run] Verified local composition plan ${localComposition.digest}; cluster ` +
+          `access and identity checks are skipped because they would read or change context.`,
+      );
+    } else if (projectId && region) {
       console.log(
         `  [dry-run] Skipping "gcloud container clusters get-credentials" (it would mutate your kubeconfig).`,
       );
@@ -525,6 +772,62 @@ export async function runDestroy(options: DestroyOptions): Promise<void> {
         );
       }
       console.log("");
+    }
+  }
+
+  // Retain verified plans in memory before any ConfigMap or Helm deletion. Cluster state may
+  // select label-verified Kubernetes objects, but external cleanup is authorized separately by
+  // the authenticated local build plan below.
+  const plannedSnapshots: LoadedCompositionPlan[] = localComposition ? [localComposition] : [];
+  let usesCompositionPlan = localComposition !== null;
+  if (!dryRun) {
+    const state = await readState(projectDir, releaseName, { namespace }).catch(
+      (error: unknown) => {
+        if (!(error instanceof StateUnavailableError)) throw error;
+        if (localComposition) {
+          console.warn(
+            `  ! Deploy state is unavailable; continuing from the locally verified composition ` +
+              `plan only: ${sanitizeForTerminal(error.message.split("\n")[0]!)}`,
+          );
+        }
+        return null;
+      },
+    );
+    if (state?.compositionPlans) {
+      usesCompositionPlan = true;
+      for (const buildId of [state.buildId, state.previousBuildId].filter(
+        (value): value is string => typeof value === "string",
+      )) {
+        const expected = state.compositionPlans[buildId];
+        if (!expected) continue;
+        if (
+          localComposition?.plan.metadata.buildId === buildId &&
+          (localComposition.digest !== expected.digest ||
+            localComposition.plan.target.fingerprint !== expected.targetFingerprint)
+        ) {
+          throw new Error(
+            `Local composition plan for ${buildId} does not match committed deploy state. ` +
+              `No resources were deleted.`,
+          );
+        }
+        const snapshot =
+          localComposition?.plan.metadata.buildId === buildId
+            ? localComposition
+            : await loadDeployedCompositionPlan({
+                releaseName,
+                namespace,
+                buildId,
+                expected,
+              });
+        if (!snapshot) {
+          throw new Error(
+            `Committed composition plan for ${buildId} is missing. No resources were deleted.`,
+          );
+        }
+        if (!plannedSnapshots.some((entry) => entry.digest === snapshot.digest)) {
+          plannedSnapshots.push(snapshot);
+        }
+      }
     }
   }
 
@@ -748,6 +1051,23 @@ export async function runDestroy(options: DestroyOptions): Promise<void> {
     }
   }
 
+  const plannedObjects = new Map<string, KubernetesOwnedObject>();
+  for (const snapshot of plannedSnapshots) {
+    for (const owned of snapshot.plan.operations.cleanup.kubernetes.contributedObjects) {
+      plannedObjects.set(
+        `${owned.ref.apiVersion}|${owned.ref.resource}|${owned.ref.namespace ?? ""}|${owned.ref.name}`,
+        owned,
+      );
+    }
+  }
+  for (const owned of plannedObjects.values()) {
+    const failure = await removePlannedKubernetesObject(owned, dryRun === true);
+    if (failure) {
+      console.warn(`    WARNING: planned Kubernetes cleanup failed: ${failure}`);
+      failures.push(failure);
+    }
+  }
+
   // 1b. Delete the adapter-written ConfigMaps helm doesn't own: the deploy-state
   // ConfigMap (state.ts writes it via kubectl apply) and any retained routing-manifest
   // snapshot ConfigMaps (rollback/deploy retention). A stale state ConfigMap otherwise
@@ -856,8 +1176,57 @@ export async function runDestroy(options: DestroyOptions): Promise<void> {
     }
   }
 
-  // 2. Clean up GCP resources from infrastructure.json
-  if (infra) {
+  const retainedResources = new Map<string, RetainedExternalResource>();
+  for (const snapshot of plannedSnapshots) {
+    for (const resource of snapshot.plan.operations.cleanup.retained) {
+      retainedResources.set(JSON.stringify(resource), resource);
+    }
+  }
+
+  // A plan retained in Kubernetes is useful for exact Kubernetes cleanup because every object is
+  // independently checked for its release ownership label before deletion. It is not authority to
+  // spend the operator's ambient cloud credentials: a namespace actor can rewrite both deploy state
+  // and retained plan ConfigMaps. Only operations also present in the authenticated local build
+  // artifact may execute automatically.
+  const locallyAuthorizedExternalOperations = new Set(
+    (localComposition?.plan.operations.cleanup.external ?? []).map((operation) =>
+      JSON.stringify(operation),
+    ),
+  );
+  const skippedExternalCleanup: ReturnType<typeof buildExternalCleanupCommand>[] = [];
+
+  // 2. Clean up external resources from the composition plan, or the legacy infrastructure file.
+  if (usesCompositionPlan) {
+    const operations = new Map<string, ExternalCleanupOperation>();
+    for (const snapshot of plannedSnapshots) {
+      for (const operation of snapshot.plan.operations.cleanup.external) {
+        operations.set(JSON.stringify(operation), operation);
+      }
+    }
+    for (const [operationKey, operation] of operations) {
+      const cleanup = buildExternalCleanupCommand(operation);
+      if (!locallyAuthorizedExternalOperations.has(operationKey)) {
+        skippedExternalCleanup.push(cleanup);
+        continue;
+      }
+      if (dryRun) {
+        console.log(`  [dry-run] ${cleanup.command} ${cleanup.args.join(" ")}`);
+        continue;
+      }
+      console.log(`  → Deleting ${cleanup.desc}`);
+      const result = await execCapture(cleanup.command, cleanup.args);
+      if (result.exitCode !== 0 && !isAlreadyGoneError(result.stderr)) {
+        console.warn(
+          `    WARNING: deletion failed: ` +
+            `${sanitizeForTerminal(result.stderr.trim()) || `exit ${result.exitCode}`}`,
+        );
+        failures.push(cleanup.desc);
+      }
+    }
+    if (operations.size === 0) {
+      console.log("  → No adapter-owned external cleanup operations in the composition plan");
+    }
+  } else if (infra) {
     // Delete GCS bucket
     if (infra.gcsBucket) {
       const bucketArgs = ["storage", "rm", "-r", `gs://${infra.gcsBucket}`, "--quiet"];
@@ -953,6 +1322,26 @@ export async function runDestroy(options: DestroyOptions): Promise<void> {
     }
   }
 
+  if (skippedExternalCleanup.length > 0) {
+    console.warn(
+      "\n  ! External cleanup was NOT executed because these operations were available only " +
+        "from cluster-writable deploy state and composition plans. Automatic execution requires " +
+        "the matching local build output to be present when destroy starts. Confirm each resource " +
+        `belongs to release "${releaseName}" before running these commands manually:`,
+    );
+    for (const cleanup of skippedExternalCleanup) {
+      console.warn(`    • ${cleanup.desc}: ${cleanup.command} ${cleanup.args.join(" ")}`);
+    }
+  }
+
+  if (retainedResources.size > 0) {
+    console.log("\n  Left in place by the composition plan (remove manually only if unused):");
+    for (const resource of retainedResources.values()) {
+      const guidance = retainedResourceGuidance(resource);
+      console.log(`    • ${guidance.description}: ${guidance.command}`);
+    }
+  }
+
   if (dryRun) {
     console.log(
       `\n[dry-run] No resources were deleted. Re-run without --dry-run (and with --yes ` +
@@ -981,12 +1370,22 @@ export async function runDestroy(options: DestroyOptions): Promise<void> {
   // releases and expensive/slow to recreate, so nuking them from a per-release `destroy` is
   // unsafe. Surface them with exact commands instead of silently leaving them AND deleting
   // the state needed to find them (the previous behavior).
-  console.log("\n✓ Removed: Helm release, retained pool rollout/rollback resources, GCS bucket,");
-  console.log("  both service accounts, and the release-scoped ext_proc resources");
-  console.log(
-    "  (traffic extension, routing backend, health check, static IP, custom IAM role).\n",
-  );
-  if (projectId) {
+  if (usesCompositionPlan) {
+    console.log(
+      skippedExternalCleanup.length > 0
+        ? "\n✓ Removed: Helm release, retained rollout/rollback resources, and verified " +
+            "Kubernetes cleanup. Cluster-only external cleanup was left for manual review.\n"
+        : "\n✓ Removed: Helm release, retained rollout/rollback resources, and every " +
+            "adapter-owned cleanup operation corroborated by the local composition plan.\n",
+    );
+  } else {
+    console.log("\n✓ Removed: Helm release, retained pool rollout/rollback resources, GCS bucket,");
+    console.log("  both service accounts, and the release-scoped ext_proc resources");
+    console.log(
+      "  (traffic extension, routing backend, health check, static IP, custom IAM role).\n",
+    );
+  }
+  if (!usesCompositionPlan && projectId) {
     console.log("  Left in place (shared / expensive — remove manually if truly unused):");
     console.log(
       `    • GKE cluster:        gcloud container clusters delete ${releaseName}-cluster --region ${region ?? "REGION"} --project ${projectId}`,
@@ -999,9 +1398,8 @@ export async function runDestroy(options: DestroyOptions): Promise<void> {
       `      authorizations named "${releaseName}-*" — list: gcloud certificate-manager maps list --project ${projectId}`,
     );
   }
-  // Preserve .k8s-adapter/infrastructure.json: it names the resources left above, so the
-  // manual commands and any retry stay possible. (Previously this was deleted, orphaning them.)
-  console.log(
-    `\n  Local state (.k8s-adapter) preserved so the resources above remain discoverable.\n`,
-  );
+  // Preserve .k8s-adapter/infrastructure.json: legacy targets need it to find retained resources,
+  // and composed targets may still have a local build plan there. Cluster-only plans are removed
+  // with the release, so their exact manual commands are printed above before returning.
+  console.log(`\n  Local state (.k8s-adapter) preserved.\n`);
 }

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -11,6 +11,15 @@ import {
   infrastructurePath,
   outputDirName,
 } from "./infrastructure-validation.js";
+import {
+  describeCompositionPlan,
+  evaluateCompositionPlanDiagnostics,
+  evaluateCompositionPlanReadiness,
+  inspectKubernetesRequirements,
+  loadDeployedCompositionPlan,
+  loadProjectCompositionPlan,
+  preflightCompositionPlan,
+} from "./composition-plan.js";
 
 // Name the file in parse errors — a bare SyntaxError from JSON.parse gives no clue
 // WHICH file is corrupt.
@@ -27,6 +36,34 @@ interface CheckResult {
   status: "pass" | "fail" | "warn";
   message: string;
   fix?: string;
+}
+
+function printCheckResults(results: CheckResult[]): void {
+  console.log("");
+  let fails = 0;
+  let warns = 0;
+  let checkCount = 0;
+  for (const result of results) {
+    if (result.name.startsWith("---")) {
+      console.log(`\n  \x1b[1m${result.name.replace(/^-+\s*/, "").replace(/\s*-+$/, "")}\x1b[0m`);
+      continue;
+    }
+    checkCount++;
+    const icon =
+      result.status === "pass"
+        ? "\x1b[32mPASS\x1b[0m"
+        : result.status === "warn"
+          ? "\x1b[33mWARN\x1b[0m"
+          : "\x1b[31mFAIL\x1b[0m";
+    console.log(`  ${icon}  ${result.name}: ${result.message}`);
+    if (result.fix && result.status !== "pass") console.log(`         Fix: ${result.fix}`);
+    if (result.status === "fail") fails++;
+    if (result.status === "warn") warns++;
+  }
+  console.log(
+    `\n  ${checkCount} checks: ${checkCount - fails - warns} passed, ${warns} warnings, ${fails} failures\n`,
+  );
+  if (fails > 0) process.exit(1);
 }
 
 async function checkTool(name: string, args: string[]): Promise<CheckResult> {
@@ -186,10 +223,32 @@ export async function runDoctor(options: {
   const { projectDir, releaseName } = options;
   const results: CheckResult[] = [];
   let namespace = resolveK8sNamespace();
+  const localComposition = loadProjectCompositionPlan(projectDir);
 
   // Ensure kubectl is pointing at the right cluster
   const infraPathForCtx = infrastructurePath(projectDir);
-  if (existsSync(infraPathForCtx)) {
+  if (localComposition) {
+    namespace = localComposition.plan.metadata.namespace;
+    try {
+      const preflight = await preflightCompositionPlan(localComposition.plan, {
+        // doctor is read-only; an unverified identity is reported as the current context rather
+        // than turning the diagnostic command into an interactive workflow.
+        explicitlyConfirmed: true,
+      });
+      results.push({
+        name: "Composition target",
+        status: "pass",
+        message: `${preflight.clusterIdentity}; Kubernetes ${preflight.serverVersion}`,
+      });
+    } catch (error) {
+      results.push({
+        name: "Composition target",
+        status: "fail",
+        message: sanitizeForTerminal(error instanceof Error ? error.message : String(error)),
+        fix: "Restore target cluster access or rebuild for the intended cluster",
+      });
+    }
+  } else if (existsSync(infraPathForCtx)) {
     const infraCtx = readJsonFile<{ projectId?: string; region?: string; namespace?: string }>(
       infraPathForCtx,
     );
@@ -225,7 +284,7 @@ export async function runDoctor(options: {
   console.log("\nRunning health checks...\n");
 
   // --- Prerequisites ---
-  results.push(await checkTool("gcloud", ["--version"]));
+  if (!localComposition) results.push(await checkTool("gcloud", ["--version"]));
   results.push(await checkTool("kubectl", ["version", "--client", "-o", "yaml"]));
   results.push(await checkTool("helm", ["version", "--short"]));
   // S24: any of docker/podman/nerdctl works, so check for a usable runtime rather than
@@ -304,7 +363,7 @@ export async function runDoctor(options: {
 
   // --- GCP resources (only if infrastructure.json exists) ---
   let projectId = "";
-  if (existsSync(infraPath)) {
+  if (!localComposition && existsSync(infraPath)) {
     const infra = readJsonFile<{
       projectId?: string;
       region?: string;
@@ -409,6 +468,63 @@ export async function runDoctor(options: {
   const kubectlOk = await execCapture("kubectl", ["cluster-info"]).catch(() => null);
   if (kubectlOk && kubectlOk.exitCode === 0) {
     results.push({ name: "K8s cluster", status: "pass", message: "Connected" });
+
+    if (state?.buildId) {
+      try {
+        const snapshot = await loadDeployedCompositionPlan({
+          releaseName,
+          namespace,
+          buildId: state.buildId,
+          ...(state.compositionPlans?.[state.buildId]
+            ? { expected: state.compositionPlans[state.buildId] }
+            : {}),
+        });
+        if (snapshot) {
+          const description = describeCompositionPlan(snapshot.plan);
+          results.push({
+            name: "Composition plan",
+            status: "pass",
+            message:
+              `${snapshot.digest} (${description.resources.length} contributed resources, ` +
+              `${description.cleanup.kubernetes.length + description.cleanup.external.length} cleanup operations)`,
+          });
+          try {
+            const compatibility = await inspectKubernetesRequirements(snapshot.plan);
+            results.push({
+              name: "Composition plan APIs",
+              status: compatibility.missingOptional.length > 0 ? "warn" : "pass",
+              message:
+                compatibility.missingOptional.length > 0
+                  ? `Kubernetes ${compatibility.serverVersion}; optional APIs missing: ` +
+                    compatibility.missingOptional
+                      .map((entry) => `${entry.apiVersion}/${entry.resource}`)
+                      .join(", ")
+                  : `Kubernetes ${compatibility.serverVersion}; all required APIs discovered`,
+            });
+          } catch (error) {
+            results.push({
+              name: "Composition plan APIs",
+              status: "fail",
+              message: sanitizeForTerminal(error instanceof Error ? error.message : String(error)),
+              fix: "Install the missing API/controller or rebuild for this cluster",
+            });
+          }
+          results.push(...(await evaluateCompositionPlanReadiness(snapshot.plan)));
+          results.push(...(await evaluateCompositionPlanDiagnostics(snapshot.plan)));
+        }
+      } catch (error) {
+        results.push({
+          name: "Composition plan",
+          status: "fail",
+          message: sanitizeForTerminal(error instanceof Error ? error.message : String(error)),
+          fix: "Rebuild and redeploy to replace the invalid retained plan snapshot",
+        });
+      }
+    }
+    if (localComposition) {
+      printCheckResults(results);
+      return;
+    }
 
     // Gateway
     const gwResult = await execCapture("kubectl", [
@@ -1181,37 +1297,7 @@ export async function runDoctor(options: {
     });
   }
 
-  // --- Print results ---
-  console.log("");
-  let fails = 0;
-  let warns = 0;
-  let checkCount = 0;
-  for (const r of results) {
-    // Section separator
-    if (r.name.startsWith("---")) {
-      console.log(`\n  \x1b[1m${r.name.replace(/^-+\s*/, "").replace(/\s*-+$/, "")}\x1b[0m`);
-      continue;
-    }
-    checkCount++;
-    const icon =
-      r.status === "pass"
-        ? "\x1b[32mPASS\x1b[0m"
-        : r.status === "warn"
-          ? "\x1b[33mWARN\x1b[0m"
-          : "\x1b[31mFAIL\x1b[0m";
-    console.log(`  ${icon}  ${r.name}: ${r.message}`);
-    if (r.fix && r.status !== "pass") {
-      console.log(`         Fix: ${r.fix}`);
-    }
-    if (r.status === "fail") fails++;
-    if (r.status === "warn") warns++;
-  }
-
-  console.log(
-    `\n  ${checkCount} checks: ${checkCount - fails - warns} passed, ${warns} warnings, ${fails} failures\n`,
-  );
-
-  if (fails > 0) process.exit(1);
+  printCheckResults(results);
 }
 
 // Standalone domain checks — called after deploy to show pending DNS/cert work

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -294,7 +294,12 @@ async function main(): Promise<void> {
     }
 
     case "rollback": {
-      await runRollback({ projectDir, releaseName, dryRun });
+      await runRollback({
+        projectDir,
+        releaseName,
+        dryRun,
+        yes: flags["yes"] === true || flags["y"] === true,
+      });
       break;
     }
 

--- a/src/cli/rollback.ts
+++ b/src/cli/rollback.ts
@@ -32,6 +32,15 @@ import {
 } from "./infrastructure-validation.js";
 import { targetArchitecture, type TargetPlatform } from "../target-platform.js";
 import { sanitizeForTerminal } from "./terminal.js";
+import {
+  assertCompositionPlanInvocation,
+  compositionPlanNeedsExplicitConfirmation,
+  inspectKubernetesRequirements,
+  loadDeployedCompositionPlan,
+  loadProjectCompositionPlan,
+  preflightCompositionPlan,
+  waitForCompositionPlanReadiness,
+} from "./composition-plan.js";
 
 // Annotation stamping the FULL build id onto retained snapshot ConfigMaps. Snapshot
 // NAMES go through sanitizeK8sName (lowercase + 63-char truncation), so two different
@@ -895,21 +904,37 @@ export async function runRollback(options: {
   projectDir: string;
   releaseName: string;
   dryRun?: boolean;
+  yes?: boolean;
 }): Promise<void> {
-  const { projectDir, releaseName, dryRun } = options;
+  const { projectDir, releaseName, dryRun, yes } = options;
 
   const infraPath = infrastructurePath(projectDir);
   const infra = existsSync(infraPath) ? JSON.parse(readFileSync(infraPath, "utf-8")) : undefined;
   // S13: validate before these reach a gcloud/kubectl argv.
   assertSafeInfrastructure(infra);
   const namespace = resolveK8sNamespace(infra?.namespace);
+  const localComposition = loadProjectCompositionPlan(projectDir);
 
   // Pin kubectl at THIS release's cluster BEFORE any cluster read — the state ConfigMap
   // read below previously ran against whatever context happened to be current, so a
   // rollback could read (and then act on) another cluster's build state. Dry-run must
   // not mutate the operator's kubeconfig (L13), so it skips this and reads local
   // state only.
-  if (!dryRun && infra?.projectId && infra?.region) {
+  if (!dryRun && localComposition) {
+    if (compositionPlanNeedsExplicitConfirmation(localComposition.plan) && !yes) {
+      throw new Error(
+        `Rollback target access is not independently verifiable. Confirm the current kubectl ` +
+          `context, then re-run with --yes. No cluster state was read or changed.`,
+      );
+    }
+    const preflight = await preflightCompositionPlan(localComposition.plan, {
+      explicitlyConfirmed: yes === true,
+    });
+    console.log(
+      `  → Composition plan verified: ${preflight.clusterIdentity}; Kubernetes ` +
+        `${preflight.serverVersion}`,
+    );
+  } else if (!dryRun && infra?.projectId && infra?.region) {
     const credResult = await execCapture("gcloud", [
       "container",
       "clusters",
@@ -945,6 +970,73 @@ export async function runRollback(options: {
   }
 
   const { buildId: currentBuildId, previousBuildId } = state;
+  if (localComposition) {
+    assertCompositionPlanInvocation(localComposition.plan, {
+      releaseName,
+      namespace,
+      buildId: currentBuildId,
+    });
+  }
+
+  const currentAnchor = state.compositionPlans?.[currentBuildId];
+  const targetAnchor = state.compositionPlans?.[previousBuildId];
+  if (
+    currentAnchor &&
+    localComposition &&
+    (localComposition.digest !== currentAnchor.digest ||
+      localComposition.plan.target.fingerprint !== currentAnchor.targetFingerprint)
+  ) {
+    throw new Error(
+      `The local composition plan for ${currentBuildId} does not match committed deploy state. ` +
+        `Restore the deployed build artifact before rolling back.`,
+    );
+  }
+  const currentComposition =
+    !dryRun && currentAnchor
+      ? localComposition?.plan.metadata.buildId === currentBuildId
+        ? localComposition
+        : await loadDeployedCompositionPlan({
+            releaseName,
+            namespace,
+            buildId: currentBuildId,
+            expected: currentAnchor,
+          })
+      : localComposition;
+  const targetComposition =
+    !dryRun && targetAnchor
+      ? await loadDeployedCompositionPlan({
+          releaseName,
+          namespace,
+          buildId: previousBuildId,
+          expected: targetAnchor,
+        })
+      : null;
+  if (!dryRun && currentAnchor && !currentComposition) {
+    throw new Error(
+      `Committed state requires a composition plan for current build ${currentBuildId}, but its ` +
+        `retained ConfigMap is missing. Refusing rollback without a verified target identity.`,
+    );
+  }
+  if (!dryRun && targetAnchor && !targetComposition) {
+    throw new Error(
+      `Committed state requires a composition plan for rollback build ${previousBuildId}, but ` +
+        `its retained ConfigMap is missing.`,
+    );
+  }
+  if (
+    currentComposition &&
+    targetComposition &&
+    currentComposition.plan.target.fingerprint !== targetComposition.plan.target.fingerprint
+  ) {
+    throw new Error(
+      `Rollback crosses incompatible deployment targets (${currentComposition.plan.target.fingerprint} ` +
+        `→ ${targetComposition.plan.target.fingerprint}). The current Helm resources cannot ` +
+        `represent both targets; deploy the older target definition explicitly instead.`,
+    );
+  }
+  if (targetComposition) {
+    await inspectKubernetesRequirements(targetComposition.plan);
+  }
 
   // N70: rollback has TWO independent topologies. Local build-metadata describes whichever
   // build happened to run last in this checkout, not necessarily the rollback target (and a
@@ -1271,6 +1363,10 @@ export async function runRollback(options: {
         `app.kubernetes.io/version=${safePreviousBuild}) and ` +
         `re-run the rollback.`,
     );
+  }
+  if (targetComposition) {
+    console.log("  → Verifying rollback target composition readiness...");
+    await waitForCompositionPlanReadiness(targetComposition.plan);
   }
 
   // N70: Helm is not rolled back, so HTTPRoute still carries the former-current topology.

--- a/src/cli/state.ts
+++ b/src/cli/state.ts
@@ -94,6 +94,11 @@ export interface AdapterState {
   poolTopologies?: Record<string, string[]>;
   /** Default pool selected by the portable origin Service for each retained build. */
   defaultPools?: Record<string, string>;
+  /** Independent trust anchors for retained build-scoped composition plans. */
+  compositionPlans?: Record<
+    string,
+    { digest: `sha256:${string}`; targetFingerprint: `sha256:${string}` }
+  >;
   /**
    * The container platform each retained build was produced for, keyed by build id.
    *

--- a/src/composition-plan/parse.ts
+++ b/src/composition-plan/parse.ts
@@ -1093,10 +1093,58 @@ export function parseCompositionPlan(value: unknown): CompositionPlan {
         .map((entry) => entry.metadata.namespace)
         .filter((entry): entry is string => entry !== undefined),
     ],
+    [
+      "$.operations.resources.readiness",
+      plan.operations.resources.readiness.flatMap((entry) =>
+        entry.kind === "kubernetes-service-endpoints"
+          ? [entry.service.namespace]
+          : entry.kind === "gcp-traffic-extension"
+            ? []
+            : entry.object.namespace
+              ? [entry.object.namespace]
+              : [],
+      ),
+    ],
+    [
+      "$.operations.routing.dataplane.readiness",
+      plan.operations.routing.dataplane.readiness.flatMap((entry) =>
+        entry.kind === "kubernetes-service-endpoints"
+          ? [entry.service.namespace]
+          : entry.kind === "gcp-traffic-extension"
+            ? []
+            : entry.object.namespace
+              ? [entry.object.namespace]
+              : [],
+      ),
+    ],
+    [
+      "$.operations.diagnostics",
+      plan.operations.diagnostics.flatMap((entry) => {
+        if (entry.kind === "kubernetes-condition") {
+          return entry.check.object.namespace ? [entry.check.object.namespace] : [];
+        }
+        if (entry.kind === "kubernetes-gateway-address") {
+          return entry.gateway.namespace ? [entry.gateway.namespace] : [];
+        }
+        return [];
+      }),
+    ],
   ] as const) {
     const mismatched = candidate.filter((entry) => entry !== namespace);
     if (mismatched.length > 0)
       fail(path, `all release-scoped objects must use namespace ${namespace}`);
+  }
+
+  const routingService =
+    plan.operations.routing.dataplane.kind === "portable-http-origin" ||
+    plan.operations.routing.dataplane.kind === "adapter-owned-envoy-proxy"
+      ? plan.operations.routing.dataplane.service
+      : null;
+  if (routingService && routingService.namespace !== namespace) {
+    fail(
+      "$.operations.routing.dataplane.service.namespace",
+      `all release-scoped objects must use namespace ${namespace}`,
+    );
   }
 
   for (const source of plan.operations.logs) {

--- a/tests/cli/composition-plan.test.ts
+++ b/tests/cli/composition-plan.test.ts
@@ -1,0 +1,632 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+vi.mock("../../src/cli/exec.js");
+
+import { execCapture, execOrThrow } from "../../src/cli/exec.js";
+import {
+  assertCompositionPlanInvocation,
+  compositionPlanNeedsExplicitConfirmation,
+  describeCompositionPlan,
+  evaluateCompositionPlanDiagnostics,
+  evaluateCompositionPlanReadiness,
+  loadDeployedCompositionPlan,
+  loadLocalCompositionPlan,
+  preflightCompositionPlan,
+} from "../../src/cli/composition-plan.js";
+import {
+  canonicalCompositionPlanJson,
+  fingerprintCompositionPlan,
+  parseCompositionPlan,
+  type CompositionPlan,
+} from "../../src/composition-plan/index.js";
+import { compositionPlanConfigMapName } from "../../src/emit/templates/composition-plan-configmap.js";
+
+const RELEASE = "test-app";
+const NAMESPACE = "test-app";
+const BUILD = "build-123";
+const TARGET_FINGERPRINT = `sha256:${"a".repeat(64)}`;
+
+function plan(
+  overrides: {
+    identity?: CompositionPlan["target"]["identity"];
+    access?: CompositionPlan["target"]["access"];
+    requirements?: CompositionPlan["requirements"]["kubernetes"]["resources"];
+    readiness?: CompositionPlan["operations"]["resources"]["readiness"];
+    objects?: CompositionPlan["operations"]["resources"]["objects"];
+    diagnostics?: CompositionPlan["operations"]["diagnostics"];
+  } = {},
+): CompositionPlan {
+  return parseCompositionPlan({
+    apiVersion: "adapter-k8s.nextjs.org/v1alpha1",
+    kind: "CompositionPlan",
+    metadata: { releaseName: RELEASE, namespace: NAMESPACE, buildId: BUILD },
+    target: {
+      fingerprint: TARGET_FINGERPRINT,
+      identity: overrides.identity ?? {
+        kind: "unverified",
+        requireExplicitConfirmation: true,
+      },
+      access: overrides.access ?? {
+        kind: "kubeconfig-current-context",
+        requireExplicitConfirmation: true,
+      },
+      registry: {
+        repository: "ghcr.io/davidilie/test-app",
+        authentication: { kind: "ambient-credentials" },
+        digestLookup: { kind: "oci-distribution" },
+      },
+    },
+    requirements: {
+      kubernetes: {
+        minimumVersion: "1.33.0",
+        resources: overrides.requirements ?? [
+          { apiVersion: "v1", resource: "services", optional: false },
+        ],
+      },
+    },
+    operations: {
+      resources: { objects: overrides.objects ?? [], readiness: overrides.readiness ?? [] },
+      network: {
+        podCidrs: { kind: "not-required" },
+        nodeCidrs: { kind: "kubernetes-node-addresses", addressTypes: ["InternalIP"] },
+        missingSourcePolicy: "fail",
+      },
+      cache: { kind: "none" },
+      cdn: { kind: "none" },
+      routing: {
+        protocol: "pool-local-v1",
+        failurePolicy: "closed",
+        dataplane: {
+          kind: "portable-http-origin",
+          service: { name: `${RELEASE}-origin`, namespace: NAMESPACE, port: 3000 },
+          targetPool: "default",
+          readiness: [],
+        },
+      },
+      cleanup: {
+        kubernetes: {
+          strategy: "adapter-release-v1",
+          contributedObjects: (overrides.objects ?? []).map((object) => ({
+            ref: {
+              apiVersion: object.apiVersion,
+              resource: object.resource,
+              name: object.metadata.name,
+              ...(object.metadata.namespace ? { namespace: object.metadata.namespace } : {}),
+            },
+            lifecycle: "helm",
+            ownership: {
+              releaseLabel: { key: "adapter-k8s.dev/release", value: RELEASE },
+              helmRelease: { name: RELEASE, namespace: NAMESPACE },
+            },
+          })),
+        },
+        external: [],
+        retained: [],
+      },
+      diagnostics: overrides.diagnostics ?? [],
+      logs: [
+        {
+          kind: "kubernetes-pods",
+          namespace: NAMESPACE,
+          selector: { releaseName: RELEASE },
+          containers: "all",
+        },
+      ],
+    },
+  });
+}
+
+function ok(stdout = "") {
+  return { exitCode: 0, stdout, stderr: "" };
+}
+
+describe("composition-plan snapshots", () => {
+  let temp: string;
+
+  beforeEach(() => {
+    temp = mkdtempSync(path.join(os.tmpdir(), "adapter-k8s-plan-"));
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    rmSync(temp, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it("requires the local file and build-metadata digest to authenticate each other", () => {
+    const value = plan();
+    const digest = fingerprintCompositionPlan(value);
+    writeFileSync(path.join(temp, "composition-plan.json"), JSON.stringify(value));
+
+    const loaded = loadLocalCompositionPlan(temp, {
+      buildId: BUILD,
+      compositionPlan: { digest, targetFingerprint: TARGET_FINGERPRINT },
+    });
+    expect(loaded?.digest).toBe(digest);
+    expect(loaded?.plan.metadata.buildId).toBe(BUILD);
+
+    expect(() =>
+      loadLocalCompositionPlan(temp, {
+        buildId: BUILD,
+        compositionPlan: {
+          digest: `sha256:${"0".repeat(64)}`,
+          targetFingerprint: TARGET_FINGERPRINT,
+        },
+      }),
+    ).toThrow(/digest mismatch.*refusing to execute/i);
+    expect(() => loadLocalCompositionPlan(temp, { buildId: BUILD })).toThrow(
+      /unauthenticated leftover plan/i,
+    );
+  });
+
+  it("verifies a deployed ConfigMap against its digest and requested identity", async () => {
+    const value = plan();
+    const digest = fingerprintCompositionPlan(value);
+    vi.mocked(execCapture).mockResolvedValue(
+      ok(
+        JSON.stringify({
+          metadata: { annotations: { "adapter-k8s.dev/composition-digest": digest } },
+          data: { "plan.json": canonicalCompositionPlanJson(value) },
+        }),
+      ),
+    );
+
+    const loaded = await loadDeployedCompositionPlan({
+      releaseName: RELEASE,
+      namespace: NAMESPACE,
+      buildId: BUILD,
+      expected: { digest, targetFingerprint: TARGET_FINGERPRINT },
+    });
+    expect(loaded?.digest).toBe(digest);
+    expect(execCapture).toHaveBeenCalledWith("kubectl", [
+      "get",
+      "configmap",
+      compositionPlanConfigMapName(RELEASE, BUILD),
+      "-n",
+      NAMESPACE,
+      "-o",
+      "json",
+      "--ignore-not-found",
+    ]);
+
+    await expect(
+      loadDeployedCompositionPlan({
+        releaseName: RELEASE,
+        namespace: NAMESPACE,
+        buildId: BUILD,
+        expected: {
+          digest: `sha256:${"f".repeat(64)}`,
+          targetFingerprint: TARGET_FINGERPRINT,
+        },
+      }),
+    ).rejects.toThrow(/does not match committed deploy state/i);
+
+    vi.mocked(execCapture).mockResolvedValue(
+      ok(
+        JSON.stringify({
+          metadata: {
+            annotations: {
+              "adapter-k8s.dev/composition-digest": `sha256:${"0".repeat(64)}`,
+            },
+          },
+          data: { "plan.json": canonicalCompositionPlanJson(value) },
+        }),
+      ),
+    );
+    await expect(
+      loadDeployedCompositionPlan({
+        releaseName: RELEASE,
+        namespace: NAMESPACE,
+        buildId: BUILD,
+      }),
+    ).rejects.toThrow(/digest mismatch.*refusing to execute/i);
+  });
+
+  it("keeps legacy artifacts and missing deployed snapshots compatible", async () => {
+    expect(loadLocalCompositionPlan(temp, { buildId: BUILD })).toBeNull();
+    vi.mocked(execCapture).mockResolvedValue(ok());
+    await expect(
+      loadDeployedCompositionPlan({
+        releaseName: RELEASE,
+        namespace: NAMESPACE,
+        buildId: BUILD,
+      }),
+    ).resolves.toBeNull();
+
+    vi.mocked(execCapture).mockResolvedValue({
+      exitCode: 1,
+      stdout: "",
+      stderr: "Error from server: forbidden; configmap was not found in the local cache",
+    });
+    await expect(
+      loadDeployedCompositionPlan({
+        releaseName: RELEASE,
+        namespace: NAMESPACE,
+        buildId: BUILD,
+      }),
+    ).rejects.toThrow(/could not read deployed composition plan.*forbidden/i);
+  });
+});
+
+describe("composition-plan cluster preflight", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(execOrThrow).mockResolvedValue(undefined);
+  });
+
+  it("pins and verifies a GKE resource without consulting a provider name", async () => {
+    const value = plan({
+      identity: {
+        kind: "gke-resource",
+        projectId: "proj-12345",
+        clusterName: "test-app-cluster",
+        location: { kind: "region", name: "europe-west2" },
+      },
+      access: {
+        kind: "gke-get-credentials",
+        projectId: "proj-12345",
+        clusterName: "test-app-cluster",
+        location: { kind: "region", name: "europe-west2" },
+      },
+      requirements: [
+        { apiVersion: "v1", resource: "services", optional: false },
+        {
+          apiVersion: "gateway.networking.k8s.io/v1",
+          resource: "gateways",
+          optional: false,
+        },
+      ],
+    });
+    vi.mocked(execCapture).mockImplementation((async (_command: string, args: string[]) => {
+      const raw = args.at(-1);
+      if (raw === "/version") return ok(JSON.stringify({ gitVersion: "v1.35.2-gke.10" }));
+      if (raw === "/api/v1") {
+        return ok(JSON.stringify({ resources: [{ name: "services", kind: "Service" }] }));
+      }
+      if (raw === "/apis/gateway.networking.k8s.io/v1") {
+        return ok(JSON.stringify({ resources: [{ name: "gateways", kind: "Gateway" }] }));
+      }
+      throw new Error(`unexpected args: ${args.join(" ")}`);
+    }) as never);
+
+    const result = await preflightCompositionPlan(value, { explicitlyConfirmed: false });
+    expect(result.serverVersion).toBe("v1.35.2-gke.10");
+    expect(result.clusterIdentity).toContain("proj-12345/test-app-cluster");
+    expect(execOrThrow).toHaveBeenCalledWith("gcloud", [
+      "container",
+      "clusters",
+      "get-credentials",
+      "test-app-cluster",
+      "--region",
+      "europe-west2",
+      "--project",
+      "proj-12345",
+      "--quiet",
+    ]);
+  });
+
+  it("requires explicit confirmation for an unverified current context", async () => {
+    const value = plan();
+    expect(compositionPlanNeedsExplicitConfirmation(value)).toBe(true);
+    await expect(preflightCompositionPlan(value, { explicitlyConfirmed: false })).rejects.toThrow(
+      /requires explicit confirmation/i,
+    );
+    expect(execCapture).not.toHaveBeenCalled();
+  });
+
+  it("rejects Kubernetes below 1.33 and a missing required API", async () => {
+    const value = plan({
+      identity: { kind: "kubernetes-namespace-uid", namespace: "kube-system", uid: "uid-1" },
+      access: { kind: "kubeconfig-context", context: "home" },
+    });
+    vi.mocked(execCapture).mockImplementation((async (_command: string, args: string[]) => {
+      if (args.join(" ") === "config current-context") return ok("home\n");
+      const raw = args.at(-1);
+      if (raw === "/api/v1/namespaces/kube-system") {
+        return ok(JSON.stringify({ metadata: { uid: "uid-1" } }));
+      }
+      if (raw === "/version") return ok(JSON.stringify({ gitVersion: "v1.32.9" }));
+      throw new Error(`unexpected args: ${args.join(" ")}`);
+    }) as never);
+    await expect(preflightCompositionPlan(value, { explicitlyConfirmed: false })).rejects.toThrow(
+      /older than.*1\.33\.0/i,
+    );
+
+    vi.mocked(execCapture).mockImplementation((async (_command: string, args: string[]) => {
+      if (args.join(" ") === "config current-context") return ok("home\n");
+      const raw = args.at(-1);
+      if (raw === "/api/v1/namespaces/kube-system") {
+        return ok(JSON.stringify({ metadata: { uid: "uid-1" } }));
+      }
+      if (raw === "/version") return ok(JSON.stringify({ gitVersion: "v1.33.0" }));
+      if (raw === "/api/v1") return ok(JSON.stringify({ resources: [] }));
+      throw new Error(`unexpected args: ${args.join(" ")}`);
+    }) as never);
+    await expect(preflightCompositionPlan(value, { explicitlyConfirmed: false })).rejects.toThrow(
+      /missing required APIs: v1\/services/i,
+    );
+  });
+
+  it("infers contributed APIs and verifies their discovered kind", async () => {
+    const value = plan({
+      identity: { kind: "kubernetes-namespace-uid", namespace: "kube-system", uid: "uid-1" },
+      access: { kind: "kubeconfig-context", context: "home" },
+      objects: [
+        {
+          apiVersion: "networking.k8s.io/v1",
+          kind: "Ingress",
+          resource: "ingresses",
+          metadata: { name: "test-app", namespace: NAMESPACE },
+          body: { spec: {} },
+        },
+      ],
+    });
+    vi.mocked(execCapture).mockImplementation((async (_command: string, args: string[]) => {
+      if (args.join(" ") === "config current-context") return ok("home\n");
+      const raw = args.at(-1);
+      if (raw === "/api/v1/namespaces/kube-system") {
+        return ok(JSON.stringify({ metadata: { uid: "uid-1" } }));
+      }
+      if (raw === "/version") return ok(JSON.stringify({ gitVersion: "v1.33.0" }));
+      if (raw === "/api/v1") {
+        return ok(JSON.stringify({ resources: [{ name: "services", kind: "Service" }] }));
+      }
+      if (raw === "/apis/networking.k8s.io/v1") {
+        return ok(JSON.stringify({ resources: [{ name: "ingresses", kind: "StatefulSet" }] }));
+      }
+      throw new Error(`unexpected args: ${args.join(" ")}`);
+    }) as never);
+
+    await expect(preflightCompositionPlan(value, { explicitlyConfirmed: false })).rejects.toThrow(
+      /ingresses reports kind StatefulSet, expected Ingress/i,
+    );
+  });
+});
+
+describe("composition-plan readiness and descriptions", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("reads object, parents, ancestors and EndpointSlices without jsonpath assumptions", async () => {
+    const value = plan({
+      readiness: [
+        {
+          kind: "kubernetes-condition",
+          object: {
+            apiVersion: "gateway.networking.k8s.io/v1",
+            resource: "gateways",
+            name: "test-app-gateway",
+            namespace: NAMESPACE,
+          },
+          conditionsAt: { kind: "object" },
+          condition: {
+            type: "Programmed",
+            status: "True",
+            observedGeneration: "must-equal-metadata-generation",
+          },
+          timeoutSeconds: 30,
+        },
+        {
+          kind: "kubernetes-condition",
+          object: {
+            apiVersion: "gateway.networking.k8s.io/v1",
+            resource: "httproutes",
+            name: "test-app-routes",
+            namespace: NAMESPACE,
+          },
+          conditionsAt: { kind: "parents", controllerName: "example.net/controller" },
+          condition: {
+            type: "Accepted",
+            status: "True",
+            observedGeneration: "must-equal-metadata-generation",
+          },
+          timeoutSeconds: 30,
+        },
+        {
+          kind: "kubernetes-condition",
+          object: {
+            apiVersion: "gateway.envoyproxy.io/v1alpha1",
+            resource: "envoyextensionpolicies",
+            name: "test-app-routing",
+            namespace: NAMESPACE,
+          },
+          conditionsAt: {
+            kind: "ancestors",
+            controllerName: "gateway.envoyproxy.io/gatewayclass-controller",
+          },
+          condition: {
+            type: "Accepted",
+            status: "True",
+            observedGeneration: "must-equal-metadata-generation",
+          },
+          timeoutSeconds: 30,
+        },
+        {
+          kind: "kubernetes-service-endpoints",
+          service: { name: "test-app-origin", namespace: NAMESPACE, port: 3000 },
+          minimumReady: 2,
+        },
+      ],
+    });
+    vi.mocked(execCapture).mockImplementation((async (_command: string, args: string[]) => {
+      const raw = args.at(-1)!;
+      if (raw.includes("/gateways/")) {
+        return ok(
+          JSON.stringify({
+            metadata: { generation: 4 },
+            status: {
+              conditions: [{ type: "Programmed", status: "True", observedGeneration: 4 }],
+            },
+          }),
+        );
+      }
+      if (raw.includes("/httproutes/")) {
+        return ok(
+          JSON.stringify({
+            metadata: { generation: 2 },
+            status: {
+              parents: [
+                {
+                  controllerName: "another/controller",
+                  conditions: [{ type: "Accepted", status: "False", observedGeneration: 2 }],
+                },
+                {
+                  controllerName: "example.net/controller",
+                  conditions: [{ type: "Accepted", status: "True", observedGeneration: 2 }],
+                },
+              ],
+            },
+          }),
+        );
+      }
+      if (raw.includes("/envoyextensionpolicies/")) {
+        return ok(
+          JSON.stringify({
+            metadata: { generation: 7 },
+            status: {
+              ancestors: [
+                {
+                  controllerName: "gateway.envoyproxy.io/gatewayclass-controller",
+                  conditions: [{ type: "Accepted", status: "True", observedGeneration: 7 }],
+                },
+              ],
+            },
+          }),
+        );
+      }
+      if (raw.includes("/endpointslices?")) {
+        return ok(
+          JSON.stringify({
+            items: [
+              {
+                endpoints: [
+                  { conditions: { ready: true } },
+                  { conditions: { ready: false } },
+                  { conditions: {} },
+                  { conditions: { ready: true, terminating: true } },
+                ],
+              },
+            ],
+          }),
+        );
+      }
+      throw new Error(`unexpected raw path ${raw}`);
+    }) as never);
+
+    const checks = await evaluateCompositionPlanReadiness(value);
+    expect(checks).toHaveLength(4);
+    expect(checks.every((check) => check.status === "pass")).toBe(true);
+    expect(checks.at(-1)?.message).toBe("2/2 ready service endpoints");
+  });
+
+  it("does not accept a stale observedGeneration", async () => {
+    const value = plan({
+      readiness: [
+        {
+          kind: "kubernetes-condition",
+          object: {
+            apiVersion: "gateway.networking.k8s.io/v1",
+            resource: "gateways",
+            name: "test-app-gateway",
+            namespace: NAMESPACE,
+          },
+          conditionsAt: { kind: "object" },
+          condition: {
+            type: "Programmed",
+            status: "True",
+            observedGeneration: "must-equal-metadata-generation",
+          },
+          timeoutSeconds: 30,
+        },
+      ],
+    });
+    vi.mocked(execCapture).mockResolvedValue(
+      ok(
+        JSON.stringify({
+          metadata: { generation: 9 },
+          status: {
+            conditions: [{ type: "Programmed", status: "True", observedGeneration: 8 }],
+          },
+        }),
+      ),
+    );
+    await expect(evaluateCompositionPlanReadiness(value)).resolves.toMatchObject([
+      { status: "fail", message: "Programmed is stale for generation 9" },
+    ]);
+  });
+
+  it("executes diagnostics from their typed plan operations", async () => {
+    const value = plan({
+      diagnostics: [
+        {
+          kind: "kubernetes-gateway-address",
+          gateway: {
+            apiVersion: "gateway.networking.k8s.io/v1",
+            resource: "gateways",
+            name: "test-app-gateway",
+            namespace: NAMESPACE,
+          },
+        },
+        {
+          kind: "gcp-health-check-shape",
+          projectId: "sample-project",
+          name: "test-app-routing-hc",
+          expectedType: "TCP",
+        },
+      ],
+    });
+    vi.mocked(execCapture).mockImplementation((async (command: string, args: string[]) => {
+      if (command === "kubectl") {
+        return ok(JSON.stringify({ status: { addresses: [{ value: "192.0.2.10" }] } }));
+      }
+      if (command === "gcloud" && args.includes("health-checks")) return ok("TCP\n");
+      throw new Error(`unexpected command: ${command} ${args.join(" ")}`);
+    }) as never);
+
+    await expect(evaluateCompositionPlanDiagnostics(value)).resolves.toEqual([
+      expect.objectContaining({ status: "pass", message: "192.0.2.10" }),
+      expect.objectContaining({ status: "pass", message: "TCP" }),
+    ]);
+  });
+
+  it("exposes exact resources, log selectors and cleanup ownership", () => {
+    const value = plan({
+      objects: [
+        {
+          apiVersion: "networking.k8s.io/v1",
+          kind: "Ingress",
+          resource: "ingresses",
+          metadata: { name: "test-app-ingress", namespace: NAMESPACE },
+          body: { spec: { ingressClassName: "nginx" } },
+        },
+      ],
+    });
+    assertCompositionPlanInvocation(value, {
+      releaseName: RELEASE,
+      namespace: NAMESPACE,
+      buildId: BUILD,
+    });
+    const description = describeCompositionPlan(value);
+    expect(description.resources).toEqual([
+      {
+        ref: {
+          apiVersion: "networking.k8s.io/v1",
+          resource: "ingresses",
+          name: "test-app-ingress",
+          namespace: NAMESPACE,
+        },
+        lifecycle: "helm",
+      },
+    ]);
+    expect(description.logs).toEqual([
+      {
+        namespace: NAMESPACE,
+        selector: `adapter-k8s.dev/release=${RELEASE}`,
+        containers: "all",
+      },
+    ]);
+    expect(description.cleanup.kubernetes[0]?.ref.name).toBe("test-app-ingress");
+  });
+});

--- a/tests/cli/deploy.test.ts
+++ b/tests/cli/deploy.test.ts
@@ -11,6 +11,7 @@ import {
   discoverClusterPodCidr,
   discoverClusterNodeCidrs,
   discoverNodeCidrsFromCluster,
+  discoverPodCidrsFromCluster,
   resolveRegistryDigest,
   resolveRegistryDigestAny,
   resolveDeployImageDigests,
@@ -235,6 +236,46 @@ describe("buildDockerCommands", () => {
 
     const routingBuild = commands.find((c) => c.description.includes("routing service"));
     expect(routingBuild).toBeDefined();
+  });
+
+  it("uses the composed registry authentication operation instead of hostname inference", () => {
+    const registry = "us-central1-docker.pkg.dev/my-project/nextjs";
+    const ambient = buildDockerCommands({
+      pools: ["ssr"],
+      buildId: "abc123",
+      registry,
+      outputDir: "out",
+      containerStrategy: "traced-assets",
+      registryAuthentication: { kind: "ambient-credentials" },
+    });
+    expect(ambient.some((command) => command.command === "gcloud")).toBe(false);
+
+    expect(() =>
+      buildDockerCommands({
+        pools: ["ssr"],
+        buildId: "abc123",
+        registry,
+        outputDir: "out",
+        containerStrategy: "traced-assets",
+        registryAuthentication: {
+          kind: "gcloud-docker-helper",
+          registryHost: "europe-west1-docker.pkg.dev",
+        },
+      }),
+    ).toThrow(/authentication names host.*repository uses/i);
+  });
+
+  it("omits the routing image for portable pool-local routing", () => {
+    const commands = buildDockerCommands({
+      pools: ["ssr"],
+      buildId: "abc123",
+      registry: "ghcr.io/example/app",
+      outputDir: "out",
+      containerStrategy: "traced-assets",
+      includeRoutingService: false,
+    });
+    expect(commands).toHaveLength(2);
+    expect(commands.some((command) => command.description.includes("routing service"))).toBe(false);
   });
 });
 
@@ -1040,6 +1081,34 @@ describe("S27: image integrity must not depend on the CLOUD", () => {
       }),
     ).rejects.toThrow(/--allow-mutable-tags/);
   });
+
+  it("does not probe Artifact Registry when the plan selects OCI distribution", async () => {
+    const SHA = "sha256:" + "d".repeat(64);
+    vi.mocked(exec.execCapture).mockImplementation((async (command: string, args: string[]) => {
+      if (command === "crane" && args[0] === "manifest") {
+        return {
+          exitCode: 0,
+          stdout: JSON.stringify({
+            schemaVersion: 2,
+            manifests: [{ digest: SHA, platform: { os: "linux", architecture: "amd64" } }],
+          }),
+          stderr: "",
+        };
+      }
+      return { exitCode: 127, stdout: "", stderr: "not found" };
+    }) as never);
+
+    await expect(
+      resolveDeployImageDigests({
+        refs: [["ssr", "us-central1-docker.pkg.dev/proj/repo/app:b1"]],
+        projectId: "proj",
+        digestLookup: { kind: "oci-distribution" },
+      }),
+    ).resolves.toEqual({ ssr: SHA });
+    expect(vi.mocked(exec.execCapture).mock.calls.some(([command]) => command === "gcloud")).toBe(
+      false,
+    );
+  });
 });
 
 describe("resolveDeployImageDigests (S23: image integrity fails closed)", () => {
@@ -1329,6 +1398,45 @@ describe("discoverNodeCidrsFromCluster (S27: generic clusters have no gcloud)", 
       stderr: "",
     } as never);
     await expect(discoverNodeCidrsFromCluster()).resolves.toBeNull();
+  });
+});
+
+describe("discoverPodCidrsFromCluster", () => {
+  beforeEach(() => {
+    vi.mocked(exec.execCapture).mockReset();
+  });
+
+  it("collects and de-duplicates dual-stack Node podCIDRs", async () => {
+    vi.mocked(exec.execCapture).mockResolvedValue({
+      exitCode: 0,
+      stdout: JSON.stringify({
+        items: [
+          { spec: { podCIDRs: ["10.42.0.0/24", "fd00:42::/64"] } },
+          { spec: { podCIDRs: ["10.42.1.0/24", "fd00:42::/64"] } },
+        ],
+      }),
+      stderr: "",
+    } as never);
+
+    await expect(discoverPodCidrsFromCluster()).resolves.toBe(
+      "10.42.0.0/24,fd00:42::/64,10.42.1.0/24",
+    );
+  });
+
+  it("rejects malformed CIDRs and unreadable API responses", async () => {
+    vi.mocked(exec.execCapture).mockResolvedValueOnce({
+      exitCode: 0,
+      stdout: JSON.stringify({ items: [{ spec: { podCIDR: "10.42.0.0/99" } }] }),
+      stderr: "",
+    } as never);
+    await expect(discoverPodCidrsFromCluster()).resolves.toBeNull();
+
+    vi.mocked(exec.execCapture).mockResolvedValueOnce({
+      exitCode: 0,
+      stdout: "not json",
+      stderr: "",
+    } as never);
+    await expect(discoverPodCidrsFromCluster()).resolves.toBeNull();
   });
 });
 

--- a/tests/cli/destroy.test.ts
+++ b/tests/cli/destroy.test.ts
@@ -1,12 +1,28 @@
 // tests/cli/destroy.test.ts
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
+  buildExternalCleanupCommand,
   buildReleaseScopedGcpResources,
   isAlreadyGoneError,
+  removePlannedKubernetesObject,
   runDestroy,
 } from "../../src/cli/destroy.js";
 import { deployExtRoleId } from "../../src/cli/init.js";
 import * as exec from "../../src/cli/exec.js";
+import {
+  compileTarget,
+  defineResourceComponent,
+  defineTarget,
+  kubernetesCluster,
+  manualExposure,
+} from "../../src/target/index.js";
+import {
+  canonicalCompositionPlanJson,
+  fingerprintCompositionPlan,
+  type CompositionPlan,
+  type RetainedExternalResource,
+} from "../../src/composition-plan/index.js";
+import { compositionPlanConfigMapName } from "../../src/emit/templates/composition-plan-configmap.js";
 import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import os from "node:os";
@@ -76,6 +92,350 @@ describe("buildReleaseScopedGcpResources", () => {
       "--project=my-project",
       "--quiet",
     ]);
+  });
+});
+
+describe("composition-plan cleanup", () => {
+  it("translates typed external operations without inferred names", () => {
+    expect(
+      buildExternalCleanupCommand({
+        kind: "gcp-global-address",
+        projectId: "project-123",
+        name: "shared-edge-address",
+      }),
+    ).toEqual({
+      desc: 'global address "shared-edge-address"',
+      command: "gcloud",
+      args: [
+        "compute",
+        "addresses",
+        "delete",
+        "shared-edge-address",
+        "--global",
+        "--project=project-123",
+        "--quiet",
+      ],
+    });
+  });
+
+  it("verifies the release ownership label before exact Kubernetes deletion", async () => {
+    const owned = {
+      ref: {
+        apiVersion: "networking.k8s.io/v1",
+        resource: "ingresses",
+        name: "custom-entry",
+        namespace: "apps",
+      },
+      lifecycle: "helm" as const,
+      ownership: {
+        releaseLabel: { key: "adapter-k8s.dev/release" as const, value: "my-app" },
+        helmRelease: { name: "my-app", namespace: "apps" },
+      },
+    };
+    vi.mocked(exec.execCapture)
+      .mockResolvedValueOnce({
+        exitCode: 0,
+        stdout: JSON.stringify({
+          metadata: { labels: { "adapter-k8s.dev/release": "my-app" } },
+        }),
+        stderr: "",
+      })
+      .mockResolvedValueOnce({ exitCode: 0, stdout: "", stderr: "" });
+    await expect(removePlannedKubernetesObject(owned, false)).resolves.toBeNull();
+    expect(vi.mocked(exec.execCapture).mock.calls[1]).toEqual([
+      "kubectl",
+      ["delete", "ingresses", "custom-entry", "-n", "apps", "--ignore-not-found"],
+    ]);
+
+    vi.mocked(exec.execCapture).mockReset();
+    vi.mocked(exec.execCapture).mockResolvedValue({
+      exitCode: 0,
+      stdout: JSON.stringify({
+        metadata: { labels: { "adapter-k8s.dev/release": "another-app" } },
+      }),
+      stderr: "",
+    });
+    await expect(removePlannedKubernetesObject(owned, false)).resolves.toMatch(
+      /ownership label.*does not match/i,
+    );
+    expect(vi.mocked(exec.execCapture)).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("runDestroy — composition-plan trust boundary", () => {
+  let tmpDir: string;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  const targetFingerprint = (plan: CompositionPlan) => plan.target.fingerprint;
+
+  function plan(options: {
+    buildId: string;
+    objectName?: string;
+    externalAddress?: string;
+    retained?: RetainedExternalResource[];
+  }): CompositionPlan {
+    const lifecycle = defineResourceComponent({
+      name: `lifecycle-${options.buildId}`,
+      build(context) {
+        return {
+          ...(options.objectName
+            ? {
+                objects: [
+                  {
+                    apiVersion: "v1",
+                    kind: "ConfigMap",
+                    resource: "configmaps",
+                    metadata: { name: options.objectName, namespace: context.namespace },
+                    body: { data: { source: "composition-plan" } },
+                  },
+                ],
+              }
+            : {}),
+          ...(options.externalAddress
+            ? {
+                externalCleanup: [
+                  {
+                    kind: "gcp-global-address" as const,
+                    projectId: "project-123",
+                    name: options.externalAddress,
+                  },
+                ],
+              }
+            : {}),
+          retained: options.retained ?? [],
+        };
+      },
+    });
+    return compileTarget(
+      defineTarget({
+        cluster: kubernetesCluster(),
+        exposure: manualExposure({
+          hosts: [{ hostname: "app.example.com", tls: { enabled: false } }],
+        }),
+        resources: [lifecycle],
+      }),
+      {
+        releaseName: "my-app",
+        namespace: "default",
+        buildId: options.buildId,
+        imageRegistry: "ghcr.io/example/my-app",
+        pools: ["default"],
+        defaultPool: "default",
+        failurePolicy: "closed",
+        cache: "none",
+      },
+    ).plan;
+  }
+
+  function planConfigMap(value: CompositionPlan): string {
+    return JSON.stringify({
+      metadata: {
+        annotations: {
+          "adapter-k8s.dev/composition-digest": fingerprintCompositionPlan(value),
+        },
+      },
+      data: { "plan.json": canonicalCompositionPlanJson(value) },
+    });
+  }
+
+  function authorizeExternalCleanupLocally(value: CompositionPlan): void {
+    const outputDir = path.join(tmpDir, ".k8s-adapter", "output");
+    const digest = fingerprintCompositionPlan(value);
+    mkdirSync(outputDir, { recursive: true });
+    writeFileSync(
+      path.join(outputDir, "composition-plan.json"),
+      canonicalCompositionPlanJson(value),
+    );
+    writeFileSync(
+      path.join(outputDir, "build-metadata.json"),
+      JSON.stringify({
+        buildId: value.metadata.buildId,
+        compositionPlan: { digest, targetFingerprint: value.target.fingerprint },
+      }),
+    );
+  }
+
+  async function destroyFromClusterPlans(plans: CompositionPlan[]): Promise<void> {
+    const [current, previous] = plans;
+    const state = {
+      buildId: current!.metadata.buildId,
+      previousBuildId: previous?.metadata.buildId ?? null,
+      compositionPlans: Object.fromEntries(
+        plans.map((value) => [
+          value.metadata.buildId,
+          {
+            digest: fingerprintCompositionPlan(value),
+            targetFingerprint: targetFingerprint(value),
+          },
+        ]),
+      ),
+    };
+    const plansByName = new Map(
+      plans.map((value) => [compositionPlanConfigMapName("my-app", value.metadata.buildId), value]),
+    );
+    vi.mocked(exec.execCapture).mockImplementation(async (command, args) => {
+      if (command === "gcloud") return { exitCode: 0, stdout: "", stderr: "" };
+      if (command === "kubectl" && args.join(" ") === "config current-context") {
+        return { exitCode: 0, stdout: "home\n", stderr: "" };
+      }
+      if (command === "kubectl" && args.at(-1) === "/version") {
+        return {
+          exitCode: 0,
+          stdout: JSON.stringify({ gitVersion: "v1.35.0" }),
+          stderr: "",
+        };
+      }
+      const discovery = new Map<string, Array<{ name: string; kind: string }>>([
+        ["/api/v1", [{ name: "services", kind: "Service" }]],
+        ["/apis/apps/v1", [{ name: "deployments", kind: "Deployment" }]],
+        [
+          "/apis/autoscaling/v2",
+          [{ name: "horizontalpodautoscalers", kind: "HorizontalPodAutoscaler" }],
+        ],
+        ["/apis/policy/v1", [{ name: "poddisruptionbudgets", kind: "PodDisruptionBudget" }]],
+        ["/apis/networking.k8s.io/v1", [{ name: "networkpolicies", kind: "NetworkPolicy" }]],
+        ["/apis/discovery.k8s.io/v1", [{ name: "endpointslices", kind: "EndpointSlice" }]],
+      ]);
+      if (command === "kubectl" && discovery.has(args.at(-1)!)) {
+        return {
+          exitCode: 0,
+          stdout: JSON.stringify({ resources: discovery.get(args.at(-1)!) }),
+          stderr: "",
+        };
+      }
+      if (command === "kubectl" && args.includes("my-app-adapter-state")) {
+        return {
+          exitCode: 0,
+          stdout: JSON.stringify({ data: { "state.json": JSON.stringify(state) } }),
+          stderr: "",
+        };
+      }
+      if (command === "kubectl" && args[0] === "get" && args[1] === "configmap") {
+        const value = plansByName.get(args[2]!);
+        if (value) return { exitCode: 0, stdout: planConfigMap(value), stderr: "" };
+      }
+      if (
+        command === "kubectl" &&
+        args[0] === "get" &&
+        args[1] === "configmaps" &&
+        plans.some((value) =>
+          value.operations.cleanup.kubernetes.contributedObjects.some(
+            (owned) => owned.ref.name === args[2],
+          ),
+        )
+      ) {
+        return {
+          exitCode: 0,
+          stdout: JSON.stringify({
+            metadata: { labels: { "adapter-k8s.dev/release": "my-app" } },
+          }),
+          stderr: "",
+        };
+      }
+      return successfulDestroyCommand(args);
+    });
+    await runDestroy({ projectDir: tmpDir, releaseName: "my-app", yes: true });
+  }
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(path.join(os.tmpdir(), "adapter-k8s-plan-trust-"));
+    mkdirSync(path.join(tmpDir, ".k8s-adapter"), { recursive: true });
+    vi.clearAllMocks();
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("never executes cluster-only external operations but preserves owned Kubernetes cleanup", async () => {
+    await destroyFromClusterPlans([
+      plan({ buildId: "build-2", objectName: "custom-config", externalAddress: "planted-ip" }),
+    ]);
+
+    expect(vi.mocked(exec.execCapture).mock.calls.some(([command]) => command === "gcloud")).toBe(
+      false,
+    );
+    expect(vi.mocked(exec.execCapture)).toHaveBeenCalledWith("kubectl", [
+      "delete",
+      "configmaps",
+      "custom-config",
+      "-n",
+      "default",
+      "--ignore-not-found",
+    ]);
+    const warnings = warnSpy.mock.calls.map((call) => String(call[0])).join("\n");
+    expect(warnings).toContain("External cleanup was NOT executed");
+    expect(warnings).toContain(
+      'global address "planted-ip": gcloud compute addresses delete planted-ip --global --project=project-123 --quiet',
+    );
+  });
+
+  it("executes an external operation corroborated by the local build plan", async () => {
+    const value = plan({ buildId: "build-2", externalAddress: "release-ip" });
+    authorizeExternalCleanupLocally(value);
+
+    await destroyFromClusterPlans([value]);
+
+    expect(vi.mocked(exec.execCapture)).toHaveBeenCalledWith("gcloud", [
+      "compute",
+      "addresses",
+      "delete",
+      "release-ip",
+      "--global",
+      "--project=project-123",
+      "--quiet",
+    ]);
+    expect(warnSpy.mock.calls.flat().join("\n")).not.toContain("External cleanup was NOT executed");
+  });
+
+  it("prints the exact union of retained resources from current and previous plans", async () => {
+    const sharedCluster: RetainedExternalResource = {
+      kind: "gke-cluster",
+      projectId: "project-123",
+      clusterName: "shared-cluster",
+      location: { kind: "region", name: "europe-west2" },
+    };
+    await destroyFromClusterPlans([
+      plan({
+        buildId: "build-2",
+        retained: [
+          sharedCluster,
+          {
+            kind: "gcp-artifact-registry",
+            projectId: "project-123",
+            region: "europe-west2",
+            repository: "nextjs",
+          },
+        ],
+      }),
+      plan({
+        buildId: "build-1",
+        retained: [
+          sharedCluster,
+          {
+            kind: "gcp-certificate-manager",
+            projectId: "project-123",
+            releasePrefix: "my-app",
+          },
+        ],
+      }),
+    ]);
+
+    const output = logSpy.mock.calls.map((call) => String(call[0])).join("\n");
+    const clusterLine =
+      '    • GKE cluster "shared-cluster": gcloud container clusters delete shared-cluster --region europe-west2 --project project-123';
+    expect(output.split(clusterLine)).toHaveLength(2);
+    expect(output).toContain(
+      '    • Artifact Registry "nextjs": gcloud artifacts repositories delete nextjs --location europe-west2 --project project-123',
+    );
+    expect(output).toContain(
+      '    • Certificate Manager resources prefixed "my-app": gcloud certificate-manager maps list --project project-123 --filter=name:my-app',
+    );
   });
 });
 

--- a/tests/composition-plan.test.ts
+++ b/tests/composition-plan.test.ts
@@ -140,6 +140,39 @@ describe("composition plan schema", () => {
     futureRequirements.kubernetes.minimumVersion = "1.36.0";
     expect(() => parseCompositionPlan(future)).not.toThrow();
   });
+
+  it("rejects cross-namespace readiness and dataplane references", () => {
+    const readiness = basePlan();
+    const operations = readiness.operations as Record<string, unknown>;
+    const resources = operations.resources as Record<string, unknown>;
+    resources.readiness = [
+      {
+        kind: "kubernetes-service-endpoints",
+        service: { name: "foreign", namespace: "other", port: 3000 },
+        minimumReady: 1,
+      },
+    ];
+    expect(() => parseCompositionPlan(readiness)).toThrow(
+      /resources\.readiness.*namespace test-app/i,
+    );
+
+    const dataplane = basePlan();
+    const routing = (dataplane.operations as Record<string, unknown>).routing as Record<
+      string,
+      unknown
+    >;
+    routing.protocol = "pool-local-v1";
+    routing.failurePolicy = "closed";
+    routing.dataplane = {
+      kind: "portable-http-origin",
+      service: { name: "origin", namespace: "other", port: 3000 },
+      targetPool: "default",
+      readiness: [],
+    };
+    expect(() => parseCompositionPlan(dataplane)).toThrow(
+      /dataplane\.service\.namespace.*namespace test-app/i,
+    );
+  });
 });
 
 describe("composition plan fingerprints", () => {


### PR DESCRIPTION
## Summary

- authenticate local and deployed plans with state-backed digests before lifecycle operations
- verify cluster identity, Kubernetes APIs, registry, network, readiness, and diagnostics from typed plan operations
- drive deploy, rollback, destroy, doctor, and describe from the plan while refusing incompatible targets and foreign cleanup

## Motivation

Generating a portable chart is not enough if lifecycle commands still infer GKE names or use the operator's current context. Every command must execute the same target selected at build time and must fail before mutation when that identity or capability contract no longer matches.

## Changes

- load local plans through build metadata and anchor deployed plan digests and target fingerprints in release state
- establish the declared cluster access method, verify cluster identity, require Kubernetes 1.33+, and discover every required API and kind
- authenticate and resolve image digests using the registry operations in the plan instead of registry-host heuristics
- derive NetworkPolicy sources, readiness gates, diagnostics, and output from typed plan operations
- preflight deploys before Helm mutation and refuse rollback across incompatible target fingerprints
- reconcile rollback resources and readiness from the retained target plan rather than the current build
- delete contributed Kubernetes objects only after verifying their exact release ownership label
- require local-plan corroboration before executing external cleanup with ambient cloud credentials
- report retained resources and cluster-only cleanup commands instead of silently claiming they were deleted
- let doctor and describe operate on generic Kubernetes targets without GKE bootstrap assumptions

## Testing

- `npm run build`
- `npm test`
- `npm run typecheck`
- `npm run lint`
- `npm run fmt:check`
