### PR TITLE
Follow-ups from stack validation: runtime parity, deploy robustness, and a latent Gateway fix

### DIFF
--- a/fixtures/main/adapter.config.multipool.mjs
+++ b/fixtures/main/adapter.config.multipool.mjs
@@ -1,0 +1,40 @@
+import { createK8sAdapter } from "@next-community/adapter-k8s";
+
+// Multi-pool variant of adapter.config.mjs — exists to exercise the shared-base
+// pool image layout (poolImageLayout: shared-base-v1), which only activates when
+// a build has more than one pool. Same infra/release as the default config.
+export default createK8sAdapter({
+  pools: {
+    web: {
+      routes: ["appPages", "pages"],
+      scaling: { min: 2, max: 10, targetCPU: 70 },
+    },
+    api: {
+      routes: ["appRoutes", "pagesApi"],
+      scaling: { min: 1, max: 4, targetCPU: 70 },
+    },
+  },
+
+  cache: {
+    enabled: true,
+    provider: "valkey",
+    memorystore: { region: "us-central1", sizeGb: 1 },
+  },
+  containerStrategy: "traced-assets",
+
+  provider: {
+    gke: {
+      cdn: {
+        enabled: true,
+        bucket: "praxis-road-491306-c0-nextjs-static",
+      },
+      gateway: {
+        type: "gateway-api",
+        className: "gke-l7-global-external-managed",
+        hosts: [
+          { hostname: "adapter-gke.jamesdaniels.net", tls: { enabled: true, managedCert: true } },
+        ],
+      },
+    },
+  },
+});

