### PR TITLE
Share runtime layers across pool images

### DIFF
--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -1,6 +1,6 @@
 // src/adapter.ts
 import { writeFile, mkdir, copyFile, cp, rm, realpath, readdir, lstat } from "node:fs/promises";
-import { existsSync, readFileSync, statSync } from "node:fs";
+import { constants, existsSync, readFileSync, statSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { createRequire } from "node:module";
@@ -17,7 +17,15 @@ import { compileTarget, targetForConfig } from "./target/index.js";
 import { fingerprintCompositionPlan } from "./composition-plan/index.js";
 import { infrastructurePath, outputDirName } from "./cli/infrastructure-validation.js";
 import { targetPlatform, type TargetPlatform } from "./target-platform.js";
-import { assertStagedNativeArtifactsTargetPlatform } from "./native-artifacts.js";
+import {
+  assertStagedNativeArtifactsTargetPlatform,
+  pruneForeignSharpPackages,
+} from "./native-artifacts.js";
+import {
+  factorSharedPoolFiles,
+  SHARED_POOL_IMAGE_LAYOUT,
+  type PoolImageLayout,
+} from "./pool-image-layout.js";
 
 // Get current directory in a way that works in ESM and CJS bundle
 const _dirname =
@@ -356,6 +364,8 @@ import {
 } from "./emit/templates/utils.js";
 import {
   generateDockerfile,
+  generateLayeredPoolDockerfile,
+  generatePoolBaseDockerfile,
   generatePoolDockerfile,
   generateRoutingServiceDockerfile,
 } from "./emit/dockerfiles.js";
@@ -525,15 +535,19 @@ export async function resolveAndCopyExternals(src: string, dest: string): Promis
       }
       const targetStat = statSync(realTarget);
       if (targetStat.isDirectory()) {
-        await cp(realTarget, destEntry, { recursive: true, dereference: true });
+        await cp(realTarget, destEntry, {
+          recursive: true,
+          dereference: true,
+          mode: constants.COPYFILE_FICLONE,
+        });
       } else {
-        await copyFile(realTarget, destEntry);
+        await copyFile(realTarget, destEntry, constants.COPYFILE_FICLONE);
       }
     } else if (stat.isDirectory()) {
       // Recurse into scoped package directories (e.g., @opentelemetry/)
       await resolveAndCopyExternals(srcEntry, destEntry);
     } else {
-      await copyFile(srcEntry, destEntry);
+      await copyFile(srcEntry, destEntry, constants.COPYFILE_FICLONE);
     }
   }
 }
