### PR TITLE
Keep composed deployments safe across cleanup and rollback

### DIFF
--- a/src/cli/rollback.ts
+++ b/src/cli/rollback.ts
@@ -2,7 +2,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { execCapture, execCaptureStdin, execOrThrow } from "./exec.js";
-import { readState, writeState } from "./state.js";
+import { readState, writeState, type AdapterState } from "./state.js";
 import { discoverBuildPools, recordedBuildPools } from "./pool-topology.js";
 import { invalidateCdnBuildTag } from "./cdn-invalidate.js";
 import {
@@ -39,6 +39,7 @@ import {
   loadDeployedCompositionPlan,
   loadProjectCompositionPlan,
   preflightCompositionPlan,
+  type LoadedCompositionPlan,
   waitForCompositionPlanReadiness,
 } from "./composition-plan.js";
 
@@ -48,6 +49,59 @@ import {
 // detect that and refuse to clobber a different build's manifest (deploy also guards
 // the composed names up front — this is defense in depth at the point of overwrite).
 export const SNAPSHOT_BUILD_ID_ANNOTATION = "adapter-k8s/build-id";
+
+type RollbackCompositionRole = "current" | "target";
+
+/**
+ * A checkout may contain either side of a two-way rollback. Bind its plan to the matching
+ * committed anchor instead of assuming the local artifact is always the currently served build.
+ */
+export function classifyLocalRollbackComposition(options: {
+  local: LoadedCompositionPlan;
+  state: Pick<AdapterState, "buildId" | "previousBuildId" | "compositionPlans">;
+  releaseName: string;
+  namespace: string;
+}): RollbackCompositionRole {
+  const { local, state, releaseName, namespace } = options;
+  const localBuildId = local.plan.metadata.buildId;
+  const role: RollbackCompositionRole =
+    localBuildId === state.buildId
+      ? "current"
+      : localBuildId === state.previousBuildId
+        ? "target"
+        : (() => {
+            throw new Error(
+              `The local composition plan belongs to build ${localBuildId}, but rollback only ` +
+                `recognizes current build ${state.buildId} and target build ` +
+                `${state.previousBuildId ?? "<none>"}. Restore either retained build artifact.`,
+            );
+          })();
+
+  assertCompositionPlanInvocation(local.plan, {
+    releaseName,
+    namespace,
+    buildId: localBuildId,
+  });
+
+  const anchor = state.compositionPlans?.[localBuildId];
+  if (role === "target" && !anchor) {
+    throw new Error(
+      `The local composition plan belongs to rollback target ${localBuildId}, but committed ` +
+        `deploy state has no trust anchor for that build. Restore the currently deployed ` +
+        `build artifact before rolling back.`,
+    );
+  }
+  if (
+    anchor &&
+    (local.digest !== anchor.digest || local.plan.target.fingerprint !== anchor.targetFingerprint)
+  ) {
+    throw new Error(
+      `The local composition plan for ${localBuildId} does not match committed deploy state. ` +
+        `Restore that build artifact before rolling back.`,
+    );
+  }
+  return role;
+}
 
 interface RoutingServingConfig {
   /**
@@ -970,30 +1024,19 @@ export async function runRollback(options: {
   }
 
   const { buildId: currentBuildId, previousBuildId } = state;
-  if (localComposition) {
-    assertCompositionPlanInvocation(localComposition.plan, {
-      releaseName,
-      namespace,
-      buildId: currentBuildId,
-    });
-  }
-
   const currentAnchor = state.compositionPlans?.[currentBuildId];
   const targetAnchor = state.compositionPlans?.[previousBuildId];
-  if (
-    currentAnchor &&
-    localComposition &&
-    (localComposition.digest !== currentAnchor.digest ||
-      localComposition.plan.target.fingerprint !== currentAnchor.targetFingerprint)
-  ) {
-    throw new Error(
-      `The local composition plan for ${currentBuildId} does not match committed deploy state. ` +
-        `Restore the deployed build artifact before rolling back.`,
-    );
-  }
+  const localCompositionRole = localComposition
+    ? classifyLocalRollbackComposition({
+        local: localComposition,
+        state,
+        releaseName,
+        namespace,
+      })
+    : null;
   const currentComposition =
     !dryRun && currentAnchor
-      ? localComposition?.plan.metadata.buildId === currentBuildId
+      ? localCompositionRole === "current"
         ? localComposition
         : await loadDeployedCompositionPlan({
             releaseName,
@@ -1001,16 +1044,22 @@ export async function runRollback(options: {
             buildId: currentBuildId,
             expected: currentAnchor,
           })
-      : localComposition;
+      : localCompositionRole === "current"
+        ? localComposition
+        : null;
   const targetComposition =
     !dryRun && targetAnchor
-      ? await loadDeployedCompositionPlan({
-          releaseName,
-          namespace,
-          buildId: previousBuildId,
-          expected: targetAnchor,
-        })
-      : null;
+      ? localCompositionRole === "target"
+        ? localComposition
+        : await loadDeployedCompositionPlan({
+            releaseName,
+            namespace,
+            buildId: previousBuildId,
+            expected: targetAnchor,
+          })
+      : localCompositionRole === "target"
+        ? localComposition
+        : null;
   if (!dryRun && currentAnchor && !currentComposition) {
     throw new Error(
       `Committed state requires a composition plan for current build ${currentBuildId}, but its ` +

--- a/src/cli/rollback.ts
+++ b/src/cli/rollback.ts
@@ -1083,7 +1083,7 @@ export async function runRollback(options: {
         `represent both targets; deploy the older target definition explicitly instead.`,
     );
   }
-  if (targetComposition) {
+  if (!dryRun && targetComposition) {
     await inspectKubernetesRequirements(targetComposition.plan);
   }
 

--- a/src/cli/stable-pool-resources.ts
+++ b/src/cli/stable-pool-resources.ts
@@ -1,12 +1,13 @@
 import { execCapture } from "./exec.js";
 import {
+  ADAPTER_RELEASE_LABEL,
   assertSafePoolName,
   assertSafeReleaseName,
   resolveK8sNamespace,
   stablePoolResourceNames,
 } from "../emit/templates/utils.js";
 
-export const RETAINED_STABLE_POOL_LABEL = "adapter-k8s.dev/release";
+export const RETAINED_STABLE_POOL_LABEL = "adapter-k8s.dev/retained-stable-pool";
 const KEEP_ANNOTATION = "helm.sh/resource-policy";
 const KEEP_VALUE = "keep";
 const GKE_HCP_CRD = "healthcheckpolicies.networking.gke.io";
@@ -72,7 +73,11 @@ function validateStableResource(
         `(release=${JSON.stringify(helmRelease ?? null)}, namespace=${JSON.stringify(helmNamespace ?? null)}).`,
     );
   }
-  if (requireRetainedLabel && labels?.[RETAINED_STABLE_POOL_LABEL] !== releaseName) {
+  const retainedMarker = labels?.[RETAINED_STABLE_POOL_LABEL] === releaseName;
+  const legacyRetained =
+    labels?.[ADAPTER_RELEASE_LABEL] === releaseName &&
+    annotations?.[KEEP_ANNOTATION] === KEEP_VALUE;
+  if (requireRetainedLabel && !retainedMarker && !legacyRetained) {
     throw new Error(
       `Stable ${kind} ${wantedName} is missing retained-resource ownership label ` +
         `${RETAINED_STABLE_POOL_LABEL}=${releaseName}.`,
@@ -227,6 +232,7 @@ export async function retainRemovedPoolResources(options: {
           labels: {
             "app.kubernetes.io/name": releaseName,
             "app.kubernetes.io/component": pool,
+            [ADAPTER_RELEASE_LABEL]: releaseName,
             [RETAINED_STABLE_POOL_LABEL]: releaseName,
           },
           annotations: { [KEEP_ANNOTATION]: KEEP_VALUE },
@@ -279,7 +285,7 @@ export async function cleanupRetainedStablePoolResources(options: {
       "-n",
       namespace,
       "-l",
-      `app.kubernetes.io/name=${releaseName},${RETAINED_STABLE_POOL_LABEL}=${releaseName}`,
+      `app.kubernetes.io/name=${releaseName},${ADAPTER_RELEASE_LABEL}=${releaseName}`,
       "-o",
       "json",
     ]);
@@ -305,7 +311,19 @@ export async function cleanupRetainedStablePoolResources(options: {
       continue;
     }
     for (const item of items) {
-      const labels = objectRecord(objectRecord(item)?.metadata)?.labels;
+      const metadata = objectRecord(objectRecord(item)?.metadata);
+      const labels = objectRecord(metadata?.labels);
+      const annotations = objectRecord(metadata?.annotations);
+      const marker = labels?.[RETAINED_STABLE_POOL_LABEL];
+      if (marker !== undefined && marker !== releaseName) {
+        failures.push(
+          `retained ${kind} candidate has foreign marker ${RETAINED_STABLE_POOL_LABEL}=` +
+            JSON.stringify(marker),
+        );
+        continue;
+      }
+      const legacyRetained = annotations?.[KEEP_ANNOTATION] === KEEP_VALUE;
+      if (marker !== releaseName && !legacyRetained) continue;
       const pool = objectRecord(labels)?.["app.kubernetes.io/component"];
       if (typeof pool !== "string" || pool === "routing-service") {
         failures.push(`retained ${kind} candidate is missing a non-routing pool component`);

--- a/tests/cli/deploy-orchestration.test.ts
+++ b/tests/cli/deploy-orchestration.test.ts
@@ -81,7 +81,12 @@ function stablePoolObject(
       resourceVersion: "123",
       labels: {
         "app.kubernetes.io/managed-by": "Helm",
-        ...(retained ? { "adapter-k8s.dev/release": RELEASE } : {}),
+        ...(retained
+          ? {
+              "adapter-k8s.dev/release": RELEASE,
+              "adapter-k8s.dev/retained-stable-pool": RELEASE,
+            }
+          : {}),
         ...(kind === "healthcheckpolicy" && legacyHcpLabels
           ? {}
           : {

--- a/tests/cli/rollback.test.ts
+++ b/tests/cli/rollback.test.ts
@@ -14,6 +14,7 @@ vi.mock("../../src/cli/cdn-invalidate.js");
 vi.mock("node:fs");
 
 import {
+  classifyLocalRollbackComposition,
   planRollbackCapacity,
   readRoutingServingConfig,
   revertRoutingServiceToBuild,
@@ -22,6 +23,7 @@ import {
   ROLLBACK_MIN_REPLICAS,
   SNAPSHOT_BUILD_ID_ANNOTATION,
 } from "../../src/cli/rollback.js";
+import type { LoadedCompositionPlan } from "../../src/cli/composition-plan.js";
 import { execCapture, execCaptureStdin, execOrThrow } from "../../src/cli/exec.js";
 import { readState, writeState } from "../../src/cli/state.js";
 import { invalidateCdnBuildTag } from "../../src/cli/cdn-invalidate.js";
@@ -50,6 +52,88 @@ const cdnFilter = path.join(
   "templates",
   "cdn-http-filter.yaml",
 );
+
+const PLAN_DIGEST_N = `sha256:${"a".repeat(64)}` as const;
+const PLAN_DIGEST_M = `sha256:${"b".repeat(64)}` as const;
+const TARGET_FINGERPRINT = `sha256:${"c".repeat(64)}` as const;
+
+function loadedComposition(buildId: string, digest: `sha256:${string}`): LoadedCompositionPlan {
+  return {
+    digest,
+    source: `/plans/${buildId}.json`,
+    plan: {
+      metadata: {
+        version: 1,
+        releaseName: RELEASE,
+        namespace: "default",
+        buildId,
+      },
+      target: { fingerprint: TARGET_FINGERPRINT },
+    } as LoadedCompositionPlan["plan"],
+  };
+}
+
+describe("classifyLocalRollbackComposition", () => {
+  const compositionPlans = {
+    buildn: { digest: PLAN_DIGEST_N, targetFingerprint: TARGET_FINGERPRINT },
+    buildm: { digest: PLAN_DIGEST_M, targetFingerprint: TARGET_FINGERPRINT },
+  };
+
+  it("accepts the rollback target artifact after state has swapped", () => {
+    expect(
+      classifyLocalRollbackComposition({
+        local: loadedComposition("buildn", PLAN_DIGEST_N),
+        state: { buildId: "buildm", previousBuildId: "buildn", compositionPlans },
+        releaseName: RELEASE,
+        namespace: "default",
+      }),
+    ).toBe("target");
+  });
+
+  it("accepts the current artifact for states that predate plan anchors", () => {
+    expect(
+      classifyLocalRollbackComposition({
+        local: loadedComposition("buildm", PLAN_DIGEST_M),
+        state: { buildId: "buildm", previousBuildId: "buildn" },
+        releaseName: RELEASE,
+        namespace: "default",
+      }),
+    ).toBe("current");
+  });
+
+  it("rejects an unanchored target artifact", () => {
+    expect(() =>
+      classifyLocalRollbackComposition({
+        local: loadedComposition("buildn", PLAN_DIGEST_N),
+        state: { buildId: "buildm", previousBuildId: "buildn" },
+        releaseName: RELEASE,
+        namespace: "default",
+      }),
+    ).toThrow(/no trust anchor/i);
+  });
+
+  it("rejects artifacts outside the two retained builds", () => {
+    expect(() =>
+      classifyLocalRollbackComposition({
+        local: loadedComposition("buildx", PLAN_DIGEST_N),
+        state: { buildId: "buildm", previousBuildId: "buildn", compositionPlans },
+        releaseName: RELEASE,
+        namespace: "default",
+      }),
+    ).toThrow(/only recognizes current build buildm and target build buildn/i);
+  });
+
+  it("rejects a retained build artifact that does not match its committed anchor", () => {
+    expect(() =>
+      classifyLocalRollbackComposition({
+        local: loadedComposition("buildn", PLAN_DIGEST_M),
+        state: { buildId: "buildm", previousBuildId: "buildn", compositionPlans },
+        releaseName: RELEASE,
+        namespace: "default",
+      }),
+    ).toThrow(/does not match committed deploy state/i);
+  });
+});
 
 /** execCapture stub: success everywhere except optionally the service selector patch. */
 function capture(patchFails: boolean) {

--- a/tests/cli/rollback.test.ts
+++ b/tests/cli/rollback.test.ts
@@ -24,6 +24,16 @@ import {
   SNAPSHOT_BUILD_ID_ANNOTATION,
 } from "../../src/cli/rollback.js";
 import type { LoadedCompositionPlan } from "../../src/cli/composition-plan.js";
+import {
+  canonicalCompositionPlanJson,
+  fingerprintCompositionPlan,
+} from "../../src/composition-plan/index.js";
+import {
+  compileTarget,
+  defineTarget,
+  kubernetesCluster,
+  manualExposure,
+} from "../../src/target/index.js";
 import { execCapture, execCaptureStdin, execOrThrow } from "../../src/cli/exec.js";
 import { readState, writeState } from "../../src/cli/state.js";
 import { invalidateCdnBuildTag } from "../../src/cli/cdn-invalidate.js";
@@ -43,6 +53,7 @@ const SNAP_M = routingManifestSnapshotName(RELEASE, "buildm");
 const SNAP_N = routingManifestSnapshotName(RELEASE, "buildn");
 const infraPath = path.join(PROJECT, ".k8s-adapter", "infrastructure.json");
 const metaPath = path.join(PROJECT, ".k8s-adapter", "output", "build-metadata.json");
+const planPath = path.join(PROJECT, ".k8s-adapter", "output", "composition-plan.json");
 const POOL_TOPOLOGIES = { buildn: ["ssr"], buildm: ["ssr"] };
 const cdnFilter = path.join(
   PROJECT,
@@ -427,6 +438,66 @@ describe("runRollback — state and CDN invalidation", () => {
     await expect(
       runRollback({ projectDir: PROJECT, releaseName: RELEASE, dryRun: true }),
     ).rejects.toThrow(/LOCAL state file/);
+  });
+
+  it("keeps a reverse composed rollback dry-run offline when the local plan is the target", async () => {
+    const targetPlan = compileTarget(
+      defineTarget({
+        cluster: kubernetesCluster(),
+        exposure: manualExposure({
+          hosts: [{ hostname: "app.example.com", tls: { enabled: false } }],
+        }),
+      }),
+      {
+        releaseName: RELEASE,
+        namespace: "default",
+        buildId: "buildn",
+        imageRegistry: "ghcr.io/example/rel",
+        pools: ["ssr"],
+        defaultPool: "ssr",
+        failurePolicy: "closed",
+        cache: "none",
+      },
+    ).plan;
+    const targetDigest = fingerprintCompositionPlan(targetPlan);
+    vi.mocked(readState).mockResolvedValue({
+      buildId: "buildm",
+      previousBuildId: "buildn",
+      poolTopologies: POOL_TOPOLOGIES,
+      compositionPlans: {
+        buildm: { digest: PLAN_DIGEST_M, targetFingerprint: targetPlan.target.fingerprint },
+        buildn: { digest: targetDigest, targetFingerprint: targetPlan.target.fingerprint },
+      },
+    } as never);
+    vi.mocked(existsSync).mockImplementation(
+      (p) => p === infraPath || p === metaPath || p === planPath,
+    );
+    vi.mocked(readFileSync).mockImplementation((p) => {
+      if (p === infraPath) return '{"projectId":"proj-12345","region":"us-central1"}';
+      if (p === metaPath)
+        return JSON.stringify({
+          buildId: "buildn",
+          compositionPlan: {
+            digest: targetDigest,
+            targetFingerprint: targetPlan.target.fingerprint,
+          },
+        });
+      if (p === planPath) return canonicalCompositionPlanJson(targetPlan);
+      return "";
+    });
+
+    await runRollback({ projectDir: PROJECT, releaseName: RELEASE, dryRun: true });
+
+    expect(vi.mocked(execCapture)).not.toHaveBeenCalled();
+    expect(vi.mocked(execCaptureStdin)).not.toHaveBeenCalled();
+    expect(vi.mocked(execOrThrow)).not.toHaveBeenCalled();
+    expect(vi.mocked(writeState)).not.toHaveBeenCalled();
+    const printed = vi
+      .mocked(console.log)
+      .mock.calls.map((call) => String(call[0]))
+      .join("\n");
+    expect(printed).toContain("[dry-run] Rollback plan: buildm → buildn");
+    expect(printed).toContain("[dry-run] Would swap state: buildId=buildn, previousBuildId=buildm");
   });
 });
 

--- a/tests/cli/stable-pool-resources.test.ts
+++ b/tests/cli/stable-pool-resources.test.ts
@@ -27,7 +27,12 @@ function stableObject(
     kind === "service" ? base : kind === "poddisruptionbudget" ? `${base}-pdb` : `${base}-hcp`;
   const labels: Record<string, string> = {
     "app.kubernetes.io/managed-by": opts.manager ?? "Helm",
-    ...(opts.retained ? { "adapter-k8s.dev/release": RELEASE } : {}),
+    ...(opts.retained
+      ? {
+          "adapter-k8s.dev/release": RELEASE,
+          "adapter-k8s.dev/retained-stable-pool": RELEASE,
+        }
+      : {}),
   };
   if (!(kind === "healthcheckpolicy" && opts.legacyHcpLabels)) {
     labels["app.kubernetes.io/name"] = RELEASE;
@@ -133,6 +138,7 @@ describe("retainRemovedPoolResources", () => {
           "app.kubernetes.io/name": RELEASE,
           "app.kubernetes.io/component": "legacy",
           "adapter-k8s.dev/release": RELEASE,
+          "adapter-k8s.dev/retained-stable-pool": RELEASE,
         },
         annotations: { "helm.sh/resource-policy": "keep" },
       });
@@ -283,6 +289,84 @@ describe("cleanupRetainedStablePoolResources", () => {
     expect(result.deleted).toEqual([]);
     expect(result.failures.join("\n")).toMatch(/identity mismatch/);
     expect(vi.mocked(execCapture).mock.calls.some(([, args]) => args[0] === "delete")).toBe(false);
+  });
+
+  it("ignores release-owned stable resources that were never retained as pool resources", async () => {
+    vi.mocked(execCapture).mockImplementation(async (_cmd, args) => {
+      if (args[0] === "get") {
+        if (args[1] !== "service") {
+          return { exitCode: 0, stdout: '{"items":[]}', stderr: "" };
+        }
+        return {
+          exitCode: 0,
+          stdout: JSON.stringify({
+            items: [
+              {
+                metadata: {
+                  name: "rel-origin",
+                  resourceVersion: "123",
+                  labels: {
+                    "adapter-k8s.dev/release": RELEASE,
+                    "app.kubernetes.io/name": RELEASE,
+                    "app.kubernetes.io/component": "origin",
+                  },
+                  annotations: {
+                    "meta.helm.sh/release-name": RELEASE,
+                    "meta.helm.sh/release-namespace": NAMESPACE,
+                  },
+                },
+                spec: {
+                  selector: {
+                    "app.kubernetes.io/name": RELEASE,
+                    "app.kubernetes.io/component": "web",
+                  },
+                },
+              },
+            ],
+          }),
+          stderr: "",
+        };
+      }
+      return { exitCode: 0, stdout: "", stderr: "" };
+    });
+
+    await expect(
+      cleanupRetainedStablePoolResources({
+        releaseName: RELEASE,
+        namespace: NAMESPACE,
+        keepPools: ["web"],
+        healthCheckPolicyCrd: false,
+      }),
+    ).resolves.toEqual({ deleted: [], failures: [] });
+    expect(vi.mocked(execCapture).mock.calls.some(([, args]) => args[0] === "delete")).toBe(false);
+  });
+
+  it("recognizes markerless resources retained by an older adapter", async () => {
+    vi.mocked(execCapture).mockImplementation(async (_cmd, args) => {
+      if (args[0] === "get") {
+        if (args[1] !== "service") {
+          return { exitCode: 0, stdout: '{"items":[]}', stderr: "" };
+        }
+        const legacy = stableObject("service", "obsolete");
+        legacy.metadata.labels["adapter-k8s.dev/release"] = RELEASE;
+        legacy.metadata.annotations["helm.sh/resource-policy"] = "keep";
+        return {
+          exitCode: 0,
+          stdout: JSON.stringify({ items: [legacy] }),
+          stderr: "",
+        };
+      }
+      return { exitCode: 0, stdout: "", stderr: "" };
+    });
+
+    await expect(
+      cleanupRetainedStablePoolResources({
+        releaseName: RELEASE,
+        namespace: NAMESPACE,
+        keepPools: [],
+        healthCheckPolicyCrd: false,
+      }),
+    ).resolves.toEqual({ deleted: ["service/rel-obsolete"], failures: [] });
   });
 
   it("keeps the Service anchor when a companion delete fails", async () => {


### PR DESCRIPTION
## Summary

- separate retained stable-pool identity from generic adapter release ownership
- allow composed deployments to roll backward and forward with either retained build artifact
- keep cleanup and rollback bound to exact ownership labels and committed plan anchors

## Motivation

Live testing exposed two lifecycle failures after portable target composition landed. Stable-pool cleanup reused `adapter-k8s.dev/release` as its retained-resource marker, so the composed origin Service was classified as a removed pool. Strict selector validation prevented deletion, but cleanup ended with a warning and left stale resources behind.

The first rollback succeeded, but the documented second rollback failed because the local composition plan was required to belong to the currently served build. After state swapped, the same checkout correctly contained the rollback target instead. The command rejected that valid artifact before it could load the retained current plan.

## Changes

- add the dedicated `adapter-k8s.dev/retained-stable-pool` identity label
- stamp retained resources with both release ownership and retained-pool identity
- process only exact retained markers or legacy release-owned resources carrying Helm's `keep` annotation
- ignore ordinary composed Services, PodDisruptionBudgets, and HealthCheckPolicies owned by the release
- fail closed when a cleanup candidate carries a foreign retained-pool marker
- classify a local composition plan as the current or target side of the two retained builds
- verify that plan against the matching committed digest and target fingerprint
- load the other side from its immutable retained ConfigMap when needed
- reject unanchored targets, unrelated builds, and mismatched plan artifacts
- keep reverse rollback previews offline without API discovery against the ambient context
- cover the portable origin Service regression, markerless upgrade compatibility, reverse rollback plan selection, and zero-access dry-runs

## Testing

- `pnpm build`
- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm fmt:check`
- `git diff --check`
- deployed `target-6ba61b8` to Kubernetes v1.35 through Helm revision 8
- passed 40/40 adapter browser tests and 317/317 mixed-load requests
- rolled back to `target-34dd205`, passed 40/40 browser tests and 417/417 mixed-load requests
- rolled forward to `target-6ba61b8` with this PR's CLI and passed all 15 live doctor checks