--- a/fixtures/main/next.config.ts
+++ b/fixtures/main/next.config.ts
@@ -8,7 +8,7 @@ const require = createRequire(import.meta.url);
 const nextConfig: NextConfig = {
   // Keep `npm run build` honest: the local fixture must exercise the adapter hooks even when it is
   // not launched through the deploy CLI (which otherwise supplies NEXT_ADAPTER_PATH).
-  adapterPath: require.resolve("@next-community/adapter-k8s"),
+  adapterPath: process.env.NEXT_ADAPTER_PATH ?? require.resolve("@next-community/adapter-k8s"),
   cacheComponents: true,
   // Keep the local deployed-app probe small enough to make a duplicated PPR Link header obvious.
   // React owns truncation; the adapter must preserve that budget when joining shell + resume.

--- a/src/cli/deploy.ts
+++ b/src/cli/deploy.ts
@@ -632,11 +632,18 @@ export async function resolveDeployImageDigests(opts: {
         : opts.digestLookup?.kind === "oci-distribution"
           ? null
           : opts.projectId;
+    // Single-flight for the crane/skopeo/docker-manifest chain: resolveRegistryDigest ends
+    // by running it, and the `??` fallback used to run the IDENTICAL chain a second time
+    // whenever the first came back null — doubled subprocess latency on exactly the slow
+    // path (no crane/skopeo installed). Memoizing keeps the gcloud-failed case (where the
+    // chain has NOT run yet) probing exactly once.
+    let anyProbePromise: Promise<string | null> | undefined;
+    const probeAny = () => (anyProbePromise ??= resolveRegistryDigestAny(ref, cli, platform));
     const digest =
       (artifactRegistryProject !== null
-        ? await resolveRegistryDigest(ref, artifactRegistryProject, platform, cli)
+        ? await resolveRegistryDigest(ref, artifactRegistryProject, platform, cli, probeAny)
         : null) ??
-      (await resolveRegistryDigestAny(ref, cli, platform)) ??
+      (await probeAny()) ??
       (cli === "docker" ? await resolveImageDigest(ref, cli, platform) : null);
     if (digest) digests[key] = digest;
     else unresolved.push(ref);
@@ -844,6 +851,10 @@ export async function resolveRegistryDigest(
   projectId: string,
   platform: TargetPlatform = targetPlatform(),
   containerCli: string = "docker",
+  // Injectable so a caller that ALSO falls back to resolveRegistryDigestAny can share one
+  // memoized probe instead of running the whole crane/skopeo/docker chain twice.
+  probeAny: () => Promise<string | null> = () =>
+    resolveRegistryDigestAny(imageRef, containerCli, platform),
 ): Promise<string | null> {
   // Artifact Registry only. Without a GCP project there is nothing to ask. The summary is a
   // useful authoritative existence/digest check, but it is never sufficient by itself because
@@ -866,7 +877,7 @@ export async function resolveRegistryDigest(
   // Artifact Registry's summary digest can name an OCI INDEX and says nothing about which
   // children it contains. Never return it directly: a requested arm64 deploy previously
   // accepted an amd64-only index here before any platform-aware probe ran.
-  return resolveRegistryDigestAny(imageRef, containerCli, platform);
+  return probeAny();
 }
 
 export async function resolveImageDigest(
@@ -2313,12 +2324,26 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
             `the state, or restore poolTopologies in .k8s-adapter/state.json.`,
         );
       }
-      previousPools = await discoverBuildPools(releaseName, previousBuildId, namespace);
-      console.warn(
-        `  ! Recovered legacy pool topology for build "${previousBuildId}" from its ` +
-          `versioned Deployments: ${previousPools.join(", ")}. The successful deploy will ` +
-          `record it in adapter state.`,
-      );
+      // `missingBuild: "empty"`: a cluster holding NOTHING of the previous build (rebuilt
+      // cluster, externally cleaned namespace) has no rollback target to preserve or to
+      // strand — failing closed here bricked every subsequent deploy against unrepairable
+      // state. Partial or inconsistent topologies still throw inside discoverBuildPools.
+      previousPools = await discoverBuildPools(releaseName, previousBuildId, namespace, {
+        missingBuild: "empty",
+      });
+      if (previousPools.length === 0) {
+        console.warn(
+          `  ! Deploy state records previous build "${previousBuildId}", but the cluster ` +
+            `has NO Deployments for it (rebuilt cluster or externally cleaned namespace). ` +
+            `Nothing to preserve for rollback — continuing as a first deploy.`,
+        );
+      } else {
+        console.warn(
+          `  ! Recovered legacy pool topology for build "${previousBuildId}" from its ` +
+            `versioned Deployments: ${previousPools.join(", ")}. The successful deploy will ` +
+            `record it in adapter state.`,
+        );
+      }
     }
   }
   if (previousBuildId && previousBuildId !== buildId) {
@@ -3762,6 +3787,11 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
           targetFingerprint: compositionSnapshot.plan.target.fingerprint,
         };
       }