@@ -719,9 +733,13 @@ export async function stageFile(
     const sourceStat = statSync(absSource);
     if (sourceStat.isDirectory()) {
       // dereference: true is required to pull in symlinked node_modules content
-      await cp(absSource, absDest, { recursive: true, dereference: true });
+      await cp(absSource, absDest, {
+        recursive: true,
+        dereference: true,
+        mode: constants.COPYFILE_FICLONE,
+      });
     } else {
-      await copyFile(absSource, absDest);
+      await copyFile(absSource, absDest, constants.COPYFILE_FICLONE);
     }
     // Mark done only AFTER a successful copy. Marking it up front meant a FAILED
     // destination was permanently recorded as staged, so a later call for the same dest
@@ -1433,7 +1451,7 @@ export function createK8sAdapter(userConfig?: K8sAdapterConfig): NextAdapter {
           const destDir = path.join(process.cwd(), ".k8s-adapter");
           await mkdir(destDir, { recursive: true });
           const dest = path.join(destDir, "cache-handler.cjs");
-          await copyFile(src, dest);
+          await copyFile(src, dest, constants.COPYFILE_FICLONE);
           modified.cacheHandler = dest;
           // Next keeps a per-process in-memory LRU IN FRONT of any custom cacheHandler
           // (cacheMaxMemorySize, 50MB default). With replicas that layer is incoherent by
@@ -1891,6 +1909,14 @@ export function createK8sAdapter(userConfig?: K8sAdapterConfig): NextAdapter {
       // applyDefaults (config.ts) guarantees this; the local keeps the branch below and the
       // emitted build-metadata in agreement instead of re-defaulting in two places.
       const containerStrategy = cfg.containerStrategy ?? "traced-assets";
+      let poolImageLayout: PoolImageLayout | undefined;
+      let prunedSharpPackages = 0;
+      let prunedSharpBytes = 0;
+      const pruneSharpContext = async (context: string): Promise<void> => {
+        const pruned = await pruneForeignSharpPackages(context, imageTargetPlatform);
+        prunedSharpPackages += pruned.packages;
+        prunedSharpBytes += pruned.bytes;
+      };
 
       // N50 (review #33): every staging site is guarded by `existsSync`, which is correct for
       // the individually-optional subtrees (`server/chunks`, `node_modules`) but turned a
@@ -2116,6 +2142,7 @@ export function createK8sAdapter(userConfig?: K8sAdapterConfig): NextAdapter {
         await cp(distDir, path.join(projectDir, absSharedStageDir, distDirRel), {
           recursive: true,
           dereference: true,
+          mode: constants.COPYFILE_FICLONE,
           filter: (src) => src !== distCacheDir && !src.startsWith(distCacheDir + path.sep),
         });
         const sharedFetchCacheDir = path.join(distCacheDir, "fetch-cache");
@@ -2123,13 +2150,13 @@ export function createK8sAdapter(userConfig?: K8sAdapterConfig): NextAdapter {
           await cp(
             sharedFetchCacheDir,
             path.join(projectDir, absSharedStageDir, ".k8s-adapter", "fetch-cache-seed"),
-            { recursive: true, dereference: true },
+            { recursive: true, dereference: true, mode: constants.COPYFILE_FICLONE },
           );
         }
         await cp(
           path.join(projectDir, "node_modules"),
           path.join(projectDir, absSharedStageDir, "node_modules"),
-          { recursive: true, dereference: true },
+          { recursive: true, dereference: true, mode: constants.COPYFILE_FICLONE },
         );
         // The app's package.json, with `type` forced to commonjs. The image executes only
         // BUILD OUTPUT (`<dist>/server/**/*.js`, which Turbopack emits as CJS) plus
@@ -2147,6 +2174,7 @@ export function createK8sAdapter(userConfig?: K8sAdapterConfig): NextAdapter {
         );
 
         const sharpStaging = await stageCommonRuntimeFiles("shared", true);
+        await pruneSharpContext(path.join(projectDir, absSharedStageDir));
 
         // Keep .env secrets out of the shared image (built from this context).
         await writeOutputFile(
@@ -2201,6 +2229,9 @@ export function createK8sAdapter(userConfig?: K8sAdapterConfig): NextAdapter {
           absSharedStageDir,
         );
       } else {
+        const poolSharpStaging: Array<{ staged: boolean; sharpVersion?: string }> = [];
+        const poolBaseDir = path.join(OUTPUT_DIR(), "pool-base");
+        await rm(path.join(projectDir, poolBaseDir), { recursive: true, force: true });
         for (const [poolName, pool] of pools) {
           const poolDir = path.join(OUTPUT_DIR(), "pools", poolName);
           const poolStageDir = path.join(poolDir, "context");
@@ -2316,6 +2347,8 @@ export function createK8sAdapter(userConfig?: K8sAdapterConfig): NextAdapter {
           await stageFile(projectDir, nextPkgDir, "node_modules/next", poolName);
 
           const sharpStaging = await stageCommonRuntimeFiles(poolName, false);
+          poolSharpStaging.push(sharpStaging);
+          await pruneSharpContext(path.join(projectDir, poolStageDir));
 
           // Keep .env secrets out of the pool image. The Dockerfile's
           // `COPY context/ .` runs from this pool dir (the docker build
@@ -2371,6 +2404,70 @@ export function createK8sAdapter(userConfig?: K8sAdapterConfig): NextAdapter {
             poolDir,
           );
         }
+
+        if (pools.size > 1) {
+          const sharpDecisions = new Set(
+            poolSharpStaging.map((staging) =>
+              staging.staged
+                ? "staged"
+                : staging.sharpVersion
+                  ? `install:${staging.sharpVersion}`
+                  : "unavailable",
+            ),
+          );
+          if (sharpDecisions.size > 1) {
+            console.warn(
+              `[adapter-k8s] Pool staging produced different sharp requirements ` +
+                `(${[...sharpDecisions].join(", ")}); keeping standalone pool images so each ` +
+                `pool retains its own native-runtime setup.`,
+            );
+          } else {
+            const sharpDecision = [...sharpDecisions][0]!;
+            const installSharpVersion = sharpDecision.startsWith("install:")
+              ? sharpDecision.slice("install:".length)
+              : undefined;
+            const poolContexts = [...pools.keys()].map((poolName) =>
+              path.join(projectDir, OUTPUT_DIR(), "pools", poolName, "context"),
+            );
+
+            const baseContext = path.join(projectDir, poolBaseDir);
+            const shared = await factorSharedPoolFiles(poolContexts, baseContext);
+            await writeOutputFile(projectDir, ".dockerignore", generateDockerignore(), poolBaseDir);
+            await writeOutputFile(
+              projectDir,
+              "Dockerfile",
+              generatePoolBaseDockerfile({
+                buildId,
+                targetPlatform: imageTargetPlatform,
+                ...(installSharpVersion ? { installSharpVersion } : {}),
+              }),
+              poolBaseDir,
+            );
+            for (const poolName of pools.keys()) {
+              await writeOutputFile(
+                projectDir,
+                "Dockerfile",
+                generateLayeredPoolDockerfile({ poolName, buildId }),
+                path.join(OUTPUT_DIR(), "pools", poolName),
+              );
+            }
+            poolImageLayout = SHARED_POOL_IMAGE_LAYOUT;
+            const eliminatedBytes = shared.sharedBytes * (pools.size - 1);
+            console.log(
+              `[adapter-k8s] Shared ${shared.sharedFiles.toLocaleString()} identical files ` +
+                `(${(shared.sharedBytes / 1024 / 1024).toFixed(1)} MiB) across ${pools.size} ` +
+                `pool images; removed ${(eliminatedBytes / 1024 / 1024).toFixed(1)} MiB of ` +
+                `repeated build context data.`,
+            );
+          }
+        }
+      }
+
+      if (prunedSharpPackages > 0) {
+        console.log(
+          `[adapter-k8s] Removed ${prunedSharpPackages} target-incompatible Sharp package(s) ` +
+            `(${(prunedSharpBytes / 1024 / 1024).toFixed(1)} MiB) from Linux image contexts.`,
+        );
       }
 
       // 6. Write final artifacts to output root for CLI visibility
@@ -2467,7 +2564,11 @@ export function createK8sAdapter(userConfig?: K8sAdapterConfig): NextAdapter {
           // rather than being shadowed by a stale copy from an earlier build.
           await rm(dest, { recursive: true, force: true });
           await mkdir(path.dirname(dest), { recursive: true });
-          await cp(depDir, dest, { recursive: true, dereference: true });
+          await cp(depDir, dest, {
+            recursive: true,
+            dereference: true,
+            mode: constants.COPYFILE_FICLONE,
+          });
         }
 
         // Keep .env secrets out of the routing-service image. `docker build`
@@ -2488,7 +2589,7 @@ export function createK8sAdapter(userConfig?: K8sAdapterConfig): NextAdapter {
           const mwRelPath = path.relative(projectDir, outputs.middleware.filePath);
           const mwDest = path.join(projectDir, routingServiceContextDir, mwRelPath);
           await mkdir(path.dirname(mwDest), { recursive: true });
-          await copyFile(outputs.middleware.filePath, mwDest);
+          await copyFile(outputs.middleware.filePath, mwDest, constants.COPYFILE_FICLONE);
           // Stage middleware's traced assets AND its wasmAssets (files and directories).
           // N50 (review #31): wasmAssets were never staged anywhere, and this tier is the one
           // that runs middleware at the edge — with ext_proc failing CLOSED whenever the app
@@ -2510,9 +2611,13 @@ export function createK8sAdapter(userConfig?: K8sAdapterConfig): NextAdapter {
               await mkdir(path.dirname(dest), { recursive: true });
               const stat = statSync(absAsset);
               if (stat.isDirectory()) {
-                await cp(absAsset, dest, { recursive: true, dereference: true });
+                await cp(absAsset, dest, {
+                  recursive: true,
+                  dereference: true,
+                  mode: constants.COPYFILE_FICLONE,
+                });
               } else {
-                await copyFile(absAsset, dest);
+                await copyFile(absAsset, dest, constants.COPYFILE_FICLONE);
               }
             }
           }
@@ -2561,7 +2666,11 @@ export function createK8sAdapter(userConfig?: K8sAdapterConfig): NextAdapter {
             // and shadow the current middleware's referenced chunk.
             await rm(chunksDest, { recursive: true, force: true });
             await mkdir(path.dirname(chunksDest), { recursive: true });
-            await cp(chunksDir, chunksDest, { recursive: true, dereference: true });
+            await cp(chunksDir, chunksDest, {
+              recursive: true,
+              dereference: true,
+              mode: constants.COPYFILE_FICLONE,
+            });
           }
         }
       } // end if (!skipStaging)
@@ -2570,9 +2679,14 @@ export function createK8sAdapter(userConfig?: K8sAdapterConfig): NextAdapter {
         const runtimeContexts =
           containerStrategy === "shared-image"
             ? [path.join(projectDir, OUTPUT_DIR(), "shared-context")]
-            : [...pools.keys()].map((poolName) =>
-                path.join(projectDir, OUTPUT_DIR(), "pools", poolName, "context"),
-              );
+            : [
+                ...(poolImageLayout === SHARED_POOL_IMAGE_LAYOUT
+                  ? [path.join(projectDir, OUTPUT_DIR(), "pool-base")]
+                  : []),
+                ...[...pools.keys()].map((poolName) =>
+                  path.join(projectDir, OUTPUT_DIR(), "pools", poolName, "context"),
+                ),
+              ];
         const routingContext = path.join(projectDir, OUTPUT_DIR(), "routing-service", "context");
         if (existsSync(routingContext)) runtimeContexts.push(routingContext);
         // next build traces bytes produced for the BUILD host. Docker's --platform flag does
@@ -2624,6 +2738,7 @@ export function createK8sAdapter(userConfig?: K8sAdapterConfig): NextAdapter {
           // the <distDir>/BUILD_ID mtime — see manifest.ts stableBuiltAt).
           generatedAt: routingManifest.builtAt,
           containerStrategy,
+          ...(poolImageLayout ? { poolImageLayout } : {}),
           hasMiddleware: !!outputs.middleware,
           failureModeAllow,
           cacheEnabled: cfg.cache?.enabled ?? false,

--- a/src/cli/deploy.ts
+++ b/src/cli/deploy.ts
@@ -1,6 +1,7 @@
 // src/cli/deploy.ts
 import path from "node:path";
 import { isIP } from "node:net";
+import { createHash } from "node:crypto";
 import { infrastructurePath, outputDirName } from "./infrastructure-validation.js";
 import {
   chmodSync,
@@ -83,6 +84,11 @@ import {
 } from "../target-platform.js";
 import type { GcloudCommand } from "./init.js";
 import type { RegistryAuthentication, RegistryDigestLookup } from "../composition-plan/index.js";
+import {
+  parsePoolImageLayout,
+  SHARED_POOL_IMAGE_LAYOUT,
+  type PoolImageLayout,
+} from "../pool-image-layout.js";
 import {
   assertCompositionPlanInvocation,
   compositionPlanNeedsExplicitConfirmation,
@@ -308,6 +314,7 @@ export interface DockerCommandOptions {
   registry: string;
   outputDir: string;
   containerStrategy: "traced-assets" | "shared-image";
+  poolImageLayout?: PoolImageLayout;
   /**
    * S24: which container CLI to shell out to. Defaults to docker for compatibility; the
    * deploy resolves the real one via resolveContainerCli(). Every verb used here — build,
@@ -344,7 +351,12 @@ export interface DockerCommandOptions {
 export function refreshFetchCacheStaging(
   projectDir: string,
   outputDir: string,
-  metadata: { distDir?: unknown; pools: string[]; containerStrategy: string },
+  metadata: {
+    distDir?: unknown;
+    pools: string[];
+    containerStrategy: string;
+    poolImageLayout?: unknown;
+  },
 ): void {
   // Validate at the point of consumption: distDir comes from build-metadata.json, which is
   // build-controlled. The same escape S20 rejects at build time is rejected here — the dest
@@ -357,6 +369,18 @@ export function refreshFetchCacheStaging(
         `project-relative path inside the project (S20). Re-run the build.`,
     );
   }
+  const poolImageLayout = parsePoolImageLayout(metadata.poolImageLayout);
+  if (poolImageLayout === SHARED_POOL_IMAGE_LAYOUT) {
+    // An older CLI does not understand the layout: it refreshes every pool delta, then the
+    // sentinel FROM fails. A retry with this CLI must remove those seeds because the child
+    // COPY overlays its parent and would otherwise shadow every later base refresh.
+    for (const pool of metadata.pools) {
+      rmSync(path.join(outputDir, "pools", pool, "context", ".k8s-adapter", "fetch-cache-seed"), {
+        recursive: true,
+        force: true,
+      });
+    }
+  }
   const src = path.join(projectDir, distDirRel, "cache", "fetch-cache");
   // Observable either way (M1 spirit): the silent-return variant of this function cost a
   // debugging round — an image shipped without the files and nothing said which of the two
@@ -368,7 +392,9 @@ export function refreshFetchCacheStaging(
   const contexts =
     metadata.containerStrategy === "shared-image"
       ? [path.join(outputDir, "shared-context")]
-      : metadata.pools.map((pool) => path.join(outputDir, "pools", pool, "context"));
+      : poolImageLayout === SHARED_POOL_IMAGE_LAYOUT
+        ? [path.join(outputDir, "pool-base", "fetch-cache")]
+        : metadata.pools.map((pool) => path.join(outputDir, "pools", pool, "context"));
   for (const context of contexts) {
     // A context can legitimately be absent (ADAPTER_K8S_SKIP_STAGING builds have no
     // contexts, and those deploys never reach the docker step anyway).
@@ -394,6 +420,10 @@ export function buildDockerCommands(options: DockerCommandOptions): GcloudComman
     "Docker target platform",
   )}`;
   const commands: GcloudCommand[] = [];
+  const poolImageLayout = parsePoolImageLayout(
+    options.poolImageLayout,
+    "Docker command poolImageLayout",
+  );
 
   // 0. Registry authentication — ONLY for Google registries.
   //
@@ -439,12 +469,37 @@ export function buildDockerCommands(options: DockerCommandOptions): GcloudComman
       args: ["push", tag],
     });
   } else {
+    let poolBaseTag: string | undefined;
+    if (poolImageLayout === SHARED_POOL_IMAGE_LAYOUT) {
+      const localTag = createHash("sha256")
+        .update(`${registry}\0${buildId}`)
+        .digest("hex")
+        .slice(0, 24);
+      poolBaseTag = `localhost/adapter-k8s-pool-base:${localTag}`;
+      commands.push({
+        description: "Build shared pool base",
+        command: cli,
+        args: ["build", platformArg, "-t", poolBaseTag, `${outputDir}/pool-base`],
+      });
+      commands.push({
+        description: "Verify shared pool base is visible in the container CLI image store",
+        command: cli,
+        args: ["image", "inspect", poolBaseTag],
+      });
+    }
     for (const pool of pools) {
       const tag = `${registry}/nextjs-app-${pool}:${buildId}`;
       commands.push({
         description: `Build ${pool} image`,
         command: cli,
-        args: ["build", platformArg, "-t", tag, `${outputDir}/pools/${pool}`],
+        args: [
+          "build",
+          platformArg,
+          ...(poolBaseTag ? ["--build-arg", `POOL_BASE_IMAGE=${poolBaseTag}`] : []),
+          "-t",
+          tag,
+          `${outputDir}/pools/${pool}`,
+        ],
       });
       commands.push({
         description: `Push ${pool} image`,
@@ -2015,6 +2070,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
   // 3. Read adapter config to determine container strategy
   // Default to traced-assets if not specified
   const containerStrategy = metadata.containerStrategy ?? "traced-assets";
+  const poolImageLayout = parsePoolImageLayout(metadata.poolImageLayout);
 
   // 4. Docker build + push
   // S7/S23: filled in below by resolveDeployImageDigests, for BOTH the push and --skip-push
@@ -2029,6 +2085,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
         distDir: metadata.distDir,
         pools,
         containerStrategy,
+        poolImageLayout,
       });
     }
     const dockerCommands = buildDockerCommands({
@@ -2037,6 +2094,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
       registry: infra.containerRegistry,
       outputDir: outputDirRelative,
       containerStrategy,
+      ...(poolImageLayout ? { poolImageLayout } : {}),
       containerCli,
       targetPlatform: builtTargetPlatform,
       ...(compositionSnapshot

--- a/src/emit/dockerfiles.ts
+++ b/src/emit/dockerfiles.ts
@@ -156,6 +156,55 @@ CMD ["node", "pool-server.cjs"]
 `;
 }
 
+/** Parent image for traced-assets builds with more than one pool. */
+export function generatePoolBaseDockerfile({
+  nodeVersion = DEFAULT_EMITTED_NODE_VERSION,
+  targetPlatform = DEFAULT_TARGET_PLATFORM,
+  buildId,
+  installSharpVersion,
+}: {
+  nodeVersion?: string;
+  targetPlatform?: TargetPlatform;
+  buildId: string;
+  installSharpVersion?: string;
+}): string {
+  assertSupportedNodeVersion(nodeVersion);
+  const sharpInstall =
+    installSharpVersion === undefined ? "" : sharpInstallStep(installSharpVersion, targetPlatform);
+  return `FROM ${baseImageRef(nodeVersion)}
+WORKDIR /app
+COPY --chown=node:node dependencies/ .
+${sharpInstall}COPY --chown=node:node content/ .
+COPY --chown=node:node fetch-cache/ .
+ENV NODE_ENV=production
+ENV NEXT_BUILD_ID=${buildId}
+ENV CONFIG_DIR=/app/config
+EXPOSE 3000
+USER node
+CMD ["node", "pool-server.cjs"]
+`;
+}
+
+/** Thin pool delta layered over the local parent built by the deploy command. */
+export function generateLayeredPoolDockerfile({
+  poolName,
+  buildId,
+}: {
+  poolName: string;
+  buildId: string;
+}): string {
+  return `ARG POOL_BASE_IMAGE=localhost/adapter-k8s-pool-base-required--update-cli:latest
+FROM \${POOL_BASE_IMAGE}
+COPY --chown=node:node context/ .
+ENV POOL_NAME=${poolName}
+ENV NEXT_BUILD_ID=${buildId}
+ENV CONFIG_DIR=/app/config
+EXPOSE 3000
+USER node
+CMD ["node", "pool-server.cjs"]
+`;
+}
+
 export function generateRoutingServiceDockerfile({
   nodeVersion = DEFAULT_EMITTED_NODE_VERSION,
   buildId,
@@ -174,9 +223,9 @@ export function generateRoutingServiceDockerfile({
   // TLS_KEY_FILE exist, and plaintext h2c otherwise (local emulate).
   return `FROM ${baseImageRef(nodeVersion)}
 WORKDIR /app
-COPY --chown=node:node context/ .
 RUN apt-get update && apt-get install -y --no-install-recommends openssl \\
  && rm -rf /var/lib/apt/lists/*
+COPY --chown=node:node context/ .
 ENV NODE_ENV=production
 ENV NEXT_BUILD_ID=${buildId}
 ENV CONFIG_DIR=/app/config

--- a/src/emit/metadata.ts
+++ b/src/emit/metadata.ts
@@ -15,6 +15,7 @@
 // Both are fixed the same way: the fields are REQUIRED. Callers supply defaults once, in
 // applyDefaults (config.ts), and this file only serializes what it is given.
 import { parseTargetPlatform, type TargetPlatform } from "../target-platform.js";
+import type { PoolImageLayout } from "../pool-image-layout.js";
 
 export function generateBuildMetadata({
   buildId,
@@ -28,6 +29,7 @@ export function generateBuildMetadata({
   containerRegistry,
   nodeCidrs,
   containerStrategy,
+  poolImageLayout,
   hasMiddleware,
   failureModeAllow,
   cacheEnabled,
@@ -59,6 +61,8 @@ export function generateBuildMetadata({
    */
   generatedAt: string;
   containerStrategy: "traced-assets" | "shared-image";
+  /** Optional so a newer CLI can still deploy standalone contexts emitted by older builds. */
+  poolImageLayout?: PoolImageLayout | undefined;
   hasMiddleware: boolean;
   /** ext_proc callout failure policy. `false` = fail CLOSED (middleware is never bypassed). */
   failureModeAllow: boolean;
@@ -110,6 +114,7 @@ export function generateBuildMetadata({
       generatedAt,
       distDir,
       containerStrategy,
+      ...(poolImageLayout ? { poolImageLayout } : {}),
       hasMiddleware,
       failureModeAllow,
       cacheEnabled,

--- a/src/native-artifacts.ts
+++ b/src/native-artifacts.ts
@@ -1,4 +1,4 @@
-import { open, opendir, stat } from "node:fs/promises";
+import { open, opendir, rm, stat } from "node:fs/promises";
 import path from "node:path";
 import { targetArchitecture, type TargetPlatform } from "./target-platform.js";
 
@@ -16,6 +16,75 @@ const PRISMA_ENGINE_RE =
   /(?:^|\/)(?:lib)?(?:query|schema|migration|introspection)[-_]engine(?:[-_.]|$)|(?:^|\/)prisma-fmt(?:[-_.]|$)/i;
 const PRISMA_MUSL_ENGINE_RE =
   /(?:^|\/)(?:(?:lib)?(?:query|schema|migration|introspection)[-_]engine|prisma-fmt)[-_.]linux-musl(?:[-_.]|$)/i;
+const SHARP_PLATFORM_PACKAGE_RE = /^sharp(?:-libvips)?-/;
+
+export interface PrunedSharpPackages {
+  packages: number;
+  files: number;
+  bytes: number;
+}
+
+async function directoryFileUsage(root: string): Promise<{ files: number; bytes: number }> {
+  let files = 0;
+  let bytes = 0;
+  const entries = await opendir(root);
+  for await (const entry of entries) {
+    const absolute = path.join(root, entry.name);
+    if (entry.isDirectory()) {
+      const nested = await directoryFileUsage(absolute);
+      files += nested.files;
+      bytes += nested.bytes;
+    } else if (entry.isFile()) {
+      files++;
+      bytes += (await stat(absolute)).size;
+    }
+  }
+  return { files, bytes };
+}
+
+/** Remove Sharp optional packages that cannot execute in the selected Linux image. */
+export async function pruneForeignSharpPackages(
+  contextRoot: string,
+  targetPlatform: TargetPlatform,
+): Promise<PrunedSharpPackages> {
+  const suffix = targetPlatform === "linux/arm64" ? "linux-arm64" : "linux-x64";
+  const keep = new Set([`sharp-${suffix}`, `sharp-libvips-${suffix}`]);
+  const result: PrunedSharpPackages = { packages: 0, files: 0, bytes: 0 };
+
+  const walk = async (directory: string): Promise<void> => {
+    const entries = await opendir(directory);
+    for await (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const absolute = path.join(directory, entry.name);
+      if (path.basename(directory) === "node_modules" && entry.name === "@img") {
+        const packages = await opendir(absolute);
+        for await (const packageEntry of packages) {
+          const packageDir = path.join(absolute, packageEntry.name);
+          if (
+            (packageEntry.isDirectory() || packageEntry.isSymbolicLink()) &&
+            SHARP_PLATFORM_PACKAGE_RE.test(packageEntry.name) &&
+            !keep.has(packageEntry.name)
+          ) {
+            if (packageEntry.isDirectory()) {
+              const usage = await directoryFileUsage(packageDir);
+              result.files += usage.files;
+              result.bytes += usage.bytes;
+            }
+            result.packages++;
+            await rm(packageDir, { recursive: true, force: true });
+          } else if (packageEntry.isDirectory()) {
+            await walk(packageDir);
+          }
+        }
+      } else {
+        await walk(absolute);
+      }
+    }
+  };
+
+  await walk(contextRoot);
+  return result;
+}
 
 // Sharp is the one native dependency this adapter retargets deliberately: staging selects the
 // requested @img pair, and the emitted Dockerfile installs that pair inside the target image

--- a/src/pool-image-layout.ts
+++ b/src/pool-image-layout.ts
@@ -1,0 +1,275 @@
+import { createHash } from "node:crypto";
+import { createReadStream } from "node:fs";
+import { lstat, mkdir, readdir, rename, rm, rmdir, unlink } from "node:fs/promises";
+import path from "node:path";
+
+export const SHARED_POOL_IMAGE_LAYOUT = "shared-base-v1" as const;
+export type PoolImageLayout = typeof SHARED_POOL_IMAGE_LAYOUT;
+
+export function parsePoolImageLayout(
+  value: unknown,
+  source = "build-metadata.json poolImageLayout",
+): PoolImageLayout | undefined {
+  if (value === undefined) return undefined;
+  if (value === SHARED_POOL_IMAGE_LAYOUT) return value;
+  throw new Error(
+    `Unsupported ${source} ${JSON.stringify(value)}. Upgrade @next-community/adapter-k8s ` +
+      `to a version that understands this image layout, or rebuild the application.`,
+  );
+}
+
+export interface SharedPoolFilesResult {
+  sharedFiles: number;
+  sharedBytes: number;
+  dependencyFiles: number;
+  dependencyBytes: number;
+  contentFiles: number;
+  contentBytes: number;
+  fetchCacheFiles: number;
+  fetchCacheBytes: number;
+}
+
+interface SharedFile {
+  relative: string;
+  candidates: IndexedFile[];
+}
+
+const MAX_CONCURRENT_DIGESTS = 64;
+const MAX_CONCURRENT_MUTATIONS = 32;
+
+interface IndexedFile {
+  absolute: string;
+  size: number;
+  mode: number;
+}
+
+async function regularFiles(
+  root: string,
+  relative = "",
+  files = new Map<string, IndexedFile>(),
+): Promise<Map<string, IndexedFile>> {
+  const dir = path.join(root, relative);
+  const entries = await readdir(dir, { withFileTypes: true });
+  for (const entry of entries.sort((left, right) => left.name.localeCompare(right.name))) {
+    const child = path.join(relative, entry.name);
+    if (entry.isDirectory()) await regularFiles(root, child, files);
+    else if (entry.isFile()) {
+      const absolute = path.join(root, child);
+      const info = await lstat(absolute);
+      files.set(child, { absolute, size: info.size, mode: info.mode });
+    }
+  }
+  return files;
+}
+
+async function fileDigest(file: string): Promise<string> {
+  const hash = createHash("sha256");
+  await new Promise<void>((resolve, reject) => {
+    const stream = createReadStream(file);
+    stream.on("data", (chunk) => hash.update(chunk));
+    stream.on("error", reject);
+    stream.on("end", resolve);
+  });
+  return hash.digest("hex");
+}
+
+function dependencyLayerPath(relative: string): boolean {
+  const parts = relative.split(path.sep);
+  return (
+    parts.includes("node_modules") ||
+    relative === "package.json" ||
+    relative === "pool-server.cjs" ||
+    relative === path.join(".k8s-adapter", "cache-handler.cjs")
+  );
+}
+
+function fetchCacheLayerPath(relative: string): boolean {
+  return relative.startsWith(path.join(".k8s-adapter", "fetch-cache-seed") + path.sep);
+}
+
+function parentDirectories(relativeFile: string): string[] {
+  const directories: string[] = [];
+  let current = path.dirname(relativeFile);
+  while (current !== ".") {
+    directories.push(current);
+    current = path.dirname(current);
+  }
+  return directories;
+}
+
+async function removeEmptiedDirectories(root: string, directories: Set<string>): Promise<void> {
+  const deepestFirst = [...directories].sort(
+    (left, right) => right.split(path.sep).length - left.split(path.sep).length,
+  );
+  for (const relative of deepestFirst) {
+    try {
+      await rmdir(path.join(root, relative));
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code !== "ENOTEMPTY" && code !== "EEXIST" && code !== "ENOENT") throw error;
+    }
+  }
+}
+
+async function runBounded<T>(
+  values: readonly T[],
+  limit: number,
+  operation: (value: T) => Promise<void>,
+): Promise<void> {
+  let next = 0;
+  const worker = async (): Promise<void> => {
+    while (next < values.length) {
+      const value = values[next++]!;
+      await operation(value);
+    }
+  };
+  const outcomes = await Promise.allSettled(
+    Array.from({ length: Math.min(limit, values.length) }, async () => worker()),
+  );
+  const failure = outcomes.find(
+    (outcome): outcome is PromiseRejectedResult => outcome.status === "rejected",
+  );
+  if (failure) throw failure.reason;
+}
+
+/**
+ * Move files that are identical at the same path in every pool into one OCI parent context.
+ * A file with different bytes, mode, type, or presence stays in every pool delta.
+ */
+export async function factorSharedPoolFiles(
+  poolContexts: string[],
+  baseContext: string,
+): Promise<SharedPoolFilesResult> {
+  if (poolContexts.length < 2) {
+    throw new Error("Shared pool image factoring requires at least two pool contexts.");
+  }
+  await rm(baseContext, { recursive: true, force: true });
+  await Promise.all(
+    ["dependencies", "content", "fetch-cache"].map((layer) =>
+      mkdir(path.join(baseContext, layer), { recursive: true }),
+    ),
+  );
+  const result: SharedPoolFilesResult = {
+    sharedFiles: 0,
+    sharedBytes: 0,
+    dependencyFiles: 0,
+    dependencyBytes: 0,
+    contentFiles: 0,
+    contentBytes: 0,
+    fetchCacheFiles: 0,
+    fetchCacheBytes: 0,
+  };
+
+  // Index every context without following symlinked directories. Looking up candidates by
+  // relative path after this pass prevents a real directory in one pool from traversing a
+  // symlinked ancestor in another pool and moving bytes outside its build context.
+  const indexes = await Promise.all(poolContexts.map((context) => regularFiles(context)));
+  const relatives = [...indexes[0]!.keys()].sort();
+  const sharedFiles: SharedFile[] = [];
+  const emptiedDirectories = poolContexts.map(() => new Set<string>());
+  let nextIndex = 0;
+  let activeDigests = 0;
+  const digestWaiters: Array<() => void> = [];
+  const boundedDigest = async (file: string): Promise<string> => {
+    while (activeDigests >= MAX_CONCURRENT_DIGESTS) {
+      await new Promise<void>((resolve) => digestWaiters.push(resolve));
+    }
+    activeDigests++;
+    try {
+      return await fileDigest(file);
+    } finally {
+      activeDigests--;
+      digestWaiters.shift()?.();
+    }
+  };
+  const inspect = async (): Promise<void> => {
+    while (nextIndex < relatives.length) {
+      const relative = relatives[nextIndex++]!;
+      const candidates = indexes.map((index) => index.get(relative));
+      if (candidates.some((candidate) => candidate === undefined)) continue;
+      const complete = candidates as IndexedFile[];
+      const first = complete[0]!;
+      if (
+        complete.some((candidate) => candidate.size !== first.size || candidate.mode !== first.mode)
+      )
+        continue;
+
+      const digests = await Promise.all(
+        complete.map((candidate) => boundedDigest(candidate.absolute)),
+      );
+      if (digests.some((digest) => digest !== digests[0])) continue;
+      sharedFiles.push({ relative, candidates: complete });
+    }
+  };
+  // Hashing is read-only and independent by path. The path workers remove most of the serial
+  // I/O tax; boundedDigest caps total open streams even when a build defines many pools.
+  await Promise.all(Array.from({ length: Math.min(32, relatives.length) }, async () => inspect()));
+
+  const orderedSharedFiles = sharedFiles.sort((left, right) =>
+    left.relative.localeCompare(right.relative),
+  );
+  const destinationDirectories = new Set<string>();
+  for (const { relative, candidates } of orderedSharedFiles) {
+    const first = candidates[0]!;
+    const dependency = dependencyLayerPath(relative);
+    const fetchCache = fetchCacheLayerPath(relative);
+    const layer = dependency ? "dependencies" : fetchCache ? "fetch-cache" : "content";
+    const destination = path.join(baseContext, layer, relative);
+    destinationDirectories.add(path.dirname(destination));
+    for (const [index] of candidates.entries()) {
+      for (const directory of parentDirectories(relative)) {
+        emptiedDirectories[index]!.add(directory);
+      }
+    }
+
+    result.sharedFiles++;
+    result.sharedBytes += first.size;
+    if (dependency) {
+      result.dependencyFiles++;
+      result.dependencyBytes += first.size;
+    } else if (fetchCache) {
+      result.fetchCacheFiles++;
+      result.fetchCacheBytes += first.size;
+    } else {
+      result.contentFiles++;
+      result.contentBytes += first.size;
+    }
+  }
+
+  // A real multi-pool app commonly has tens of thousands of shared files but only a few
+  // dozen destination directories. Create each directory once, then move independent paths
+  // concurrently. The per-file serial mkdir/rename/unlink loop was the largest remaining
+  // factoring cost on the four-pool fixture.
+  await runBounded(
+    [...destinationDirectories].sort(),
+    MAX_CONCURRENT_MUTATIONS,
+    async (directory) => {
+      await mkdir(directory, { recursive: true });
+    },
+  );
+  const mutationLimit = Math.max(
+    1,
+    Math.min(MAX_CONCURRENT_MUTATIONS, Math.floor(64 / poolContexts.length)),
+  );
+  await runBounded(orderedSharedFiles, mutationLimit, async ({ relative, candidates }) => {
+    const dependency = dependencyLayerPath(relative);
+    const fetchCache = fetchCacheLayerPath(relative);
+    const layer = dependency ? "dependencies" : fetchCache ? "fetch-cache" : "content";
+    const destination = path.join(baseContext, layer, relative);
+    await rename(candidates[0]!.absolute, destination);
+    const unlinks = await Promise.allSettled(
+      candidates.slice(1).map((candidate) => unlink(candidate.absolute)),
+    );
+    const failure = unlinks.find(
+      (outcome): outcome is PromiseRejectedResult => outcome.status === "rejected",
+    );
+    if (failure) throw failure.reason;
+  });
+
+  await Promise.all(
+    poolContexts.map((context, index) =>
+      removeEmptiedDirectories(context, emptiedDirectories[index]!),
+    ),
+  );
+  return result;
+}

--- a/tests/adapter-build-context.test.ts
+++ b/tests/adapter-build-context.test.ts
@@ -15,7 +15,7 @@ import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, existsSync
 import os from "node:os";
 import path from "node:path";
 import { createK8sAdapter } from "../src/adapter.js";
-import { mockOutputs, mockAppPage, mockRouting } from "./helpers/mock-outputs.js";
+import { mockOutputs, mockAppPage, mockAppRoute, mockRouting } from "./helpers/mock-outputs.js";
 import type { K8sAdapterConfig } from "../src/types.js";
 
 const validConfig: K8sAdapterConfig = {
@@ -192,6 +192,50 @@ describe("CEL public-file handling (N40, post-exclusion-removal)", () => {
 });
 
 describe("pool build context staging", () => {
+  it("emits one shared runtime base and thin, disjoint deltas for multiple pools", async () => {
+    seedProject();
+    const route = writeFile(".next/server/app/api/hello/route.js", "module.exports={}");
+    const ctx = ctxFor() as any;
+    ctx.outputs.appRoutes = [mockAppRoute({ pathname: "/api/hello", filePath: route, assets: {} })];
+    const config: K8sAdapterConfig = {
+      ...structuredClone(validConfig),
+      pools: {
+        web: { routes: ["appPages"] },
+        api: { routes: ["appRoutes"] },
+      },
+    };
+
+    await createK8sAdapter(config).onBuildComplete!(ctx);
+
+    const output = path.join(projectDir, ".k8s-adapter/output");
+    expect(
+      existsSync(path.join(output, "pool-base/dependencies/node_modules/next/package.json")),
+    ).toBe(true);
+    expect(
+      existsSync(
+        path.join(output, "pool-base/content/.next/server/chunks/[root-of-the-server]__abc.js"),
+      ),
+    ).toBe(true);
+    expect(
+      existsSync(path.join(output, "pool-base/fetch-cache/.k8s-adapter/fetch-cache-seed/entry")),
+    ).toBe(true);
+    expect(existsSync(path.join(output, "pools/web/context/.next/server/app/page.js"))).toBe(true);
+    expect(
+      existsSync(path.join(output, "pools/api/context/.next/server/app/api/hello/route.js")),
+    ).toBe(true);
+    expect(existsSync(path.join(output, "pools/api/context/.next/server/app/page.js"))).toBe(false);
+    expect(
+      existsSync(path.join(output, "pools/web/context/.next/server/app/api/hello/route.js")),
+    ).toBe(false);
+    expect(readFileSync(path.join(output, "pools/web/Dockerfile"), "utf8")).toContain(
+      "FROM ${POOL_BASE_IMAGE}",
+    );
+    expect(readFileSync(path.join(output, "pool-base/Dockerfile"), "utf8")).toContain(
+      "COPY --chown=node:node dependencies/ .",
+    );
+    expect(JSON.parse(outputFile("build-metadata.json")).poolImageLayout).toBe("shared-base-v1");
+  });
+
   it("stages handler, traced assets, chunks, public files, next and @next/routing", async () => {
     const { chunk } = seedProject();
     await build({ handlerAssets: { ".next/server/app/page.js.nft.json": chunk } });
@@ -206,6 +250,22 @@ describe("pool build context staging", () => {
     expect(JSON.parse(readFileSync(poolContext("package.json"), "utf-8"))).toEqual({
       type: "commonjs",
     });
+  });
+
+  it("drops traced Sharp packages for other platforms but retains the selected Linux pair", async () => {
+    seedProject();
+    const darwin = writeFile("node_modules/@img/sharp-darwin-arm64/lib/sharp.node", "darwin");
+    const linux = writeFile("node_modules/@img/sharp-linux-x64/lib/sharp.node", "linux");
+
+    await build({
+      handlerAssets: {
+        "node_modules/@img/sharp-darwin-arm64/lib/sharp.node": darwin,
+        "node_modules/@img/sharp-linux-x64/lib/sharp.node": linux,
+      },
+    });
+
+    expect(existsSync(poolContext("node_modules/@img/sharp-darwin-arm64"))).toBe(false);
+    expect(existsSync(poolContext("node_modules/@img/sharp-linux-x64/lib/sharp.node"))).toBe(true);
   });
 
   // `next` is the APP's dependency: the staged copy must be the version the app builds

--- a/tests/cli/deploy.test.ts
+++ b/tests/cli/deploy.test.ts
@@ -88,6 +88,48 @@ describe("refreshFetchCacheStaging", () => {
     expect(existsSync(path.join(base, "stale"))).toBe(false);
   });
 
+  it("copies once into the shared pool base for the layered traced-assets layout", () => {
+    write(".next/cache/fetch-cache/abc123", "entry-bytes");
+    write(".k8s-adapter/output/pool-base/fetch-cache/.keep");
+    write(".k8s-adapter/output/pools/ssr/context/pool-manifest.json");
+    write(".k8s-adapter/output/pools/api/context/pool-manifest.json");
+    write(
+      ".k8s-adapter/output/pools/ssr/context/.k8s-adapter/fetch-cache-seed/stale",
+      "old-cli seed",
+    );
+    write(
+      ".k8s-adapter/output/pools/api/context/.k8s-adapter/fetch-cache-seed/stale",
+      "old-cli seed",
+    );
+
+    refreshFetchCacheStaging(projectDir, path.join(projectDir, ".k8s-adapter/output"), {
+      distDir: ".next",
+      pools: ["ssr", "api"],
+      containerStrategy: "traced-assets",
+      poolImageLayout: "shared-base-v1",
+    });
+
+    expect(
+      readFileSync(
+        path.join(
+          projectDir,
+          ".k8s-adapter/output/pool-base/fetch-cache/.k8s-adapter/fetch-cache-seed/abc123",
+        ),
+        "utf8",
+      ),
+    ).toBe("entry-bytes");
+    for (const pool of ["ssr", "api"]) {
+      expect(
+        existsSync(
+          path.join(
+            projectDir,
+            `.k8s-adapter/output/pools/${pool}/context/.k8s-adapter/fetch-cache-seed`,
+          ),
+        ),
+      ).toBe(false);
+    }
+  });
+
   it("no-ops when the build produced no fetch-cache, and skips absent contexts", () => {
     write(".k8s-adapter/output/pools/ssr/context/pool-server.cjs");
     refreshFetchCacheStaging(projectDir, path.join(projectDir, ".k8s-adapter/output"), {
@@ -124,6 +166,17 @@ describe("refreshFetchCacheStaging", () => {
       rmSync(victim, { recursive: true, force: true });
     }
   });
+
+  it("refuses an image layout that this CLI does not understand", () => {
+    write(".next/cache/fetch-cache/abc", "x");
+    expect(() =>
+      refreshFetchCacheStaging(projectDir, path.join(projectDir, ".k8s-adapter/output"), {
+        pools: ["ssr"],
+        containerStrategy: "traced-assets",
+        poolImageLayout: "shared-base-v2",
+      }),
+    ).toThrow(/Unsupported.*shared-base-v2.*Upgrade/);
+  });
 });
 
 describe("buildDockerCommands", () => {
@@ -145,6 +198,52 @@ describe("buildDockerCommands", () => {
     expect(commands[1]!.args).toContain(`${registry}/nextjs-app-ssr:abc123`);
     expect(commands[2]!.args).toContain("push");
     expect(commands[2]!.args).toContain(`${registry}/nextjs-app-ssr:abc123`);
+  });
+
+  it("builds one local pool base and makes every thin pool image inherit it", () => {
+    const registry = "ghcr.io/example/app";
+    const commands = buildDockerCommands({
+      pools: ["web", "api"],
+      buildId: "abc123",
+      registry,
+      outputDir: ".k8s-adapter/output",
+      containerStrategy: "traced-assets",
+      poolImageLayout: "shared-base-v1",
+      includeRoutingService: false,
+    });
+
+    expect(commands).toHaveLength(6);
+    expect(commands[0]!.description).toBe("Build shared pool base");
+    expect(commands[0]!.args.at(-1)).toBe(".k8s-adapter/output/pool-base");
+    const baseTag = commands[0]!.args[commands[0]!.args.indexOf("-t") + 1]!;
+    expect(baseTag).toMatch(/^localhost\/adapter-k8s-pool-base:[a-f0-9]{24}$/);
+    expect(commands.filter((command) => command.description.includes("Push shared"))).toEqual([]);
+    expect(commands[1]).toEqual({
+      description: "Verify shared pool base is visible in the container CLI image store",
+      command: "docker",
+      args: ["image", "inspect", baseTag],
+    });
+    for (const pool of ["web", "api"]) {
+      const build = commands.find((command) => command.description === `Build ${pool} image`)!;
+      expect(build.args).toContain("--build-arg");
+      expect(build.args).toContain(`POOL_BASE_IMAGE=${baseTag}`);
+      expect(build.args.at(-1)).toBe(`.k8s-adapter/output/pools/${pool}`);
+    }
+    expect(commands[3]!.description).toBe("Push web image");
+    expect(commands[5]!.description).toBe("Push api image");
+  });
+
+  it("refuses build commands for an unknown pool image layout", () => {
+    expect(() =>
+      buildDockerCommands({
+        pools: ["web", "api"],
+        buildId: "abc123",
+        registry: "ghcr.io/example/app",
+        outputDir: "out",
+        containerStrategy: "traced-assets",
+        poolImageLayout: "shared-base-v2" as never,
+      }),
+    ).toThrow(/Unsupported.*shared-base-v2.*Upgrade/);
   });
 
   it("S24: uses the resolved container CLI, not a hardcoded docker", () => {

--- a/tests/emit/dockerfiles.test.ts
+++ b/tests/emit/dockerfiles.test.ts
@@ -2,6 +2,8 @@
 import { describe, it, expect } from "vitest";
 import {
   generateDockerfile,
+  generateLayeredPoolDockerfile,
+  generatePoolBaseDockerfile,
   generatePoolDockerfile,
   generateRoutingServiceDockerfile,
   DEFAULT_EMITTED_NODE_VERSION,
@@ -168,6 +170,36 @@ describe("generatePoolDockerfile", () => {
   });
 });
 
+describe("shared pool image layers", () => {
+  it("installs dependencies once in a reusable base before copying build content", () => {
+    const result = generatePoolBaseDockerfile({
+      buildId: "abc123",
+      installSharpVersion: "0.34.5",
+    });
+    expect(result).toContain("FROM node:24-slim");
+    expect(result).toContain("COPY --chown=node:node dependencies/ .");
+    expect(result).toContain("COPY --chown=node:node content/ .");
+    expect(result).toContain("COPY --chown=node:node fetch-cache/ .");
+    expect(result.indexOf("dependencies/ .")).toBeLessThan(result.indexOf("RUN npm install"));
+    expect(result.indexOf("RUN npm install")).toBeLessThan(result.indexOf("content/ ."));
+    expect(result.indexOf("content/ .")).toBeLessThan(result.indexOf("fetch-cache/ ."));
+    expect(result).not.toContain("POOL_NAME");
+    expect(result).toContain('CMD ["node", "pool-server.cjs"]');
+  });
+
+  it("emits a thin pool image whose parent is supplied by the deploy step", () => {
+    const result = generateLayeredPoolDockerfile({ poolName: "api", buildId: "abc123" });
+    expect(result).toContain(
+      "ARG POOL_BASE_IMAGE=localhost/adapter-k8s-pool-base-required--update-cli:latest\n" +
+        "FROM ${POOL_BASE_IMAGE}\n",
+    );
+    expect(result).toContain("COPY --chown=node:node context/ .");
+    expect(result).toContain("ENV POOL_NAME=api");
+    expect(result).not.toContain("node:24-slim");
+    expect(result).not.toContain("npm install");
+  });
+});
+
 describe("generateRoutingServiceDockerfile", () => {
   it("generates a Dockerfile for the routing service", () => {
     const result = generateRoutingServiceDockerfile({ buildId: "abc123" });
@@ -178,6 +210,9 @@ describe("generateRoutingServiceDockerfile", () => {
     expect(result).toContain("COPY --chown=node:node context/ .");
     expect(result).toContain("USER node");
     expect(result).not.toContain("POOL_NAME");
+    expect(result.indexOf("apt-get install")).toBeLessThan(
+      result.indexOf("COPY --chown=node:node context/ ."),
+    );
   });
 
   it("does not bake a TLS cert into the image — the runtime generates one under /tmp/tls", () => {

--- a/tests/emit/metadata.test.ts
+++ b/tests/emit/metadata.test.ts
@@ -73,4 +73,12 @@ describe("generateBuildMetadata", () => {
         .cacheMemorystore,
     ).toEqual({ region: "us-central1" });
   });
+
+  it("records the shared pool image layout only when the build emitted it", () => {
+    expect(JSON.parse(generateBuildMetadata(base)).poolImageLayout).toBeUndefined();
+    expect(
+      JSON.parse(generateBuildMetadata({ ...base, poolImageLayout: "shared-base-v1" }))
+        .poolImageLayout,
+    ).toBe("shared-base-v1");
+  });
 });

--- a/tests/native-artifacts.test.ts
+++ b/tests/native-artifacts.test.ts
@@ -1,10 +1,11 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import {
   assertStagedNativeArtifactsTargetPlatform,
   findForeignNativeArtifacts,
+  pruneForeignSharpPackages,
 } from "../src/native-artifacts.js";
 
 const roots: string[] = [];
@@ -140,5 +141,47 @@ describe("staged native artifact target contract", () => {
     );
 
     await expect(findForeignNativeArtifacts(root, "linux/amd64")).resolves.toEqual([]);
+  });
+});
+
+describe("Sharp image-context pruning", () => {
+  it("removes host and foreign optional packages while retaining the target pair and colour", async () => {
+    const root = context();
+    write(root, "node_modules/@img/sharp-darwin-arm64/lib/sharp.node", Buffer.alloc(11));
+    write(root, "node_modules/@img/sharp-libvips-darwin-arm64/lib/libvips.dylib", Buffer.alloc(13));
+    write(root, "node_modules/@img/sharp-linux-x64/lib/sharp.node", Buffer.alloc(17));
+    write(root, "node_modules/@img/sharp-libvips-linux-x64/lib/libvips.so", Buffer.alloc(19));
+    write(root, "node_modules/@img/colour/index.js", Buffer.alloc(23));
+    write(
+      root,
+      "node_modules/wrapper/node_modules/@img/sharp-linux-arm64/lib/sharp.node",
+      Buffer.alloc(29),
+    );
+
+    await expect(pruneForeignSharpPackages(root, "linux/amd64")).resolves.toEqual({
+      packages: 3,
+      files: 3,
+      bytes: 53,
+    });
+    expect(existsSync(path.join(root, "node_modules/@img/sharp-darwin-arm64"))).toBe(false);
+    expect(existsSync(path.join(root, "node_modules/@img/sharp-libvips-darwin-arm64"))).toBe(false);
+    expect(
+      existsSync(path.join(root, "node_modules/wrapper/node_modules/@img/sharp-linux-arm64")),
+    ).toBe(false);
+    expect(existsSync(path.join(root, "node_modules/@img/sharp-linux-x64"))).toBe(true);
+    expect(existsSync(path.join(root, "node_modules/@img/sharp-libvips-linux-x64"))).toBe(true);
+    expect(existsSync(path.join(root, "node_modules/@img/colour"))).toBe(true);
+  });
+
+  it("retains the arm64 pair for an arm64 image", async () => {
+    const root = context();
+    write(root, "node_modules/@img/sharp-linux-arm64/lib/sharp.node", Buffer.alloc(7));
+    write(root, "node_modules/@img/sharp-libvips-linux-arm64/lib/libvips.so", Buffer.alloc(9));
+
+    await expect(pruneForeignSharpPackages(root, "linux/arm64")).resolves.toEqual({
+      packages: 0,
+      files: 0,
+      bytes: 0,
+    });
   });
 });

--- a/tests/pool-image-layout.test.ts
+++ b/tests/pool-image-layout.test.ts
@@ -1,0 +1,249 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  chmodSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { factorSharedPoolFiles } from "../src/pool-image-layout.js";
+
+const roots: string[] = [];
+
+function tempDir(): string {
+  const root = mkdtempSync(path.join(os.tmpdir(), "pool-image-layout-"));
+  roots.push(root);
+  return root;
+}
+
+function write(root: string, relative: string, contents: string, mode?: number): void {
+  const file = path.join(root, relative);
+  mkdirSync(path.dirname(file), { recursive: true });
+  writeFileSync(file, contents);
+  if (mode !== undefined) chmodSync(file, mode);
+}
+
+type FileSnapshot = { contents: string; mode: number; uid: number; gid: number };
+
+function snapshot(root: string, relative = ""): Map<string, FileSnapshot> {
+  const files = new Map<string, FileSnapshot>();
+  for (const entry of readdirSync(path.join(root, relative), { withFileTypes: true })) {
+    const child = path.join(relative, entry.name);
+    if (entry.isDirectory()) {
+      for (const [name, value] of snapshot(root, child)) files.set(name, value);
+    } else if (entry.isFile()) {
+      const info = lstatSync(path.join(root, child));
+      files.set(child, {
+        contents: readFileSync(path.join(root, child), "utf8"),
+        mode: info.mode,
+        uid: info.uid,
+        gid: info.gid,
+      });
+    }
+  }
+  return files;
+}
+
+function mergedSnapshot(base: string, delta: string): Map<string, FileSnapshot> {
+  const merged = new Map<string, FileSnapshot>();
+  for (const layer of ["dependencies", "content", "fetch-cache"]) {
+    for (const [name, value] of snapshot(path.join(base, layer))) merged.set(name, value);
+  }
+  for (const [name, value] of snapshot(delta)) merged.set(name, value);
+  return merged;
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("factorSharedPoolFiles", () => {
+  it("moves only byte-and-mode-identical files shared by every pool", async () => {
+    const root = tempDir();
+    const web = path.join(root, "web");
+    const api = path.join(root, "api");
+    const base = path.join(root, "base");
+
+    for (const pool of [web, api]) {
+      write(pool, "node_modules/next/package.json", "same dependency");
+      write(pool, ".next/server/chunks/common.js", "same content");
+      write(pool, "config/routing-manifest.json", "same config");
+    }
+    write(web, "config/pool-manifest-web.json", "web only");
+    write(api, "config/pool-manifest-api.json", "api only");
+    write(web, ".next/server/app/page.js", "web handler");
+    write(api, ".next/server/app/page.js", "api handler");
+    write(web, "bin/tool", "same bytes", 0o755);
+    write(api, "bin/tool", "same bytes", 0o644);
+
+    const result = await factorSharedPoolFiles([web, api], base);
+
+    expect(result).toEqual({
+      sharedFiles: 3,
+      sharedBytes:
+        Buffer.byteLength("same dependency") +
+        Buffer.byteLength("same content") +
+        Buffer.byteLength("same config"),
+      dependencyFiles: 1,
+      dependencyBytes: Buffer.byteLength("same dependency"),
+      contentFiles: 2,
+      contentBytes: Buffer.byteLength("same content") + Buffer.byteLength("same config"),
+      fetchCacheFiles: 0,
+      fetchCacheBytes: 0,
+    });
+    expect(
+      readFileSync(path.join(base, "dependencies/node_modules/next/package.json"), "utf8"),
+    ).toBe("same dependency");
+    expect(readFileSync(path.join(base, "content/.next/server/chunks/common.js"), "utf8")).toBe(
+      "same content",
+    );
+    expect(readFileSync(path.join(base, "content/config/routing-manifest.json"), "utf8")).toBe(
+      "same config",
+    );
+    for (const pool of [web, api]) {
+      expect(existsSync(path.join(pool, "node_modules/next/package.json"))).toBe(false);
+      expect(existsSync(path.join(pool, ".next/server/chunks/common.js"))).toBe(false);
+      expect(existsSync(path.join(pool, "config/routing-manifest.json"))).toBe(false);
+      expect(existsSync(path.join(pool, "bin/tool"))).toBe(true);
+    }
+    expect(readFileSync(path.join(web, ".next/server/app/page.js"), "utf8")).toBe("web handler");
+    expect(readFileSync(path.join(api, ".next/server/app/page.js"), "utf8")).toBe("api handler");
+  });
+
+  it("replaces stale base output before factoring a rebuild", async () => {
+    const root = tempDir();
+    const web = path.join(root, "web");
+    const api = path.join(root, "api");
+    const base = path.join(root, "base");
+    write(base, "content/stale.js", "old");
+    write(web, "fresh.js", "new");
+    write(api, "fresh.js", "new");
+
+    await factorSharedPoolFiles([web, api], base);
+
+    expect(existsSync(path.join(base, "content/stale.js"))).toBe(false);
+    expect(readFileSync(path.join(base, "content/fresh.js"), "utf8")).toBe("new");
+  });
+
+  it("keeps the deploy-time fetch-cache seed in a separate final layer", async () => {
+    const root = tempDir();
+    const web = path.join(root, "web");
+    const api = path.join(root, "api");
+    const base = path.join(root, "base");
+    for (const pool of [web, api]) {
+      write(pool, ".k8s-adapter/fetch-cache-seed/key", "seed");
+      write(pool, "pool-server.cjs", "runtime");
+    }
+
+    const result = await factorSharedPoolFiles([web, api], base);
+
+    expect(result.fetchCacheFiles).toBe(1);
+    expect(result.fetchCacheBytes).toBe(4);
+    expect(
+      readFileSync(path.join(base, "fetch-cache/.k8s-adapter/fetch-cache-seed/key"), "utf8"),
+    ).toBe("seed");
+  });
+
+  it("preserves each pool's merged paths, bytes, modes, and ownership", async () => {
+    const root = tempDir();
+    const web = path.join(root, "web");
+    const api = path.join(root, "api");
+    const base = path.join(root, "base");
+    for (const pool of [web, api]) {
+      write(pool, "node_modules/next/index.js", "runtime", 0o755);
+      write(pool, ".next/server/chunks/common.js", "chunk");
+      write(pool, ".k8s-adapter/fetch-cache-seed/key", "seed");
+    }
+    write(web, ".next/server/app/page.js", "web");
+    write(api, ".next/server/app/route.js", "api");
+    const before = [snapshot(web), snapshot(api)];
+
+    await factorSharedPoolFiles([web, api], base);
+
+    expect(mergedSnapshot(base, web)).toEqual(before[0]);
+    expect(mergedSnapshot(base, api)).toEqual(before[1]);
+  });
+
+  it("leaves symlinks and everything below symlinked ancestors in the pool delta", async () => {
+    const root = tempDir();
+    const target = path.join(root, "target");
+    const web = path.join(root, "web");
+    const api = path.join(root, "api");
+    const base = path.join(root, "base");
+    write(target, "nested/file.js", "outside");
+    mkdirSync(web, { recursive: true });
+    mkdirSync(api, { recursive: true });
+    symlinkSync(target, path.join(web, "linked"));
+    symlinkSync(target, path.join(api, "linked"));
+    write(web, "common.js", "shared");
+    write(api, "common.js", "shared");
+
+    await factorSharedPoolFiles([web, api], base);
+
+    expect(lstatSync(path.join(web, "linked")).isSymbolicLink()).toBe(true);
+    expect(lstatSync(path.join(api, "linked")).isSymbolicLink()).toBe(true);
+    expect(existsSync(path.join(base, "content/linked"))).toBe(false);
+  });
+
+  it("does not traverse a symlinked ancestor present in only one pool", async () => {
+    const root = tempDir();
+    const target = path.join(root, "target");
+    const web = path.join(root, "web");
+    const api = path.join(root, "api");
+    const base = path.join(root, "base");
+    write(target, "file.js", "same bytes");
+    write(web, "linked/file.js", "same bytes");
+    mkdirSync(api, { recursive: true });
+    symlinkSync(target, path.join(api, "linked"));
+
+    await factorSharedPoolFiles([web, api], base);
+
+    expect(readFileSync(path.join(web, "linked/file.js"), "utf8")).toBe("same bytes");
+    expect(readFileSync(path.join(target, "file.js"), "utf8")).toBe("same bytes");
+    expect(existsSync(path.join(base, "content/linked/file.js"))).toBe(false);
+  });
+
+  it("supports an empty pool delta and leaves a single pool on the legacy layout", async () => {
+    const root = tempDir();
+    const web = path.join(root, "web");
+    const api = path.join(root, "api");
+    const base = path.join(root, "base");
+    write(web, "same.js", "shared");
+    write(api, "same.js", "shared");
+    await factorSharedPoolFiles([web, api], base);
+    expect(readdirSync(web)).toEqual([]);
+    expect(readdirSync(api)).toEqual([]);
+
+    const only = path.join(root, "only");
+    write(only, "untouched.js", "one pool");
+    await expect(factorSharedPoolFiles([only], path.join(root, "unused"))).rejects.toThrow(
+      /at least two/,
+    );
+    expect(readFileSync(path.join(only, "untouched.js"), "utf8")).toBe("one pool");
+  });
+
+  it("preserves empty directories that existed before factoring", async () => {
+    const root = tempDir();
+    const web = path.join(root, "web");
+    const api = path.join(root, "api");
+    const base = path.join(root, "base");
+    for (const pool of [web, api]) {
+      write(pool, "nested/common.js", "shared");
+      mkdirSync(path.join(pool, "keep-empty"), { recursive: true });
+    }
+
+    await factorSharedPoolFiles([web, api], base);
+
+    expect(existsSync(path.join(web, "nested"))).toBe(false);
+    expect(existsSync(path.join(api, "nested"))).toBe(false);
+    expect(existsSync(path.join(web, "keep-empty"))).toBe(true);
+    expect(existsSync(path.join(api, "keep-empty"))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- share byte- and mode-identical traced runtime files through one reusable pool parent image
- remove target-incompatible Sharp packages and keep pool-specific handlers in small child layers
- reduce staging and rebuild work without changing image tags, runtime routes, or legacy single-pool output

## Motivation

A four-pool Next.js build staged `1,229.17 MiB` across its pool contexts. Most of that data was the same Next.js runtime, dependencies, chunks, and static content copied once per pool, so the builder, registry, and Kubernetes nodes processed the same bytes repeatedly.

## Changes

- index each pool context without following symlinks and compare regular files by path, mode, size, and SHA-256
- move files shared by every pool into separate dependency, build-output, and fetch-cache layers
- create shared destinations once and apply independent moves and unlinks through a bounded worker pool
- use copy-on-write staging when the host filesystem supports `COPYFILE_FICLONE`, with the standard copy fallback elsewhere
- remove host and foreign `@img/sharp-*` packages while retaining the selected Linux/glibc target pair
- install the target Sharp runtime once in the shared parent when every pool has the same requirement
- emit thin pool Dockerfiles that inherit the local parent and copy only their pool delta
- keep deploy-time fetch-cache refreshes in the final parent layer so they do not invalidate dependencies or build output
- install routing-service OpenSSL before copying its changing context so the package layer remains reusable
- record `poolImageLayout: shared-base-v1` and preserve standalone output when the field is absent, the build has one pool, or Sharp requirements differ

## Performance

Measured on the four-pool Next.js 16.3 testbed using logical context sizes and Docker's compressed image sizes:

| Measurement | Before | After | Change |
| --- | ---: | ---: | ---: |
| Staged pool contexts | `1,229.17 MiB` | `307.75 MiB` | `-74.96%` |
| Unique compressed OCI layers | `444.79 MiB` | `167.65 MiB` | `-62.31%` |
| Unique compressed non-Node layers | `368.06 MiB` | `90.92 MiB` | `-75.30%` |
| Sum of four compressed images | `674.96 MiB` | `658.86 MiB` | `-2.38%` |
| Warm adapter callback, initial shared layout to final | `19.615s` | `16.423s` | `-16.27%` |

The shared-layer measurements count the common parent once and each child delta once. Each pool still receives its complete runtime filesystem. GHCR cross-mounted shared layers between the pool repositories during deployment; cross-mount behavior is registry-specific.

The callback comparison alternated the initial and final implementations against the same warm Next.js build and build ID. `COPYFILE_FICLONE` is an opportunistic staging optimization and falls back when unsupported. Remote builders that cannot resolve the selected container CLI's local image store are not supported by this layout and fail before child images are pushed.

## Testing

- `npm run build`
- `npm test` (`2,597` passed, `17` skipped)
- `npm run lint`
- `npm run typecheck`
- `npm run fmt:check`
- `git diff --check`
- verified merged parent and pool filesystems preserve paths, bytes, modes, ownership, empty directories, and symlink boundaries
- built all four `linux/amd64` pool images and verified every pool reached readiness with zero restarts
- verified Sharp `0.35.3` and libvips `8.18.3` load in the final web image, with the Darwin package absent and the Linux x64 package present
- deployed `target-opt-final` through the adapter CLI to Kubernetes v1.35 on Talos with all five workload images pinned by digest
- passed `15/15` adapter doctor checks and `30/40` live browser checks across Chromium and mobile

The remaining live checks reproduce existing testbed issues: the remote-cache fixture is not configured for a stable cross-request value, and the affected App Router pages return `NEXT_STATIC_GEN_BAILOUT` on both the retained pre-optimization image and this build. Pages Router SSR/ISR/API, Cache Components streaming, optimized images, Edge output, middleware headers, uploads, webhooks, SSE, Redis, and public `next-resume` stripping pass on the final deployment.