+      // A previous build with no surviving Deployments (previousPools === []) is recorded
+      // as ABSENT, not as an empty topology: recordedBuildPools rejects [] as malformed on
+      // the next read, and there is nothing for rollback to target anyway.
+      const recordablePreviousBuildId =
+        previousPools.length > 0 ? previousBuildId : undefined;
       await writeState(
         projectDir,
         {
@@ -3770,16 +3800,18 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
           cdnTags,
           ...(Object.keys(routingImageDigests).length > 0 ? { routingImageDigests } : {}),
           poolTopologies: {
-            ...(previousBuildId ? { [previousBuildId]: [...previousPools] } : {}),
+            ...(recordablePreviousBuildId
+              ? { [recordablePreviousBuildId]: [...previousPools] }
+              : {}),
             [buildId]: [...pools],
           },
           ...(hasPortableOrigin || state?.defaultPools
             ? {
                 defaultPools: {
-                  ...(previousBuildId
+                  ...(recordablePreviousBuildId
                     ? {
-                        [previousBuildId]:
-                          state?.defaultPools?.[previousBuildId] ?? previousPools[0]!,
+                        [recordablePreviousBuildId]:
+                          state?.defaultPools?.[recordablePreviousBuildId] ?? previousPools[0]!,
                       }
                     : {}),
                   [buildId]: defaultPool,

--- a/src/cli/deploy.ts
+++ b/src/cli/deploy.ts
@@ -3790,8 +3790,7 @@ export async function runDeploy(options: DeployOptions): Promise<void> {
       // A previous build with no surviving Deployments (previousPools === []) is recorded
       // as ABSENT, not as an empty topology: recordedBuildPools rejects [] as malformed on
       // the next read, and there is nothing for rollback to target anyway.
-      const recordablePreviousBuildId =
-        previousPools.length > 0 ? previousBuildId : undefined;
+      const recordablePreviousBuildId = previousPools.length > 0 ? previousBuildId : undefined;
       await writeState(
         projectDir,
         {

--- a/src/cli/pool-topology.ts
+++ b/src/cli/pool-topology.ts
@@ -64,6 +64,19 @@ export async function discoverBuildPools(
   releaseName: string,
   buildId: string,
   configuredNamespace?: string,
+  options?: {
+    /**
+     * What a topology with ZERO matching Deployments means. The default ("fail") is right
+     * for rollback: a build with no Deployments cannot be rolled back to. Deploy passes
+     * "empty": when the cluster holds NOTHING of the previous build (rebuilt cluster,
+     * externally cleaned namespace), there is no rollback target to preserve OR to strand,
+     * and refusing would brick every future deploy against state the operator cannot
+     * repair without hand-editing state.json. Partial/inconsistent topologies (kubectl
+     * errors, label mismatches) still throw in BOTH modes — only the fully-absent case is
+     * downgraded.
+     */
+    missingBuild?: "fail" | "empty";
+  },
 ): Promise<string[]> {
   assertSafeReleaseName(releaseName);
   assertSafeBuildId(buildId);
@@ -138,6 +151,7 @@ export async function discoverBuildPools(
   }
 
   if (pools.size === 0) {
+    if (options?.missingBuild === "empty") return [];
     throw new Error(
       `Could not recover any pool Deployment for build "${buildId}" in namespace ` +
         `"${namespace}". Refusing to continue: the rollback topology is unknown.`,

--- a/src/emit/templates/gateway.ts
+++ b/src/emit/templates/gateway.ts
@@ -311,8 +311,11 @@ ${rules}
   if (!hasTls) return appRoute;
 
   // HTTP -> HTTPS redirect: a rule whose only filter is RequestRedirect short-circuits
-  // before any backendRef (GKE Gateway API supports RequestRedirect with scheme/port/
-  // statusCode), so http:// traffic gets a 302 to https:// instead of plaintext service.
+  // before any backendRef, so http:// traffic gets a 302 to https:// instead of plaintext
+  // service. `port` MUST be omitted: the GKE Gateway controller rejects it (GWCER104) and,
+  // with no-error-isolation, one invalid route blocks reconciliation of the ENTIRE Gateway —
+  // NEG programming for every later backend change silently stalls (surfaced as LB 503s the
+  // first time a deploy actually changed backends). Scheme https already implies 443.
   const redirectRoute = `---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
@@ -329,7 +332,6 @@ ${hostnameLines}
         - type: RequestRedirect
           requestRedirect:
             scheme: https
-            port: 443
             statusCode: 302
 `;
 

--- a/src/native-artifacts.ts
+++ b/src/native-artifacts.ts
@@ -108,12 +108,21 @@ function elfArchitecture(header: Buffer): string | undefined {
 function isMachO(header: Buffer): boolean {
   if (header.length < 4) return false;
   const magic = header.readUInt32BE(0);
+  if (magic === 0xcafebabe) {
+    // 0xCAFEBABE is ALSO the Java class-file magic. Disambiguate the way `file` does: the
+    // next 32-bit word is nfat_arch for a fat Mach-O (a handful at most) but
+    // (minor_version << 16 | major_version) for a class file — major_version is ≥ 45 for
+    // every Java release, and any nonzero minor pushes the word far higher. Without this, an
+    // executable-bit .class file in a staged dependency aborted an otherwise valid build as
+    // a "foreign Mach-O". Too short to read the word: stay fail-closed as Mach-O.
+    if (header.length >= 8 && header.readUInt32BE(4) > 30) return false;
+    return true;
+  }
   return (
     magic === 0xfeedface ||
     magic === 0xcefaedfe ||
     magic === 0xfeedfacf ||
     magic === 0xcffaedfe ||
-    magic === 0xcafebabe ||
     magic === 0xbebafeca ||
     magic === 0xcafebabf ||
     magic === 0xbfbafeca

--- a/src/native-artifacts.ts
+++ b/src/native-artifacts.ts
@@ -1,5 +1,6 @@
 import { open, opendir, rm, stat } from "node:fs/promises";
 import path from "node:path";
+import { runBounded } from "./pool-image-layout.js";
 import { targetArchitecture, type TargetPlatform } from "./target-platform.js";
 
 type NativeFormat = "ELF" | "Mach-O" | "PE" | "unknown native addon";
@@ -176,12 +177,17 @@ async function inspectCandidate(
   }
 }
 
+const MAX_CONCURRENT_INSPECTIONS = 64;
+
 export async function findForeignNativeArtifacts(
   contextRoot: string,
   targetPlatform: TargetPlatform,
 ): Promise<ForeignNativeArtifact[]> {
-  const problems: ForeignNativeArtifact[] = [];
-
+  // Enumerate serially — directory metadata is cheap and open directory handles are finite —
+  // then stat/inspect concurrently: each file is independent, and one awaited syscall at a
+  // time made this walk the scan's critical path on multi-pool traced contexts (hundreds of
+  // thousands of files per context). Same worker shape as factorSharedPoolFiles' hashing.
+  const files: Array<{ absolute: string; relative: string }> = [];
   const walk = async (dir: string): Promise<void> => {
     const entries = await opendir(dir);
     for await (const entry of entries) {
@@ -193,18 +199,24 @@ export async function findForeignNativeArtifacts(
       if (!entry.isFile()) continue;
       const relative = path.relative(contextRoot, absolute).split(path.sep).join("/");
       if (isManagedSharpArtifact(relative)) continue;
-      // Named native libraries go straight to header inspection. Other files need a mode
-      // lookup so extensionless executables are not missed.
-      if (!namedNativeCandidate(relative)) {
-        const info = await stat(absolute);
-        if ((info.mode & 0o111) === 0) continue;
-      }
-      const problem = await inspectCandidate(absolute, relative, targetPlatform);
-      if (problem) problems.push(problem);
+      files.push({ absolute, relative });
     }
   };
-
   await walk(contextRoot);
+
+  const problems: ForeignNativeArtifact[] = [];
+  await runBounded(files, MAX_CONCURRENT_INSPECTIONS, async ({ absolute, relative }) => {
+    // Named native libraries go straight to header inspection. Other files need a mode
+    // lookup so extensionless executables are not missed.
+    if (!namedNativeCandidate(relative)) {
+      const info = await stat(absolute);
+      if ((info.mode & 0o111) === 0) return;
+    }
+    const problem = await inspectCandidate(absolute, relative, targetPlatform);
+    if (problem) problems.push(problem);
+  });
+  // The sort was always part of the contract; under concurrency it is what keeps the report
+  // deterministic (push order now depends on scheduling).
   return problems.sort((left, right) => left.file.localeCompare(right.file));
 }
 

--- a/src/pool-image-layout.ts
+++ b/src/pool-image-layout.ts
@@ -111,7 +111,7 @@ async function removeEmptiedDirectories(root: string, directories: Set<string>):
   }
 }
 
-async function runBounded<T>(
+export async function runBounded<T>(
   values: readonly T[],
   limit: number,
   operation: (value: T) => Promise<void>,

--- a/src/pool-server/dispatch.ts
+++ b/src/pool-server/dispatch.ts
@@ -1274,6 +1274,12 @@ export async function invokeLocalHandlerOverHttp({
 
       clientReq.once("error", (error) => {
         clearTimeout(invocationDeadline);
+        // Cleared on EVERY exit from this handler, including the timed-out branch below: a
+        // head-timeout abort used to leave the (unref'd) execution timer armed, and when it
+        // fired minutes later it logged a bogus "exceeded maxDuration" for a request that
+        // had already 504'd and re-destroyed the settled invocation. Clearing a timer that
+        // already fired (executionTimedOut) is a no-op.
+        if (executionDeadline) clearTimeout(executionDeadline);
         // N37: a deadline abort is the adapter's own teardown, not an entrypoint crash — answer
         // 504 and settle, rather than rejecting into the generic 500 path. `discardResponse`
         // invocations share the outer `res` with a response already sent to the client, so they
@@ -1288,7 +1294,6 @@ export async function invokeLocalHandlerOverHttp({
           server.close(() => resolve());
           return;
         }
-        if (executionDeadline) clearTimeout(executionDeadline);
         server.close(() => reject(error));
       });
 

--- a/src/pool-server/index.ts
+++ b/src/pool-server/index.ts
@@ -3183,7 +3183,16 @@ export async function startPoolServer(): Promise<ReturnType<typeof createPoolSer
             // Bound it: a 5s timeout so a slow/hung origin can't pin the request, and the
             // SHARED MAX_IMAGE_BYTES cap (N35) so an oversized body can't exhaust memory —
             // the same number the external path enforces, which it previously did not.
-            const selfUrl = `http://127.0.0.1:${port}${publicImagePath}`;
+            //
+            // The re-entry URL is the RAW validated `url` param, not the decoded pathname:
+            // upstream's fetchInternalImage hands the raw url to the full request pipeline,
+            // so `?url=%2Fapi%2Fog%3Ftitle%3DX` must reach the route as /api/og?title=X —
+            // the decoded pathname has the query stripped and re-decodes `%23`/`%3F` into
+            // characters that re-parse as fragment/query separators. basePath is prefixed
+            // exactly when the decoded-pathname check above decided it was missing.
+            const loopbackUrl =
+              publicImagePath === decodedImagePath ? urlParam.url : `${basePath}${urlParam.url}`;
+            const selfUrl = `http://127.0.0.1:${port}${loopbackUrl}`;
             const imgRes = await fetch(selfUrl, {
               signal: AbortSignal.timeout(5000),
               // The EXTERNAL path re-validates every redirect hop against the SSRF

--- a/tests/cli/deploy.test.ts
+++ b/tests/cli/deploy.test.ts
@@ -1181,6 +1181,31 @@ describe("S27: image integrity must not depend on the CLOUD", () => {
     ).rejects.toThrow(/--allow-mutable-tags/);
   });
 
+  it("runs the platform-aware probe chain once per image, even when it comes up empty", async () => {
+    // resolveRegistryDigest ends by running the crane/skopeo/docker-manifest chain; the
+    // caller's ?? fallback used to run the IDENTICAL chain again whenever that answer was
+    // null — doubling every probe subprocess on exactly the slow path (no crane/skopeo
+    // installed, image genuinely unresolvable).
+    vi.mocked(exec.execCapture).mockImplementation((async (command: string) => {
+      if (command === "gcloud") {
+        return { exitCode: 0, stdout: "sha256:" + "e".repeat(64) + "\n", stderr: "" };
+      }
+      return { exitCode: 127, stdout: "", stderr: "not found" };
+    }) as never);
+
+    await expect(
+      resolveDeployImageDigests({
+        refs: [["ssr", "us-central1-docker.pkg.dev/proj/repo/app:b1"]],
+        projectId: "proj",
+        allowMutableTags: true,
+      }),
+    ).resolves.toEqual({});
+    const craneCalls = vi
+      .mocked(exec.execCapture)
+      .mock.calls.filter(([command, args]) => command === "crane" && args?.[0] === "manifest");
+    expect(craneCalls).toHaveLength(1);
+  });
+
   it("does not probe Artifact Registry when the plan selects OCI distribution", async () => {
     const SHA = "sha256:" + "d".repeat(64);
     vi.mocked(exec.execCapture).mockImplementation((async (command: string, args: string[]) => {

--- a/tests/cli/pool-topology.test.ts
+++ b/tests/cli/pool-topology.test.ts
@@ -126,4 +126,51 @@ describe("discoverBuildPools", () => {
       /claims pool "api".*adapter-derived name is "rel-api-buildm"/s,
     );
   });
+
+  it('missingBuild "empty" downgrades ONLY the fully-absent topology', async () => {
+    // A rebuilt cluster (or an externally cleaned namespace) holds NOTHING of the recorded
+    // previous build. Deploy opts into [] here — refusing bricked every subsequent deploy
+    // against state the operator could only repair by hand-editing state.json.
+    vi.mocked(execCapture).mockResolvedValueOnce({
+      exitCode: 0,
+      stdout: '{"items":[]}',
+      stderr: "",
+    });
+    await expect(
+      discoverBuildPools("rel", "buildm", undefined, { missingBuild: "empty" }),
+    ).resolves.toEqual([]);
+
+    // Everything short of fully-absent still fails closed in the SAME mode: a kubectl
+    // error hides an unknown amount of topology…
+    vi.mocked(execCapture).mockResolvedValueOnce({
+      exitCode: 1,
+      stdout: "",
+      stderr: "deployments is forbidden",
+    });
+    await expect(
+      discoverBuildPools("rel", "buildm", undefined, { missingBuild: "empty" }),
+    ).rejects.toThrow(/incomplete topology can delete or strand rollback pools/);
+
+    // …and an inconsistently-labelled Deployment is a PARTIAL topology, not an absent one.
+    vi.mocked(execCapture).mockResolvedValueOnce({
+      exitCode: 0,
+      stdout: JSON.stringify({
+        items: [
+          {
+            metadata: {
+              name: "rel-not-api-buildm",
+              labels: {
+                "app.kubernetes.io/component": "api",
+                "app.kubernetes.io/version": "buildm",
+              },
+            },
+          },
+        ],
+      }),
+      stderr: "",
+    });
+    await expect(
+      discoverBuildPools("rel", "buildm", undefined, { missingBuild: "empty" }),
+    ).rejects.toThrow(/Refusing to trust inconsistent labels/);
+  });
 });

--- a/tests/emit/templates/gateway.test.ts
+++ b/tests/emit/templates/gateway.test.ts
@@ -198,13 +198,17 @@ describe("renderHTTPRoute HTTP->HTTPS redirect (M8)", () => {
       /name: nextjs-routes\nspec:\n  parentRefs:\n    - name: nextjs-gateway\n      sectionName: https/,
     );
 
-    // The redirect route attaches to the http listener and 302-upgrades to https:443.
+    // The redirect route attaches to the http listener and 302-upgrades to https.
     expect(yaml).toContain("name: nextjs-http-redirect");
     expect(yaml).toMatch(
       /name: nextjs-http-redirect\nspec:\n  parentRefs:\n    - name: nextjs-gateway\n      sectionName: http/,
     );
     expect(yaml).toContain("type: RequestRedirect");
-    expect(yaml).toMatch(/requestRedirect:\n\s+scheme: https\n\s+port: 443\n\s+statusCode: 302/);
+    expect(yaml).toMatch(/requestRedirect:\n\s+scheme: https\n\s+statusCode: 302/);
+    // `port` must stay omitted: the GKE Gateway controller rejects it (GWCER104) and one
+    // invalid route blocks reconciliation of the whole Gateway (no-error-isolation), which
+    // stalls NEG programming for every subsequent backend change. https implies 443.
+    expect(yaml).not.toContain("port: 443");
     // Same hostnames on the redirect route.
     const redirectDoc = yaml.slice(yaml.indexOf("name: nextjs-http-redirect"));
     expect(redirectDoc).toContain('"app.example.com"');

--- a/tests/native-artifacts.test.ts
+++ b/tests/native-artifacts.test.ts
@@ -118,6 +118,29 @@ describe("staged native artifact target contract", () => {
     ]);
   });
 
+  it("distinguishes a Java class file from a fat Mach-O sharing the CAFEBABE magic", async () => {
+    const root = context();
+    // Java 17 class file: magic, minor 0, major 61 — the second word (0x0000003d) is far
+    // above any real fat-header nfat_arch. Executable bit set, the exact shape that used to
+    // abort the build as a foreign "Mach-O".
+    write(
+      root,
+      "node_modules/some-tool/Runner.class",
+      Buffer.from("cafebabe0000003d", "hex"),
+      0o755,
+    );
+    // A REAL fat Mach-O (nfat_arch = 2) must still be rejected.
+    write(
+      root,
+      "node_modules/bcrypt/prebuilds/darwin-universal/bcrypt.node",
+      Buffer.from("cafebabe00000002", "hex"),
+    );
+
+    const failures = await findForeignNativeArtifacts(root, "linux/amd64");
+    expect(failures).toEqual([expect.objectContaining({ format: "Mach-O" })]);
+    expect(failures[0]!.file).toContain("bcrypt");
+  });
+
   it("fails closed on an unrecognized .node binary", async () => {
     const root = context();
     write(root, "node_modules/addon/build/Release/addon.node", Buffer.from("not a library"));

--- a/tests/pool-server/dispatch-streaming.test.ts
+++ b/tests/pool-server/dispatch-streaming.test.ts
@@ -332,6 +332,42 @@ describe("handler invocation deadline", () => {
       .catch(() => "reset" as const);
     expect(outcome).toBe("reset");
   });
+
+  it("disarms the maxDuration timer when the head timeout aborts the invocation first", async () => {
+    // A handler that stalls past the HEAD timeout takes the invocationTimedOut branch
+    // (504). The still-armed execution timer used to fire later anyway, logging a bogus
+    // "exceeded maxDuration" for an invocation that had already settled — noise that
+    // misleads anyone triaging timeout incidents.
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const front = await startFront(
+        {
+          handlerLoader: handlerLoaderFor("/stalls-at-head", () => {
+            // Never writes a head, never ends: the head timeout must win.
+          }),
+          poolName: "main",
+          buildId: "b1",
+          staticAssets: [],
+          handlerTimeoutMs: 100,
+          routeExecutionTimeouts: { "/stalls-at-head": 400 },
+        },
+        routeResolution("/stalls-at-head"),
+      );
+      openServers.push(front.server);
+
+      const res = await timedGet(front.port, "/stalls-at-head");
+      expect(res.status).toBe(504);
+
+      // Cross the (disarmed) execution deadline, then assert it never spoke.
+      await new Promise((r) => setTimeout(r, 500));
+      const maxDurationLogs = errorSpy.mock.calls.filter((call) =>
+        String(call[0]).includes("exceeded maxDuration"),
+      );
+      expect(maxDurationLogs).toEqual([]);
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
 });
 
 // N30 (SECURITY/CACHE), leak-guard half: writeInnerResponse rewrites an origin-oriented

--- a/tests/pool-server/index.image.test.ts
+++ b/tests/pool-server/index.image.test.ts
@@ -1147,6 +1147,37 @@ describe("image optimizer — middleware coverage must still win over the cachea
     }
   });
 
+  it("preserves the source url's query string on the loopback re-entry", async () => {
+    // Upstream parity: fetchInternalImage resolves a relative source through the FULL
+    // request pipeline with the raw url — `?url=%2Fdynamic-image%3Fv%3D42` reaches the
+    // route as /dynamic-image?v=42. Middleware here is both the re-entry trigger (source
+    // coverage forces the loopback) and the observer: it answers an ANIMATED GIF (which
+    // the optimizer passes through byte-for-byte) ONLY when the query survived, so a
+    // dropped query is a 400.
+    const scoped = makeBooter();
+    try {
+      const { port: p2 } = await scoped.boot(null, {
+        middlewareMatcher: "^\\/dynamic-image$",
+        middlewareSource: `const GIF = Buffer.from("${ANIMATED_GIF_BODY.toString("base64")}", "base64");
+export function proxy(request) {
+  const url = new URL(request.url);
+  if (url.pathname === "/dynamic-image" && url.search === "?v=42&t=a%2Fb") {
+    return new Response(GIF, { headers: { "content-type": "image/gif" } });
+  }
+  return new Response("query lost: " + url.search, { status: 404 });
+}\n`,
+      });
+      const res = await fetch(
+        `http://127.0.0.1:${p2}/_next/image?url=${encodeURIComponent("/dynamic-image?v=42&t=a%2Fb")}&w=640&q=75`,
+      );
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toBe("image/gif");
+      expect(Buffer.from(await res.arrayBuffer()).equals(ANIMATED_GIF_BODY)).toBe(true);
+    } finally {
+      await scoped.cleanup();
+    }
+  });
+
   it("continues the optimizer after middleware when an app catch-all also matches", async () => {
     const scoped = makeBooter();
     try {


### PR DESCRIPTION
Stacked on #41. Fixes for everything surfaced while validating the #14→#41 stack against the full upstream e2e suite (k3d, 6 lanes) and the live GKE fixture — the stack itself came through clean (per-suite failure counts identical to baseline; 28/28 live tests on single-pool, multi-pool, and restored topologies).

## Runtime (pool server)

- **Optimizer loopback drops the source query string.** The self-fetch was rebuilt from the decoded pathname, so `?url=%2Fapi%2Fog%3Ftitle%3DX` reached the route as bare `/api/og` (and re-decoded `%23`/`%3F` re-parse as fragment/query separators). Now re-enters with the raw validated url, matching upstream `fetchInternalImage`; the basePath-prefix decision is preserved. Test observes the re-entry through covering middleware.
- **maxDuration timer leaks past a head-timeout 504.** The `invocationTimedOut` early-return skipped the `clearTimeout`, so the unref'd execution timer fired minutes later with a bogus `exceeded maxDuration` log and re-destroyed the settled invocation. A/B-verified test.

## Deploy robustness

- **A rebuilt cluster bricked every subsequent deploy.** `discoverBuildPools` fail-closed on *zero* Deployments for the recorded previous build — correct for rollback and for partial/ambiguous topologies, but a cluster holding *nothing* of that build (rebuild, cleaned namespace) has no rollback target to preserve *or* strand. Deploy now opts into `missingBuild: "empty"`, warns loudly, and continues as a first deploy; kubectl errors and label inconsistencies still throw in both modes; rollback keeps the strict default. State recording skips the vanished build instead of writing `[]`, which `recordedBuildPools` would reject on the next read. (Found live: stale lane state vs a re-bootstrapped k3d cluster refused all 1,080 e2e suite deploys.)
- **Digest probe chain ran twice on the slow path.** `resolveRegistryDigest` ends with the crane/skopeo/docker-manifest chain, and the caller's `??` fallback re-ran the identical chain on null. Shared single-flight now; behavior unchanged, pinned by a call-count test.
- **`0xCAFEBABE` false positive.** An executable-bit Java `.class` in a staged dependency aborted the build as a foreign Mach-O. Disambiguated via the second word (nfat_arch vs class-file version), file(1)'s heuristic.

## Latent Gateway bug the stack exposed (pre-existing, ours)

The emitted HTTP→HTTPS redirect route carried `port: 443` in `RequestRedirect`. The GKE Gateway controller rejects it (GWCER104), and with `no-error-isolation` that single invalid route blocked reconciliation of the **entire Gateway** — invisible while deploys reused the same Services/NEGs, then LB 503s on the first topology-changing deploy (which this stack's multi-pool layout made routine). Dropped the field (https implies 443) and pinned its absence.

## Fixture

`fixtures/main/adapter.config.multipool.mjs` (web+api split) so the shared-base image layout has real-infra coverage — single-pool builds keep the legacy layout, so nothing else in e2e exercises it. Validated live: 28/28 both topologies; parent context 217M, pool deltas 216K/80K.

## Previously deferred, now included

~~Originally deferred~~ **now included**: `findForeignNativeArtifacts` runs its stat/header inspections through the same bounded worker shape as `factorSharedPoolFiles` (`runBounded`, now exported). Enumeration stays serial; the pre-existing `localeCompare` sort keeps the report deterministic. The two review candidates verified as false positives (fetch-cache seed rm ordering, unconditional `getSetCookie`) remain deliberately untouched — they are correct as written.

Unit suite: 2,616 passed / 3 skipped; tsc clean.
