### PR TITLE
Add generated WebSocket upgrade dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,34 @@ pools: {
 },
 ```
 
+## Experimental WebSocket Route Handlers
+
+The pool runtime supports Next's generated Node.js `upgradeHandler` adapter contract—the same
+additive entrypoint consumed by adapter-vercel. This is transport support for the experimental
+Next.js WebSocket work; stable Next.js does not yet expose `NextResponse.upgrade()`.
+
+Once a compatible Next build generates the entrypoint, an upgrade follows the ordinary routing
+path: trusted routing-extension results are reused, untrusted or incomplete results are resolved
+locally, middleware and rewrites apply exactly once, and a route assigned to another pool is
+tunnelled to its owning pool. HTTP-only routes answer `426 Upgrade Required`.
+
+Current boundaries are deliberate:
+
+- Node.js App Route outputs only—Pages Router, Edge Runtime, and static export are unsupported.
+- External WebSocket rewrites are rejected instead of bypassing the HTTP proxy's SSRF protections.
+- Peers and topic subscriptions are process-local. Multiple replicas need application-level shared
+  pub/sub when messages must span pods.
+- Connections are not durable across deploys, rollbacks, HPA scale-down, node replacement, or load
+  balancer maintenance. Clients must reconnect, and should use a keepalive appropriate for their
+  ingress/load-balancer timeout.
+- During shutdown the pod stops accepting upgrades, gives established sockets the configured
+  bounded shutdown window, sends close code `1001` (going away), and then force-closes survivors.
+
+Treat this as an experimental compatibility surface until the Next.js API and its upstream e2e
+suite are published. Exposure components supplied by an operator must preserve HTTP/1.1 WebSocket
+upgrade semantics; the adapter cannot infer that property for an arbitrary GatewayClass or Ingress
+controller.
+
 ## CI/CD
 
 The CLI is a convenience wrapper—everything it does can be done with a container runtime, `helm`, and (on GKE) `gcloud`. The chart is self-contained, including the load-balancer extension registration. See [docs/ci-cd.md](./docs/ci-cd.md) for the pipeline shape, the blue/green cutover commands, and known runtime requirements—including why image digests must be resolved from the registry, not the local daemon.

--- a/README.md
+++ b/README.md
@@ -242,10 +242,40 @@ The pool runtime supports Next's generated Node.js `upgradeHandler` adapter cont
 additive entrypoint consumed by adapter-vercel. This is transport support for the experimental
 Next.js WebSocket work; stable Next.js does not yet expose `NextResponse.upgrade()`.
 
+On a compatible Next.js branch, enable the experiment and keep the route dynamic:
+
+```js
+// next.config.js
+export default {
+  experimental: { webSocketRouteHandlers: true },
+};
+```
+
+```ts
+// app/ws/route.ts
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+export function GET() {
+  return NextResponse.upgrade({
+    open(peer) {
+      peer.send("connected");
+    },
+    message(peer, message) {
+      peer.send(message.rawData);
+    },
+  });
+}
+```
+
 Once a compatible Next build generates the entrypoint, an upgrade follows the ordinary routing
 path: trusted routing-extension results are reused, untrusted or incomplete results are resolved
 locally, middleware and rewrites apply exactly once, and a route assigned to another pool is
-tunnelled to its owning pool. HTTP-only routes answer `426 Upgrade Required`.
+tunnelled to its owning pool. A Route Handler can return an ordinary `Response` to reject the
+upgrade; missing, non-Node, non-App-Route, and HTTP-only outputs answer `404 Not Found`, matching
+Next's route-ownership contract. An ordinary HTTP request to a handler that returns
+`NextResponse.upgrade()` receives Next's sanitized `426 Upgrade Required` fallback.
 
 Current boundaries are deliberate:
 

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -109,6 +109,12 @@ The specific behaviors the architecture exists to get right, each confirmed agai
   remaining PPR resume-data consistency case.
 - **Performance is unverified.** No load testing, no throughput tuning, no published benchmarks. This is the "operational hardening" the README's status refers to.
 - **The generic provider is younger** than the GKE one and has correspondingly less real-world exposure, though it passes the same unit suite and its live verification covered the full request path.
+- **WebSocket Route Handlers are transport-tested, not yet framework-e2e verified.** The pool has
+  real-socket coverage for generated `upgradeHandler` dispatch, trusted and local routing,
+  cross-pool tunnelling, repeated handshake headers, and bounded shutdown. The public
+  `NextResponse.upgrade()` API and its upstream e2e fixture are still experimental/unpublished;
+  that suite must pass against the exact Next branch before this support is called framework
+  verified.
 
 ## Reproducing
 

--- a/src/pool-server/dispatch.ts
+++ b/src/pool-server/dispatch.ts
@@ -496,16 +496,138 @@ export function mergeResolvedHeadersIntoHeadersArg(
   return headersArg;
 }
 
+const WEBSOCKET_FALLBACK_REPLACED_HEADERS = new Set([
+  "accept-ranges",
+  "age",
+  "cache-control",
+  "connection",
+  "content-digest",
+  "content-disposition",
+  "content-encoding",
+  "content-language",
+  "content-length",
+  "content-location",
+  "content-range",
+  "content-type",
+  "digest",
+  "edge-control",
+  "etag",
+  "expires",
+  "keep-alive",
+  "last-modified",
+  "proxy-connection",
+  "repr-digest",
+  "sec-websocket-accept",
+  "sec-websocket-extensions",
+  "sec-websocket-key",
+  "sec-websocket-protocol",
+  "sec-websocket-version",
+  "surrogate-control",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+  "x-lighttpd-send-file",
+  "x-sendfile",
+]);
+
+function headersArgPairs(headersArg: unknown): Array<[string, string]> {
+  const pairs: Array<[string, string]> = [];
+  const append = (name: unknown, value: unknown) => {
+    if (Array.isArray(value)) {
+      for (const item of value) pairs.push([String(name), String(item)]);
+    } else if (value !== undefined) {
+      pairs.push([String(name), String(value)]);
+    }
+  };
+  if (Array.isArray(headersArg)) {
+    if (headersArg.length > 0 && !Array.isArray(headersArg[0])) {
+      for (let index = 0; index + 1 < headersArg.length; index += 2) {
+        append(headersArg[index], headersArg[index + 1]);
+      }
+    } else {
+      for (const entry of headersArg as Array<[unknown, unknown]>) append(entry[0], entry[1]);
+    }
+  } else if (headersArg && typeof headersArg === "object") {
+    for (const [name, value] of Object.entries(headersArg)) append(name, value);
+  }
+  return pairs;
+}
+
+function isGeneratedWebSocketFallback(status: number, headersArg: unknown): boolean {
+  if (status !== 426) return false;
+  const headers = new Headers(headersArgPairs(headersArg));
+  return (
+    headers.get("connection")?.toLowerCase() === "close" &&
+    headers.get("upgrade")?.toLowerCase() === "websocket" &&
+    headers.get("sec-websocket-version") === "13"
+  );
+}
+
+/**
+ * The generated App Route has already canonicalized an ordinary HTTP invocation of
+ * NextResponse.upgrade() into a safe 426. Routing headers live outside the loopback entrypoint in
+ * this adapter, so merging them with the normal "routing wins" rule would re-introduce forbidden
+ * Connection/framing/internal fields after Next removed them. Recreate the fallback's inheritance
+ * order: safe routing fields first, then handler fields, while its canonical transport fields win.
+ */
+function mergeResolvedHeadersIntoWebSocketFallback(
+  resolvedHeaders: Headers,
+  headersArg: unknown,
+): unknown {
+  const handlerPairs = headersArgPairs(headersArg);
+  const handlerNames = new Set(handlerPairs.map(([name]) => name.toLowerCase()));
+  const nominated = new Set(
+    (resolvedHeaders.get("connection") ?? "")
+      .split(",")
+      .map((name) => name.trim().toLowerCase())
+      .filter(Boolean),
+  );
+  const isForbidden = (name: string) => {
+    const lower = name.toLowerCase();
+    return (
+      WEBSOCKET_FALLBACK_REPLACED_HEADERS.has(lower) ||
+      nominated.has(lower) ||
+      lower.endsWith("-cache-control") ||
+      lower.startsWith("x-accel-") ||
+      lower.startsWith("x-middleware-") ||
+      lower.startsWith("x-nextjs-") ||
+      lower === INTERNAL_SECRET_HEADER ||
+      (INTERNAL_DISPATCH_HEADERS as readonly string[]).includes(lower)
+    );
+  };
+
+  const inherited: Array<[string, string]> = [];
+  for (const [name, value] of resolvedHeaders.entries()) {
+    const lower = name.toLowerCase();
+    if (lower === "set-cookie" || isForbidden(lower) || handlerNames.has(lower)) continue;
+    inherited.push([name, value]);
+  }
+  if (!nominated.has("set-cookie")) {
+    for (const cookie of resolvedHeaders.getSetCookie()) inherited.push(["set-cookie", cookie]);
+  }
+  return [...inherited, ...handlerPairs];
+}
+
 /** Apply Next middleware's authoritative request-header replacement to a Node request. */
 export function applyMiddlewareRequestHeaders(
   req: IncomingMessage,
   middlewareRequestHeaders: Headers | undefined,
+  options: { preserveMiddlewareCookieHeader?: boolean } = {},
 ): void {
   if (!middlewareRequestHeaders) return;
   const originalHost = req.headers.host;
   const nextHeaders: IncomingMessage["headers"] = {};
   for (const [key, value] of middlewareRequestHeaders.entries()) {
     if (key === "x-middleware-set-cookie") {
+      // WebSocket routing is split across Node's `upgrade` event and Next's generated
+      // entrypoint. Next preserves this framework-authored header across that handoff so its
+      // request store can merge middleware cookies without treating a client-forged cookie as
+      // input. Ordinary HTTP dispatch keeps the historical cookie-header projection below.
+      if (options.preserveMiddlewareCookieHeader) {
+        nextHeaders[key] = value;
+        continue;
+      }
       const cookies: string[] = [];
       for (const setCookie of splitCookiesString(value)) {
         const nameValue = setCookie.trim().split(";")[0];
@@ -534,7 +656,9 @@ export function installResolvedResponseHeaders(
   res.writeHead = ((status: number, ...args: unknown[]) => {
     const headersIndex = typeof args[0] === "string" ? 1 : 0;
     if (args[headersIndex] !== undefined && args[headersIndex] !== null) {
-      args[headersIndex] = mergeResolvedHeadersIntoHeadersArg(resolvedHeaders, args[headersIndex]);
+      args[headersIndex] = isGeneratedWebSocketFallback(status, args[headersIndex])
+        ? mergeResolvedHeadersIntoWebSocketFallback(resolvedHeaders, args[headersIndex])
+        : mergeResolvedHeadersIntoHeadersArg(resolvedHeaders, args[headersIndex]);
     }
     return Reflect.apply(originalWriteHead, res, [status, ...args]) as ServerResponse;
   }) as typeof res.writeHead;

--- a/src/pool-server/dispatch.ts
+++ b/src/pool-server/dispatch.ts
@@ -89,18 +89,27 @@ function webHeadersToNodeHeaders(webHeaders: Headers): Record<string, string | s
 // attacker-chosen origin into the relative-vs-absolute Location comparison below.
 const FORWARDED_HOST_RE = /^[a-zA-Z0-9.-]+(:[0-9]{1,5})?$/;
 
-// Effective public scheme of a request that reached this pool. TLS terminates at the load
-// balancer (GXLB) which stamps x-forwarded-proto, so the pool's own socket is always plain
-// http — the forwarded value is the only witness of the client's real scheme. Only the two
-// real schemes are honored — a spoofed value (e.g. `javascript:`) becomes http.
-function requestProtocol(req: IncomingMessage): "http" | "https" {
+// The client's real scheme as witnessed by x-forwarded-proto, or undefined when the header is
+// absent or carries anything other than one of the two real schemes (e.g. a spoofed
+// `javascript:`). Exported so websocket-upgrade.ts derives the handshake's same-origin authority
+// from the same witness this file uses — an https site behind the TLS-terminating load balancer
+// must compare a browser's `Origin: https://…` against `https://…`, not against the plain-http
+// scheme of the pool's own socket.
+export function validatedForwardedProtocol(req: IncomingMessage): "http" | "https" | undefined {
   const forwardedProto = req.headers["x-forwarded-proto"];
   const forwardedProtoValue = (Array.isArray(forwardedProto) ? forwardedProto[0] : forwardedProto)
     ?.split(",")[0]
     ?.trim();
   return forwardedProtoValue === "https" || forwardedProtoValue === "http"
     ? forwardedProtoValue
-    : "http";
+    : undefined;
+}
+
+// Effective public scheme of a request that reached this pool. TLS terminates at the load
+// balancer (GXLB) which stamps x-forwarded-proto, so the pool's own socket is always plain
+// http — the forwarded value is the only witness of the client's real scheme.
+function requestProtocol(req: IncomingMessage): "http" | "https" {
+  return validatedForwardedProtocol(req) ?? "http";
 }
 
 function middlewareRedirectLocation(req: IncomingMessage, target: URL): string {

--- a/src/pool-server/dispatch.ts
+++ b/src/pool-server/dispatch.ts
@@ -242,7 +242,7 @@ const PROXY_ABSOLUTE_DEADLINE_MS = 600_000;
 // same reason — capping the streaming phase would kill SSE and long PPR resumes that a same-pool
 // route is expected to serve. Generous by default (a blocking SSG render on a cold pod is
 // legitimately slow); the point is that it is finite.
-const REQUEST_HEAD_TIMEOUT_MS = Math.max(
+export const REQUEST_HEAD_TIMEOUT_MS = Math.max(
   1_000,
   parseInt(process.env.ADAPTER_K8S_HANDLER_TIMEOUT_MS ?? "", 10) || 60_000,
 );

--- a/src/pool-server/handler-loader.ts
+++ b/src/pool-server/handler-loader.ts
@@ -110,6 +110,33 @@ export function resolveRouteHandlerExport(
 }
 
 /**
+ * Resolve Next's generated adapter-facing WebSocket entrypoint.
+ *
+ * The public Route Handler API remains a normal `GET` that may eventually return
+ * `NextResponse.upgrade()`. Next compiles that API into an additive `upgradeHandler` export for
+ * adapters that own a persistent Node.js server. Do not inspect `routeModule.userland` here: a
+ * user-authored export with that name is not the adapter contract, and accepting it would let a
+ * fixture pass without proving that Next generated the real entrypoint.
+ *
+ * Dynamic `import()` of a CommonJS route can expose `module.exports` under `default`, hence the
+ * one wrapper shape in addition to the canonical top-level export.
+ */
+export function resolveUpgradeHandlerExport(
+  module: LoadedModule,
+): ArtifactRouteHandler | undefined {
+  if (typeof module.upgradeHandler === "function") {
+    return module.upgradeHandler as ArtifactRouteHandler;
+  }
+  if (module.default && typeof module.default === "object") {
+    const nested = module.default as Record<string, unknown>;
+    if (typeof nested.upgradeHandler === "function") {
+      return nested.upgradeHandler as ArtifactRouteHandler;
+    }
+  }
+  return undefined;
+}
+
+/**
  * Un-latch the route module's ResponseCache mode (the rdc stale-forever root cause):
  * `RouteModule.getResponseCache` lazily constructs `new ResponseCache(minimalMode)` ONCE
  * per instance (route-module.ts:1101), latching the FIRST request's mode for the process
@@ -271,11 +298,52 @@ export function createHandlerLoader(
     if (resolvedCtor === null) resolvedCtor = defaultResponseCacheCtor();
     return resolvedCtor;
   };
-  const cache = new Map<string, Promise<ArtifactRouteHandler>>();
+  // Cache the imported module rather than only its HTTP handler. HTTP and WebSocket dispatch are
+  // two entrypoints on the SAME generated route module and must share initialization, module state,
+  // route-wide WebSocket peer tracking, and the ResponseCache patch below.
+  const moduleCache = new Map<string, Promise<LoadedModule>>();
+  const handlerCache = new Map<string, Promise<ArtifactRouteHandler>>();
+
+  function loadModuleForOutput(outputId: string): Promise<LoadedModule> {
+    const cached = moduleCache.get(outputId);
+    if (cached) return cached;
+
+    const output = manifest.outputs[outputId];
+    if (!output) {
+      return Promise.reject(
+        new Error(`Unknown output ID: ${outputId} for pool ${manifest.poolName}`),
+      );
+    }
+
+    const promise = loadModule(output.filePath).then(async (module): Promise<LoadedModule> => {
+      // Turbopack modules with top-level await (e.g., Genkit, heavy async deps) may export a
+      // Promise as module.exports. Await it to get the real exports.
+      let resolved: LoadedModule = module;
+      const defaultExport = module.default;
+      if (defaultExport instanceof Promise) {
+        resolved = (await defaultExport) as LoadedModule;
+      } else if (
+        defaultExport &&
+        typeof defaultExport === "object" &&
+        Object.getPrototypeOf(defaultExport)?.constructor?.name === "Promise"
+      ) {
+        resolved = await (defaultExport as Promise<LoadedModule>);
+      }
+      const ctor = responseCacheCtor();
+      if (ctor) unlatchResponseCache(resolved, ctor);
+      return resolved;
+    });
+    // A transient import failure must not poison either transport for the life of the pod.
+    promise.catch(() => {
+      if (moduleCache.get(outputId) === promise) moduleCache.delete(outputId);
+    });
+    moduleCache.set(outputId, promise);
+    return promise;
+  }
 
   return {
     async load(outputId: string): Promise<ArtifactRouteHandler> {
-      const cached = cache.get(outputId);
+      const cached = handlerCache.get(outputId);
       if (cached) return cached;
 
       const output = manifest.outputs[outputId];
@@ -283,42 +351,37 @@ export function createHandlerLoader(
         throw new Error(`Unknown output ID: ${outputId} for pool ${manifest.poolName}`);
       }
 
-      const promise = loadModule(output.filePath).then(
-        async (module): Promise<ArtifactRouteHandler> => {
-          // Turbopack modules with top-level await (e.g., Genkit, heavy async deps)
-          // may export a Promise as module.exports. Await it to get the real exports.
-          let resolved: LoadedModule = module;
-          const defaultExport = module.default;
-          if (defaultExport instanceof Promise) {
-            resolved = (await defaultExport) as LoadedModule;
-          } else if (
-            defaultExport &&
-            typeof defaultExport === "object" &&
-            Object.getPrototypeOf(defaultExport)?.constructor?.name === "Promise"
-          ) {
-            resolved = await (defaultExport as Promise<LoadedModule>);
-          }
-          try {
-            const ctor = responseCacheCtor();
-            if (ctor) unlatchResponseCache(resolved, ctor);
-            // The route's own pathname keys the _ENTRIES fallback — the registry is
-            // process-global, so a pool with several edge routes must select by key.
-            return resolveRouteHandlerExport(resolved, output.pathname);
-          } catch (err) {
-            throw new Error(
-              `Failed to resolve handler for outputId="${outputId}" ` +
-                `filePath="${output.filePath}": ${(err as Error).message}`,
-            );
-          }
-        },
-      );
-      // Evict a rejected load from the cache so a later request can retry —
-      // otherwise a transient import failure poisons the route for the pod's life.
-      promise.catch(() => {
-        if (cache.get(outputId) === promise) cache.delete(outputId);
+      const promise = loadModuleForOutput(outputId).then((resolved): ArtifactRouteHandler => {
+        try {
+          // The route's own pathname keys the _ENTRIES fallback — the registry is
+          // process-global, so a pool with several edge routes must select by key.
+          return resolveRouteHandlerExport(resolved, output.pathname);
+        } catch (err) {
+          throw new Error(
+            `Failed to resolve handler for outputId="${outputId}" ` +
+              `filePath="${output.filePath}": ${(err as Error).message}`,
+          );
+        }
       });
-      cache.set(outputId, promise);
+      // Handler-shape failures are retryable too. The module stays imported, but a later call can
+      // observe a generated registry entry that completed initialization in the meantime.
+      promise.catch(() => {
+        if (handlerCache.get(outputId) === promise) handlerCache.delete(outputId);
+      });
+      handlerCache.set(outputId, promise);
       return promise;
+    },
+
+    /**
+     * Load the optional generated WebSocket entrypoint. `undefined` is an ordinary HTTP-only route,
+     * not a module failure. Unknown outputs remain loud, matching `load()`.
+     */
+    async loadUpgrade(outputId: string): Promise<ArtifactRouteHandler | undefined> {
+      if (!manifest.outputs[outputId]) {
+        throw new Error(`Unknown output ID: ${outputId} for pool ${manifest.poolName}`);
+      }
+      const module = await loadModuleForOutput(outputId);
+      return resolveUpgradeHandlerExport(module);
     },
 
     has(outputId: string): boolean {

--- a/src/pool-server/index.ts
+++ b/src/pool-server/index.ts
@@ -1881,14 +1881,27 @@ export async function startPoolServer(): Promise<ReturnType<typeof createPoolSer
   // requests are served/404'd like un-prefixed ones. (URL assetPrefixes point at a separate host,
   // so those requests never reach the pool.)
   let assetPrefix = "";
+  let webSocketAllowedOrigins: string[] = [];
   try {
     const rsf = JSON.parse(
       readFileSync(path.join(process.cwd(), ".next", "required-server-files.json"), "utf-8"),
     );
     const ap = String(rsf?.config?.assetPrefix ?? "");
     if (ap.startsWith("/")) assetPrefix = ap.replace(/\/$/, "");
+    const webSocketConfig = rsf?.config?.experimental?.webSocketRouteHandlers;
+    const configuredOrigins =
+      webSocketConfig && typeof webSocketConfig === "object"
+        ? webSocketConfig.allowedOrigins
+        : undefined;
+    if (Array.isArray(configuredOrigins)) {
+      // Next validates the canonical HTTP(S)-origin shape at build time. Re-check the serialized
+      // artifact's element types at consumption so malformed build output cannot broaden policy.
+      webSocketAllowedOrigins = configuredOrigins.filter(
+        (origin: unknown): origin is string => typeof origin === "string",
+      );
+    }
   } catch {
-    // no assetPrefix
+    // No assetPrefix or WebSocket cross-origin exception. Same-origin remains the safe default.
   }
 
   // Set preview/draft mode env vars from prerender manifest.
@@ -2333,6 +2346,10 @@ export async function startPoolServer(): Promise<ReturnType<typeof createPoolSer
     middlewareMatchers,
   );
   const appRequire = createRequire(path.join(process.cwd(), "package.json"));
+  const pinnedWebSocket = appRequire("next/dist/compiled/ws") as {
+    extension?: { parse?: (value: string) => unknown };
+  };
+  const parseWebSocketExtensions = pinnedWebSocket.extension?.parse;
   const { createRequestResponseMocks } = appRequire("next/dist/server/lib/mock-request") as {
     createRequestResponseMocks(options: {
       url: string;
@@ -3745,6 +3762,11 @@ export async function startPoolServer(): Promise<ReturnType<typeof createPoolSer
     reason: readinessReason,
   });
 
+  // Next's generated WebSocket entrypoint accepts a framework-owned lifecycle scope only when it
+  // is stamped on the raw request before the Adapter handoff. Keep one stable object for this
+  // server: a per-request scope would defeat Next's connection registry and shutdown bookkeeping.
+  const webSocketRegistryScope = {};
+
   // Create and start server
   const server = createPoolServer({
     port,
@@ -3764,6 +3786,9 @@ export async function startPoolServer(): Promise<ReturnType<typeof createPoolSer
           releaseName,
           buildId,
           internalSecret,
+          webSocketRegistryScope,
+          webSocketAllowedOrigins,
+          parseWebSocketExtensions,
           handshakeTimeoutMs: REQUEST_HEAD_TIMEOUT_MS,
         },
         req,

--- a/src/pool-server/index.ts
+++ b/src/pool-server/index.ts
@@ -3786,6 +3786,7 @@ export async function startPoolServer(): Promise<ReturnType<typeof createPoolSer
           releaseName,
           buildId,
           internalSecret,
+          proofHeaderNames,
           webSocketRegistryScope,
           webSocketAllowedOrigins,
           parseWebSocketExtensions,

--- a/src/pool-server/index.ts
+++ b/src/pool-server/index.ts
@@ -41,6 +41,7 @@ import {
   installResolvedResponseHeaders,
   isVerifiedPreviewRequest,
   mergeResolvedHeadersIntoHeadersArg,
+  REQUEST_HEAD_TIMEOUT_MS,
 } from "./dispatch.js";
 import { nextStaticAssetHeaders } from "../static-asset-headers.js";
 import {
@@ -76,6 +77,7 @@ import {
   type ReadinessState,
 } from "./server.js";
 import { readWebBodyWithLimit } from "./body-limit.js";
+import { handleWebSocketUpgrade } from "./websocket-upgrade.js";
 import {
   registerValkeyCacheHandler,
   seedSandboxCacheHandlerRegistry,
@@ -3751,6 +3753,23 @@ export async function startPoolServer(): Promise<ReturnType<typeof createPoolSer
     internalSecret,
     proofHeaderNames,
     onRequest: handleRequest,
+    // The generated upgrade entrypoint is additive: ordinary requests continue through the exact
+    // HTTP path above, while Node's separate `upgrade` event gets raw persistent-socket transport.
+    onUpgrade: (req, socket, head) =>
+      handleWebSocketUpgrade(
+        {
+          resolve: (url, headers, method, body) => resolver.resolve(url, headers, method, body),
+          handlerLoader,
+          poolName,
+          releaseName,
+          buildId,
+          internalSecret,
+          handshakeTimeoutMs: REQUEST_HEAD_TIMEOUT_MS,
+        },
+        req,
+        socket,
+        head,
+      ),
     readiness,
     // A probe path the APP owns must not be silently shadowed (it was: the old check also
     // ignored a query string, so `/healthz` was intercepted and `/healthz?x=1` was not).

--- a/src/pool-server/server.ts
+++ b/src/pool-server/server.ts
@@ -1,5 +1,6 @@
 // src/pool-server/server.ts
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import type { Duplex } from "node:stream";
 import {
   INTERNAL_DISPATCH_HEADERS,
   INTERNAL_DISPATCH_PROOF_HEADER,
@@ -46,34 +47,21 @@ export interface ReadinessState {
   reason: string;
 }
 
+export interface RequestTrustOptions {
+  internalSecret?: string | undefined;
+  trustInternalHeaders?: boolean;
+  /** Build-derived matcher and RSC headers covered by the per-request dispatch proof. */
+  proofHeaderNames?: readonly string[] | undefined;
+}
+
 /**
- * Establish the request trust boundary: decide whether this request's internal dispatch headers
- * are trustworthy, strip everything a client must not be able to assert, wrap `writeHead` so no
- * internal control header can leak back, and attach the socket-error guard.
- *
- * Exported because there are TWO doors into `handleRequest`: the HTTP server below and the
- * in-process `revalidate()` re-entry (Pages `res.revalidate()`), which called `handleRequest`
- * directly and therefore skipped all of this while `handleRequest` still read `x-output-id` /
- * `x-mw-evaluated` as trusted. Not exploitable today (Next builds those internal headers itself)
- * but it was a second, unguarded entrance to the same trust boundary; both callers now share
- * this one function. Idempotent — applying it twice strips the same headers and stacks a
- * harmless second wrapper.
+ * Request-only half of the pool trust boundary, shared by ordinary HTTP and Node's separate
+ * `upgrade` event. Returns whether proof-gated dispatch headers were accepted.
  */
-export function applyRequestTrustBoundary(
+export function applyIncomingRequestTrustBoundary(
   req: IncomingMessage,
-  res: ServerResponse,
-  options: {
-    internalSecret?: string | undefined;
-    trustInternalHeaders?: boolean;
-    /**
-     * This build's proof-covered request headers — the middleware-matcher inputs and the RSC
-     * negotiation headers (routing-common.ts `buildProofHeaderNames`). Part of the proof's
-     * covered set, so the value MUST be the same list the signing tier used; both derive it from
-     * the one build's routing manifest.
-     */
-    proofHeaderNames?: readonly string[] | undefined;
-  },
-): void {
+  options: RequestTrustOptions,
+): boolean {
   const { internalSecret, trustInternalHeaders = false, proofHeaderNames } = options;
 
   // Establish whether the internal dispatch headers on this request can be trusted. With a
@@ -129,6 +117,23 @@ export function applyRequestTrustBoundary(
       delete req.headers[h];
     }
   }
+
+  return trusted;
+}
+
+/**
+ * Full HTTP trust boundary: apply the shared incoming-request checks, prevent internal response
+ * headers from leaking, and guard client-disconnect errors.
+ *
+ * Exported because both the HTTP server below and Pages `res.revalidate()` re-entry call the same
+ * handler. Idempotent: applying it twice strips the same headers and stacks a harmless wrapper.
+ */
+export function applyRequestTrustBoundary(
+  req: IncomingMessage,
+  res: ServerResponse,
+  options: RequestTrustOptions,
+): void {
+  applyIncomingRequestTrustBoundary(req, options);
 
   // Wrap res.writeHead to strip internal headers from responses.
   // Real paths pass headers both ways: via the setHeader-map AND as the headers
@@ -222,6 +227,15 @@ export function filterWriteHeadHeadersArg(
 
 export interface PoolServerOptions {
   onRequest: (req: IncomingMessage, res: ServerResponse) => void | Promise<void>;
+  /**
+   * Node upgrade transport used by Next's generated App Route `upgradeHandler`. Returning
+   * `accepted` marks the still-open socket as an established WebSocket for graceful shutdown.
+   */
+  onUpgrade?: (
+    req: IncomingMessage,
+    socket: Duplex,
+    head: Buffer,
+  ) => "accepted" | "rejected" | Promise<"accepted" | "rejected">;
   port: number;
   /**
    * When true, trust x-output-id etc. from the request WITHOUT a secret. Legacy fallback used
@@ -267,6 +281,7 @@ export interface PoolServerOptions {
 export function createPoolServer(options: PoolServerOptions) {
   const {
     onRequest,
+    onUpgrade,
     port,
     trustInternalHeaders = false,
     internalSecret,
@@ -375,6 +390,46 @@ export function createPoolServer(options: PoolServerOptions) {
     );
   });
 
+  // Node removes upgraded connections from ordinary HTTP connection management. Keep explicit
+  // ownership so a rollout has a bounded, protocol-aware shutdown instead of either leaking the
+  // process until SIGKILL or dropping every connection without a close frame.
+  const upgradedSockets = new Map<Duplex, { accepted: boolean }>();
+  let draining = false;
+  if (onUpgrade) {
+    server.on("upgrade", (req, socket, head) => {
+      if (draining) {
+        socket.end(
+          "HTTP/1.1 503 Service Unavailable\r\nConnection: close\r\n" + "Content-Length: 0\r\n\r\n",
+        );
+        return;
+      }
+
+      applyIncomingRequestTrustBoundary(req, {
+        internalSecret,
+        trustInternalHeaders,
+        proofHeaderNames,
+      });
+      upgradedSockets.set(socket, { accepted: false });
+      socket.once("close", () => upgradedSockets.delete(socket));
+      // Client resets are normal for long-lived connections and must never become an uncaught
+      // EventEmitter error that terminates the whole pool.
+      socket.on("error", () => undefined);
+
+      Promise.resolve(onUpgrade(req, socket, head))
+        .then((disposition) => {
+          const state = upgradedSockets.get(socket);
+          if (state && disposition === "accepted") state.accepted = true;
+          if (disposition === "rejected" && !socket.destroyed && !socket.writableEnded) {
+            socket.end();
+          }
+        })
+        .catch((error) => {
+          console.error("Unhandled WebSocket upgrade error:", error);
+          if (!socket.destroyed) socket.destroy();
+        });
+    });
+  }
+
   // Keep-alive must outlive the proxy tier's upstream idle timeout (Envoy in front of this
   // pool, and Node's default is 5s): when the pool closes an idle socket the proxy just chose
   // for a new request, the client sees an intermittent 502 (and e2e runs see `socket hang up`).
@@ -436,18 +491,54 @@ export function createPoolServer(options: PoolServerOptions) {
      */
     async stop(options: { graceMs?: number } = {}): Promise<void> {
       const graceMs = Math.max(1, options.graceMs ?? 15_000);
+      draining = true;
       const closed = new Promise<void>((resolve) => server.close(() => resolve()));
       // An idle keep-alive socket alone is enough to keep close() pending forever.
       server.closeIdleConnections?.();
       const forceClose = setTimeout(() => server.closeAllConnections?.(), Math.floor(graceMs / 2));
       forceClose.unref?.();
-      // Last resort: even closeAllConnections can be defeated (an upgraded socket the HTTP
-      // server no longer tracks), so the wait itself is bounded.
-      const timedOut = new Promise<void>((resolve) => {
-        const t = setTimeout(resolve, graceMs);
-        t.unref?.();
-      });
-      await Promise.race([closed, timedOut]);
+      const deadline = Date.now() + graceMs;
+      while (upgradedSockets.size > 0 && Date.now() < deadline) {
+        await new Promise<void>((resolve) => {
+          const t = setTimeout(resolve, Math.min(100, Math.max(1, deadline - Date.now())));
+          t.unref?.();
+        });
+      }
+
+      if (upgradedSockets.size > 0) {
+        // RFC 6455 close code 1001: endpoint is going away (rollout, rollback, HPA scale-down).
+        // Pending handshakes are still HTTP, so only established sockets receive a WS frame.
+        const goingAway = Buffer.from([0x88, 0x02, 0x03, 0xe9]);
+        for (const [socket, state] of upgradedSockets) {
+          try {
+            if (!socket.destroyed) {
+              if (state.accepted) socket.write(goingAway);
+              else socket.end();
+            }
+          } catch {
+            // The peer disappeared between the set iteration and the write.
+          }
+        }
+        // Give the close frame a short opportunity to flush, while remaining inside the caller's
+        // already-bounded signal path.
+        await new Promise<void>((resolve) => {
+          const t = setTimeout(resolve, Math.min(250, Math.max(1, graceMs)));
+          t.unref?.();
+        });
+        for (const socket of upgradedSockets.keys()) {
+          if (!socket.destroyed) socket.destroy();
+        }
+      }
+
+      // Last resort for ordinary HTTP: even closeAllConnections can be defeated by platform/Node
+      // behavior, so never wait past the same bound after explicitly closing upgraded sockets.
+      await Promise.race([
+        closed,
+        new Promise<void>((resolve) => {
+          const t = setTimeout(resolve, Math.max(1, deadline - Date.now()));
+          t.unref?.();
+        }),
+      ]);
       clearTimeout(forceClose);
     },
 

--- a/src/pool-server/websocket-upgrade.ts
+++ b/src/pool-server/websocket-upgrade.ts
@@ -21,7 +21,11 @@ import {
   parseRequestUrl,
 } from "../routing-common.js";
 import { sanitizeK8sName } from "../emit/templates/utils.js";
-import { applyMiddlewareRequestHeaders, extractRouteParams } from "./dispatch.js";
+import {
+  applyMiddlewareRequestHeaders,
+  extractRouteParams,
+  validatedForwardedProtocol,
+} from "./dispatch.js";
 import type { HandlerLoader } from "./handler-loader.js";
 import type { ResolveResult } from "./resolve.js";
 
@@ -161,11 +165,18 @@ function exactHttpOrigin(value: string): URL | undefined {
   return undefined;
 }
 
+// Same-origin authority a browser's `Origin` is compared against. TLS terminates at the load
+// balancer, so the pool's own socket is plain http even for a wss:// handshake against an https
+// site — deriving the scheme from `socket.encrypted` computed `http://host` and 403'd every
+// legitimate same-origin `Origin: https://host`. The validated x-forwarded-proto witness is the
+// same signal the HTTP path uses (requestProtocol in dispatch.ts); socket.encrypted is only the
+// fallback for a direct connection that carries no witness at all.
 function webSocketRequestAuthority(req: IncomingMessage): URL | undefined {
   const hosts = rawHeaderValues(req, "host");
   if (hosts.length !== 1 || !hosts[0] || /\s|[\\/@?#,]/.test(hosts[0])) return undefined;
   const encrypted = Boolean((req.socket as { encrypted?: boolean } | undefined)?.encrypted);
-  return exactHttpOrigin(`${encrypted ? "https" : "http"}://${hosts[0]}`);
+  const scheme = validatedForwardedProtocol(req) ?? (encrypted ? "https" : "http");
+  return exactHttpOrigin(`${scheme}://${hosts[0]}`);
 }
 
 function validateWebSocketHandshake(
@@ -479,9 +490,8 @@ function trustedResolutionFromHeaders(req: IncomingMessage): ResolveResult | und
 
 function publicRequestUrl(req: IncomingMessage): URL {
   const url = parseRequestUrl(req.url ?? "/", req.headers.host);
-  const forwarded = req.headers["x-forwarded-proto"];
-  const protocol = (Array.isArray(forwarded) ? forwarded[0] : forwarded)?.split(",", 1)[0]?.trim();
-  if (protocol === "https" || protocol === "http") url.protocol = `${protocol}:`;
+  const protocol = validatedForwardedProtocol(req);
+  if (protocol) url.protocol = `${protocol}:`;
   return url;
 }
 

--- a/src/pool-server/websocket-upgrade.ts
+++ b/src/pool-server/websocket-upgrade.ts
@@ -13,7 +13,10 @@ import {
 } from "node:http";
 import type { Duplex } from "node:stream";
 import {
+  computeDispatchProof,
+  dispatchProofInputsFromRequest,
   INTERNAL_DISPATCH_HEADERS,
+  INTERNAL_DISPATCH_PROOF_HEADER,
   INTERNAL_EXECUTION_DEADLINE_HEADER,
   INTERNAL_SECRET_HEADER,
   MW_EVALUATED_TRUSTED,
@@ -43,6 +46,8 @@ export interface WebSocketUpgradeDispatcher {
   releaseName: string;
   buildId: string;
   internalSecret?: string | undefined;
+  /** Build-derived matcher and RSC headers covered by the cross-pool dispatch proof. */
+  proofHeaderNames?: readonly string[] | undefined;
   /** Stable server-owned scope required by Next's generated connection registry. */
   webSocketRegistryScope: object;
   /** Exact cross-origin values accepted by experimental.webSocketRouteHandlers. */
@@ -112,6 +117,7 @@ function isPrivateResponseHeader(name: string): boolean {
   return (
     lower === "x-next-cache-tags" ||
     lower === INTERNAL_SECRET_HEADER ||
+    lower === INTERNAL_DISPATCH_PROOF_HEADER ||
     (INTERNAL_DISPATCH_HEADERS as readonly string[]).includes(lower) ||
     lower.startsWith("x-middleware-")
   );
@@ -286,6 +292,7 @@ function validateWebSocketOrigin(
 function removePrivateRawRequestHeaders(req: IncomingMessage): void {
   const privateNames = new Set<string>([
     INTERNAL_SECRET_HEADER,
+    INTERNAL_DISPATCH_PROOF_HEADER,
     ...INTERNAL_DISPATCH_HEADERS,
     ...UNTRUSTED_NEXT_REQUEST_HEADERS,
   ]);
@@ -422,7 +429,7 @@ function generatedUpgradeDisposition(outcome: unknown): UpgradeDisposition {
   return upgraded ? "accepted" : "rejected";
 }
 
-/** Read the secret-gated phase-two routing verdict, then erase the transport vocabulary. */
+/** Read the proof-gated phase-two routing verdict, then erase the transport vocabulary. */
 function trustedResolutionFromHeaders(req: IncomingMessage): ResolveResult | undefined {
   const discardDispatch = () => {
     for (const header of INTERNAL_DISPATCH_HEADERS) delete req.headers[header];
@@ -706,6 +713,7 @@ function forwardedUpgradeHeaders(
     const lower = name.toLowerCase();
     if (
       lower === INTERNAL_SECRET_HEADER ||
+      lower === INTERNAL_DISPATCH_PROOF_HEADER ||
       (INTERNAL_DISPATCH_HEADERS as readonly string[]).includes(lower) ||
       HOP_BY_HOP_REQUEST_HEADERS.has(lower) ||
       nominated.has(lower)
@@ -734,7 +742,17 @@ function forwardedUpgradeHeaders(
     headers["x-invoke-query"] = JSON.stringify(resolution.invocationQuery);
   }
   headers[INTERNAL_EXECUTION_DEADLINE_HEADER] = String(executionDeadlineAt);
-  if (deps.internalSecret) headers[INTERNAL_SECRET_HEADER] = deps.internalSecret;
+  if (deps.internalSecret) {
+    headers[INTERNAL_DISPATCH_PROOF_HEADER] = computeDispatchProof(
+      deps.internalSecret,
+      dispatchProofInputsFromRequest({
+        method: req.method,
+        target: req.url,
+        headers,
+        proofHeaderNames: deps.proofHeaderNames,
+      }),
+    );
+  }
   return headers;
 }
 

--- a/src/pool-server/websocket-upgrade.ts
+++ b/src/pool-server/websocket-upgrade.ts
@@ -1,0 +1,656 @@
+// Next.js generated App Route WebSocket dispatch for the pool server.
+//
+// The public application API is intentionally NOT implemented here. Next owns the future
+// `NextResponse.upgrade()` object, executes the route's normal GET exactly once, and compiles an
+// additive adapter-facing `upgradeHandler(ctx, { node: { req, socket, head } })` export. This file
+// supplies the persistent Node transport around that generated entrypoint: trusted routing,
+// fail-safe local resolution, cross-pool tunnelling, bounded handshakes, and HTTP rejection.
+import {
+  request as httpRequest,
+  STATUS_CODES,
+  type IncomingHttpHeaders,
+  type IncomingMessage,
+} from "node:http";
+import type { Duplex } from "node:stream";
+import {
+  INTERNAL_DISPATCH_HEADERS,
+  INTERNAL_EXECUTION_DEADLINE_HEADER,
+  INTERNAL_SECRET_HEADER,
+  MW_EVALUATED_TRUSTED,
+  parseRequestUrl,
+} from "../routing-common.js";
+import { sanitizeK8sName } from "../emit/templates/utils.js";
+import { applyMiddlewareRequestHeaders, extractRouteParams } from "./dispatch.js";
+import type { HandlerLoader } from "./handler-loader.js";
+import type { ResolveResult } from "./resolve.js";
+
+export type UpgradeDisposition = "accepted" | "rejected";
+
+export interface WebSocketUpgradeDispatcher {
+  resolve(
+    url: URL,
+    headers: Headers,
+    method: string,
+    body: ReadableStream<Uint8Array>,
+  ): Promise<ResolveResult>;
+  handlerLoader: HandlerLoader;
+  poolName: string;
+  releaseName: string;
+  buildId: string;
+  internalSecret?: string | undefined;
+  /** Absolute budget for resolution + module load + generated handler acceptance. */
+  handshakeTimeoutMs?: number;
+  /** Test seam for a sibling pool endpoint; production uses Kubernetes service DNS on port 3000. */
+  resolvePoolEndpoint?: ((poolName: string) => { hostname: string; port: number }) | undefined;
+}
+
+const MAX_REJECTION_BODY_BYTES = 1024 * 1024;
+const DEFAULT_HANDSHAKE_TIMEOUT_MS = 60_000;
+
+class HandshakeDeadlineError extends Error {
+  constructor(stage: string) {
+    super(`WebSocket ${stage} exceeded the handshake deadline`);
+    this.name = "HandshakeDeadlineError";
+  }
+}
+
+const HOP_BY_HOP_RESPONSE_HEADERS = new Set([
+  "connection",
+  "content-length",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+]);
+
+function isPrivateResponseHeader(name: string): boolean {
+  const lower = name.toLowerCase();
+  return (
+    lower === "x-next-cache-tags" ||
+    lower === INTERNAL_SECRET_HEADER ||
+    (INTERNAL_DISPATCH_HEADERS as readonly string[]).includes(lower) ||
+    lower.startsWith("x-middleware-")
+  );
+}
+
+function emptyBody(): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      controller.close();
+    },
+  });
+}
+
+function requestHeaders(req: IncomingMessage): Headers {
+  const headers = new Headers();
+  for (const [name, value] of Object.entries(req.headers)) {
+    if (typeof value === "string") headers.set(name, value);
+    else if (Array.isArray(value)) value.forEach((entry) => headers.append(name, entry));
+  }
+  return headers;
+}
+
+function parseHeaderMap(raw: string | undefined): Headers | undefined {
+  if (!raw) return undefined;
+  try {
+    const value = JSON.parse(raw) as Record<string, string | string[]>;
+    const headers = new Headers();
+    for (const [name, item] of Object.entries(value)) {
+      if (Array.isArray(item)) item.forEach((entry) => headers.append(name, entry));
+      else if (typeof item === "string") headers.set(name, item);
+    }
+    return headers;
+  } catch {
+    return undefined;
+  }
+}
+
+function parseJsonRecord(raw: string | undefined): Record<string, string> | null {
+  if (!raw) return null;
+  try {
+    const value = JSON.parse(raw) as unknown;
+    if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+    const record: Record<string, string> = {};
+    for (const [key, item] of Object.entries(value)) {
+      if (typeof item !== "string") return null;
+      record[key] = item;
+    }
+    return record;
+  } catch {
+    return null;
+  }
+}
+
+function parseInvocationQuery(
+  raw: string | undefined,
+): Record<string, string | string[]> | undefined {
+  if (!raw) return undefined;
+  try {
+    const value = JSON.parse(raw) as unknown;
+    if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+    const query: Record<string, string | string[]> = {};
+    for (const [key, item] of Object.entries(value)) {
+      if (typeof item === "string") query[key] = item;
+      else if (Array.isArray(item) && item.every((entry) => typeof entry === "string")) {
+        query[key] = item as string[];
+      } else {
+        return undefined;
+      }
+    }
+    return query;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Read the secret-gated phase-two routing verdict, then erase the transport vocabulary. */
+function trustedResolutionFromHeaders(req: IncomingMessage): ResolveResult | undefined {
+  const outputId =
+    typeof req.headers["x-output-id"] === "string" ? req.headers["x-output-id"] : undefined;
+  const middlewareVerdict =
+    typeof req.headers["x-mw-evaluated"] === "string" ? req.headers["x-mw-evaluated"] : undefined;
+  if (!outputId || !middlewareVerdict || !MW_EVALUATED_TRUSTED.has(middlewareVerdict)) {
+    for (const header of INTERNAL_DISPATCH_HEADERS) delete req.headers[header];
+    return undefined;
+  }
+
+  const routeMatches = parseJsonRecord(
+    typeof req.headers["x-route-matches"] === "string" ? req.headers["x-route-matches"] : undefined,
+  );
+  const resolvedHeaders = parseHeaderMap(
+    typeof req.headers["x-resolved-headers"] === "string"
+      ? req.headers["x-resolved-headers"]
+      : undefined,
+  );
+  const middlewareRequestHeaders = parseHeaderMap(
+    typeof req.headers["x-mw-request-headers"] === "string"
+      ? req.headers["x-mw-request-headers"]
+      : undefined,
+  );
+  const invokePath =
+    typeof req.headers["x-invoke-path"] === "string" ? req.headers["x-invoke-path"] : undefined;
+  const invocationQuery = parseInvocationQuery(
+    typeof req.headers["x-invoke-query"] === "string" ? req.headers["x-invoke-query"] : undefined,
+  );
+  const deadlineRaw = req.headers[INTERNAL_EXECUTION_DEADLINE_HEADER];
+  const deadline = typeof deadlineRaw === "string" ? Number(deadlineRaw) : Number.NaN;
+  const executionDeadlineAt = Number.isSafeInteger(deadline) && deadline > 0 ? deadline : undefined;
+  const pool =
+    typeof req.headers["x-upstream-pool"] === "string" ? req.headers["x-upstream-pool"] : undefined;
+
+  for (const header of INTERNAL_DISPATCH_HEADERS) delete req.headers[header];
+  return {
+    kind: "route",
+    pool: pool ?? "",
+    matchedPathname: outputId,
+    routeMatches,
+    resolvedHeaders,
+    ...(middlewareRequestHeaders ? { middlewareRequestHeaders } : {}),
+    ...(invokePath ? { invokePath } : {}),
+    ...(invocationQuery ? { invocationQuery } : {}),
+    ...(executionDeadlineAt ? { executionDeadlineAt } : {}),
+  };
+}
+
+function publicRequestUrl(req: IncomingMessage): URL {
+  const url = parseRequestUrl(req.url ?? "/", req.headers.host);
+  const forwarded = req.headers["x-forwarded-proto"];
+  const protocol = (Array.isArray(forwarded) ? forwarded[0] : forwarded)?.split(",", 1)[0]?.trim();
+  if (protocol === "https" || protocol === "http") url.protocol = `${protocol}:`;
+  return url;
+}
+
+function appendHeader(
+  lines: string[],
+  name: string,
+  value: string,
+  options: { allowUpgrade?: boolean } = {},
+): void {
+  const lower = name.toLowerCase();
+  if (isPrivateResponseHeader(lower)) return;
+  if (
+    HOP_BY_HOP_RESPONSE_HEADERS.has(lower) &&
+    !(options.allowUpgrade && (lower === "connection" || lower === "upgrade"))
+  ) {
+    return;
+  }
+  // Node already rejected CR/LF in parsed response headers, but keep this serializer safe for
+  // values originating in a Web Headers object too.
+  if (/\r|\n/.test(name) || /\r|\n/.test(value)) return;
+  lines.push(`${name}: ${value}\r\n`);
+}
+
+async function beforeDeadline<T>(
+  promise: Promise<T>,
+  deadlineAt: number,
+  stage: string,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(
+          () => reject(new HandshakeDeadlineError(stage)),
+          Math.max(1, deadlineAt - Date.now()),
+        );
+        timer.unref?.();
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+function webHeaderEntries(headers: Headers): Array<[string, string]> {
+  const entries: Array<[string, string]> = [];
+  for (const [name, value] of headers.entries()) {
+    if (name.toLowerCase() !== "set-cookie") entries.push([name, value]);
+  }
+  for (const cookie of headers.getSetCookie()) entries.push(["set-cookie", cookie]);
+  return entries;
+}
+
+function mergedResponseHeaderEntries(
+  responseHeaders: Headers,
+  resolvedHeaders?: Headers,
+): Array<[string, string]> {
+  const merged = new Map<string, Array<[string, string]>>();
+  for (const [name, value] of webHeaderEntries(responseHeaders)) {
+    const lower = name.toLowerCase();
+    const current = merged.get(lower) ?? [];
+    current.push([name, value]);
+    merged.set(lower, current);
+  }
+  if (resolvedHeaders) {
+    for (const [name, value] of webHeaderEntries(resolvedHeaders)) {
+      const lower = name.toLowerCase();
+      if (lower === "set-cookie") {
+        const current = merged.get(lower) ?? [];
+        current.push([name, value]);
+        merged.set(lower, current);
+      } else {
+        merged.set(lower, [[name, value]]);
+      }
+    }
+  }
+  return [...merged.values()].flat();
+}
+
+async function readResponseBody(response: Response): Promise<Buffer> {
+  if (!response.body) return Buffer.alloc(0);
+  const reader = response.body.getReader();
+  const chunks: Buffer[] = [];
+  let total = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > MAX_REJECTION_BODY_BYTES) {
+        await reader.cancel("WebSocket rejection response exceeded adapter limit");
+        throw new Error("WebSocket rejection response exceeded 1 MiB");
+      }
+      chunks.push(Buffer.from(value));
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  return Buffer.concat(chunks, total);
+}
+
+async function writeHttpResponse(
+  socket: Duplex,
+  response: Response,
+  resolvedHeaders?: Headers,
+): Promise<void> {
+  if (socket.destroyed) return;
+  const body = await readResponseBody(response);
+  const lines = [
+    `HTTP/1.1 ${response.status} ${STATUS_CODES[response.status] ?? ""}\r\n`,
+    "Connection: close\r\n",
+    `Content-Length: ${body.length}\r\n`,
+  ];
+  for (const [name, value] of mergedResponseHeaderEntries(response.headers, resolvedHeaders)) {
+    appendHeader(lines, name, value, {
+      // RFC 9110's 426 response advertises the required protocol in Upgrade. Every other
+      // hop-by-hop field is transport state owned by this socket and stays stripped.
+      allowUpgrade: response.status === 426 && name.toLowerCase() === "upgrade",
+    });
+  }
+  lines.push("\r\n");
+  await new Promise<void>((resolve) => {
+    const done = () => resolve();
+    socket.once("close", done);
+    socket.once("error", done);
+    socket.end(Buffer.concat([Buffer.from(lines.join("")), body]), done);
+  });
+}
+
+async function rejectUpgrade(
+  socket: Duplex,
+  status: number,
+  headers?: Record<string, string>,
+  resolvedHeaders?: Headers,
+): Promise<UpgradeDisposition> {
+  await writeHttpResponse(
+    socket,
+    new Response(null, { status, ...(headers ? { headers } : {}) }),
+    resolvedHeaders,
+  );
+  return "rejected";
+}
+
+function sanitizedUpgradeResponseHead(res: IncomingMessage): Buffer {
+  const lines = [
+    `HTTP/1.1 ${res.statusCode ?? 101} ${res.statusMessage ?? STATUS_CODES[res.statusCode ?? 101] ?? ""}\r\n`,
+  ];
+  for (let index = 0; index + 1 < res.rawHeaders.length; index += 2) {
+    appendHeader(lines, res.rawHeaders[index]!, res.rawHeaders[index + 1]!, {
+      allowUpgrade: true,
+    });
+  }
+  lines.push("\r\n");
+  return Buffer.from(lines.join(""));
+}
+
+function forwardedUpgradeHeaders(
+  req: IncomingMessage,
+  resolution: Extract<ResolveResult, { kind: "route" }>,
+  deps: WebSocketUpgradeDispatcher,
+  executionDeadlineAt: number,
+): IncomingHttpHeaders {
+  const headers: IncomingHttpHeaders = {};
+  const nominated = new Set<string>();
+  const connection = req.headers.connection;
+  for (const value of Array.isArray(connection) ? connection : connection ? [connection] : []) {
+    for (const token of value.split(",")) {
+      const name = token.trim().toLowerCase();
+      if (name) nominated.add(name);
+    }
+  }
+  for (const [name, value] of Object.entries(req.headers)) {
+    if (value === undefined) continue;
+    const lower = name.toLowerCase();
+    if (
+      lower === INTERNAL_SECRET_HEADER ||
+      (INTERNAL_DISPATCH_HEADERS as readonly string[]).includes(lower) ||
+      (nominated.has(lower) && lower !== "upgrade")
+    ) {
+      continue;
+    }
+    headers[lower] = value;
+  }
+  // These are the only connection-scoped fields intentionally carried onto the NEW hop.
+  headers.connection = "Upgrade";
+  headers.upgrade = "websocket";
+  headers["x-output-id"] = resolution.matchedPathname;
+  headers["x-matched-pathname"] = resolution.matchedPathname;
+  headers["x-route-matches"] = resolution.routeMatches
+    ? JSON.stringify(resolution.routeMatches)
+    : "";
+  headers["x-mw-evaluated"] = "ran";
+  if (resolution.invokePath) headers["x-invoke-path"] = resolution.invokePath;
+  if (resolution.invocationQuery) {
+    headers["x-invoke-query"] = JSON.stringify(resolution.invocationQuery);
+  }
+  headers[INTERNAL_EXECUTION_DEADLINE_HEADER] = String(executionDeadlineAt);
+  if (deps.internalSecret) headers[INTERNAL_SECRET_HEADER] = deps.internalSecret;
+  return headers;
+}
+
+async function proxyUpgradeToPool(
+  req: IncomingMessage,
+  socket: Duplex,
+  head: Buffer,
+  resolution: Extract<ResolveResult, { kind: "route" }>,
+  deps: WebSocketUpgradeDispatcher,
+  deadlineAt: number,
+): Promise<UpgradeDisposition> {
+  return new Promise<UpgradeDisposition>((resolve) => {
+    const endpoint = deps.resolvePoolEndpoint?.(resolution.pool) ?? {
+      hostname: sanitizeK8sName(`${deps.releaseName}-${resolution.pool}-${deps.buildId}`),
+      port: 3000,
+    };
+    let settled = false;
+    const finish = (result: UpgradeDisposition) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(deadline);
+      resolve(result);
+    };
+    const proxyReq = httpRequest({
+      hostname: endpoint.hostname,
+      port: endpoint.port,
+      method: "GET",
+      path: req.url,
+      headers: forwardedUpgradeHeaders(req, resolution, deps, deadlineAt),
+    });
+    const deadline = setTimeout(
+      () => {
+        proxyReq.destroy(new Error("cross-pool WebSocket handshake deadline exceeded"));
+      },
+      Math.max(1, deadlineAt - Date.now()),
+    );
+    deadline.unref?.();
+
+    const abortProxy = () => {
+      if (!settled) proxyReq.destroy(new Error("WebSocket client disconnected during handshake"));
+    };
+    socket.once("close", abortProxy);
+
+    proxyReq.once("upgrade", (proxyRes, proxySocket, proxyHead) => {
+      socket.off("close", abortProxy);
+      try {
+        socket.write(sanitizedUpgradeResponseHead(proxyRes));
+        if (proxyHead.length > 0) socket.write(proxyHead);
+        if (head.length > 0) proxySocket.write(head);
+      } catch {
+        proxySocket.destroy();
+        if (!socket.destroyed) socket.destroy();
+        finish("rejected");
+        return;
+      }
+
+      const teardown = () => {
+        if (!socket.destroyed) socket.destroy();
+        if (!proxySocket.destroyed) proxySocket.destroy();
+      };
+      socket.on("error", teardown);
+      proxySocket.on("error", teardown);
+      socket.on("close", teardown);
+      proxySocket.on("close", teardown);
+      socket.pipe(proxySocket);
+      proxySocket.pipe(socket);
+      finish("accepted");
+    });
+
+    proxyReq.once("response", (proxyRes) => {
+      socket.off("close", abortProxy);
+      const lines = [
+        `HTTP/1.1 ${proxyRes.statusCode ?? 502} ${proxyRes.statusMessage ?? STATUS_CODES[proxyRes.statusCode ?? 502] ?? ""}\r\n`,
+        "Connection: close\r\n",
+      ];
+      for (let index = 0; index + 1 < proxyRes.rawHeaders.length; index += 2) {
+        appendHeader(lines, proxyRes.rawHeaders[index]!, proxyRes.rawHeaders[index + 1]!);
+      }
+      lines.push("\r\n");
+      if (!socket.destroyed) socket.write(lines.join(""));
+      let relayedBytes = 0;
+      proxyRes.on("data", (chunk: Buffer) => {
+        relayedBytes += chunk.length;
+        if (relayedBytes > MAX_REJECTION_BODY_BYTES) {
+          proxyRes.destroy(new Error("cross-pool WebSocket rejection exceeded 1 MiB"));
+          if (!socket.destroyed) socket.destroy();
+          finish("rejected");
+          return;
+        }
+        if (!socket.destroyed) socket.write(chunk);
+      });
+      proxyRes.once("end", () => {
+        if (!socket.destroyed) socket.end();
+        finish("rejected");
+      });
+      proxyRes.once("error", () => {
+        if (!socket.destroyed) socket.destroy();
+        finish("rejected");
+      });
+    });
+
+    proxyReq.once("error", (error) => {
+      socket.off("close", abortProxy);
+      if (!settled) {
+        console.error(
+          `[pool-server] cross-pool WebSocket handshake to pool "${resolution.pool}" failed:`,
+          error,
+        );
+        void rejectUpgrade(socket, 502).finally(() => finish("rejected"));
+      }
+    });
+    proxyReq.end();
+  });
+}
+
+function handlerContext(
+  req: IncomingMessage,
+  resolution: Extract<ResolveResult, { kind: "route" }>,
+): Record<string, unknown> {
+  const publicUrl = publicRequestUrl(req);
+  const resolvedPathname = resolution.invokePath
+    ? new URL(resolution.invokePath, publicUrl).pathname
+    : publicUrl.pathname;
+  const params = extractRouteParams(
+    resolution.matchedPathname,
+    resolution.routeMatches,
+    resolvedPathname,
+  );
+  return {
+    waitUntil(waitable: Promise<unknown>) {
+      Promise.resolve(waitable).catch((error) => {
+        console.error("[pool-server] WebSocket waitUntil failed:", error);
+      });
+    },
+    requestMeta: {
+      relativeProjectDir: ".",
+      hostname: req.headers.host?.split(":", 1)[0] ?? "127.0.0.1",
+      minimalMode: true,
+      outputId: resolution.matchedPathname,
+      matchedPathname: resolution.matchedPathname,
+      routeMatches: resolution.routeMatches,
+      resolvedPathname,
+      initURL: publicUrl.toString(),
+      ...(resolution.invokePath ? { rewrittenPathname: resolvedPathname } : {}),
+      ...(resolution.invocationQuery ? { query: resolution.invocationQuery } : {}),
+      ...(params ? { params } : {}),
+    },
+  };
+}
+
+/** Dispatch one Node HTTP upgrade through Next routing to a generated App Route entrypoint. */
+export async function handleWebSocketUpgrade(
+  deps: WebSocketUpgradeDispatcher,
+  req: IncomingMessage,
+  socket: Duplex,
+  head: Buffer,
+): Promise<UpgradeDisposition> {
+  if (req.method !== "GET" || req.headers.upgrade?.toLowerCase() !== "websocket") {
+    return rejectUpgrade(socket, 426, { Upgrade: "websocket" });
+  }
+
+  const timeoutMs = Math.max(1, deps.handshakeTimeoutMs ?? DEFAULT_HANDSHAKE_TIMEOUT_MS);
+  const localDeadlineAt = Date.now() + timeoutMs;
+  const trustedResolution = trustedResolutionFromHeaders(req);
+  const publicUrl = (() => {
+    try {
+      return publicRequestUrl(req);
+    } catch {
+      return undefined;
+    }
+  })();
+  if (!publicUrl) return rejectUpgrade(socket, 400);
+
+  let resolution: ResolveResult;
+  try {
+    resolution =
+      trustedResolution ??
+      (await beforeDeadline(
+        deps.resolve(publicUrl, requestHeaders(req), "GET", emptyBody()),
+        localDeadlineAt,
+        "route resolution",
+      ));
+  } catch (error) {
+    console.error("[pool-server] WebSocket route resolution failed:", error);
+    return rejectUpgrade(socket, error instanceof HandshakeDeadlineError ? 504 : 500);
+  }
+
+  switch (resolution.kind) {
+    case "redirect":
+      return rejectUpgrade(
+        socket,
+        resolution.status,
+        { Location: resolution.url.toString() },
+        resolution.resolvedHeaders,
+      );
+    case "error":
+      return rejectUpgrade(socket, resolution.status);
+    case "not-found":
+      return rejectUpgrade(socket, 404, undefined, resolution.resolvedHeaders);
+    case "middleware-response":
+      try {
+        await writeHttpResponse(socket, resolution.response);
+      } catch (error) {
+        console.error("[pool-server] WebSocket rejection response failed:", error);
+        if (!socket.destroyed) socket.destroy();
+      }
+      return "rejected";
+    case "external-rewrite":
+      // A safe external raw-socket dial needs the same DNS rebinding and address-range checks as
+      // the HTTP external-rewrite proxy. Do not turn an experimental feature into an SSRF bypass.
+      return rejectUpgrade(socket, 502);
+    case "route":
+      break;
+  }
+
+  if (!resolution.pool) resolution.pool = deps.poolName;
+  applyMiddlewareRequestHeaders(req, resolution.middlewareRequestHeaders);
+
+  const deadlineAt = Math.min(
+    localDeadlineAt,
+    resolution.executionDeadlineAt ?? Number.POSITIVE_INFINITY,
+  );
+  if (resolution.pool !== deps.poolName) {
+    return proxyUpgradeToPool(req, socket, head, resolution, deps, deadlineAt);
+  }
+
+  if (!deps.handlerLoader.has(resolution.matchedPathname)) {
+    return rejectUpgrade(socket, 404);
+  }
+  const output = deps.handlerLoader.get(resolution.matchedPathname);
+  if (output?.runtime === "edge") {
+    return rejectUpgrade(socket, 501);
+  }
+
+  let upgradeHandler;
+  try {
+    upgradeHandler = await beforeDeadline(
+      deps.handlerLoader.loadUpgrade(resolution.matchedPathname),
+      deadlineAt,
+      "route module load",
+    );
+  } catch (error) {
+    console.error("[pool-server] WebSocket route module load failed:", error);
+    return rejectUpgrade(socket, error instanceof HandshakeDeadlineError ? 504 : 500);
+  }
+  if (!upgradeHandler) return rejectUpgrade(socket, 426, { Upgrade: "websocket" });
+
+  const context = handlerContext(req, resolution);
+  await beforeDeadline(
+    Promise.resolve(upgradeHandler(context, { node: { req, socket, head } })),
+    deadlineAt,
+    "generated handler",
+  );
+  return "accepted";
+}

--- a/src/pool-server/websocket-upgrade.ts
+++ b/src/pool-server/websocket-upgrade.ts
@@ -17,6 +17,7 @@ import {
   INTERNAL_EXECUTION_DEADLINE_HEADER,
   INTERNAL_SECRET_HEADER,
   MW_EVALUATED_TRUSTED,
+  UNTRUSTED_NEXT_REQUEST_HEADERS,
   parseRequestUrl,
 } from "../routing-common.js";
 import { sanitizeK8sName } from "../emit/templates/utils.js";
@@ -38,6 +39,12 @@ export interface WebSocketUpgradeDispatcher {
   releaseName: string;
   buildId: string;
   internalSecret?: string | undefined;
+  /** Stable server-owned scope required by Next's generated connection registry. */
+  webSocketRegistryScope: object;
+  /** Exact cross-origin values accepted by experimental.webSocketRouteHandlers. */
+  webSocketAllowedOrigins?: readonly string[];
+  /** Parser from the app's pinned `next/dist/compiled/ws` transport. */
+  parseWebSocketExtensions?: ((value: string) => unknown) | undefined;
   /** Absolute budget for resolution + module load + generated handler acceptance. */
   handshakeTimeoutMs?: number;
   /** Test seam for a sibling pool endpoint; production uses Kubernetes service DNS on port 3000. */
@@ -46,6 +53,23 @@ export interface WebSocketUpgradeDispatcher {
 
 const MAX_REJECTION_BODY_BYTES = 1024 * 1024;
 const DEFAULT_HANDSHAKE_TIMEOUT_MS = 60_000;
+const NEXT_REQUEST_META = Symbol.for("NextInternalRequestMeta");
+const NEXT_WEBSOCKET_HEADERS_FILTERED = Symbol.for("next.websocket.upgrade-headers-filtered");
+const BODY_FRAMING_HEADERS = ["content-length", "transfer-encoding", "expect", "trailer"];
+const BODY_FRAMING_ERROR = "WebSocket upgrade requests cannot include HTTP body framing.";
+const RAW_HTTP_ERROR_CACHE_CONTROL = "private, no-cache, no-store, max-age=0, must-revalidate";
+const HTTP_TOKEN = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
+
+interface GeneratedUpgradeOutcome {
+  statusCode?: number;
+  upgraded: boolean;
+}
+
+interface WebSocketHandshakeError {
+  status: number;
+  message: string;
+  headers?: Record<string, string>;
+}
 
 class HandshakeDeadlineError extends Error {
   constructor(stage: string) {
@@ -60,6 +84,19 @@ const HOP_BY_HOP_RESPONSE_HEADERS = new Set([
   "keep-alive",
   "proxy-authenticate",
   "proxy-authorization",
+  "proxy-connection",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+]);
+
+const HOP_BY_HOP_REQUEST_HEADERS = new Set([
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "proxy-connection",
   "te",
   "trailer",
   "transfer-encoding",
@@ -93,14 +130,196 @@ function requestHeaders(req: IncomingMessage): Headers {
   return headers;
 }
 
+function rawHeaderValues(req: IncomingMessage, headerName: string): string[] {
+  const values: string[] = [];
+  if (Array.isArray(req.rawHeaders) && req.rawHeaders.length > 0) {
+    for (let index = 0; index + 1 < req.rawHeaders.length; index += 2) {
+      if (req.rawHeaders[index]?.toLowerCase() === headerName) {
+        values.push(req.rawHeaders[index + 1] ?? "");
+      }
+    }
+    return values;
+  }
+  const value = req.headers[headerName];
+  if (value === undefined) return values;
+  return Array.isArray(value) ? value : [value];
+}
+
+function exactHttpOrigin(value: string): URL | undefined {
+  try {
+    const url = new URL(value);
+    if (
+      (url.protocol === "http:" || url.protocol === "https:") &&
+      !url.hostname.includes("*") &&
+      url.origin === value
+    ) {
+      return url;
+    }
+  } catch {
+    // Invalid authorities and Origins are protocol errors, not URL-parser failures.
+  }
+  return undefined;
+}
+
+function webSocketRequestAuthority(req: IncomingMessage): URL | undefined {
+  const hosts = rawHeaderValues(req, "host");
+  if (hosts.length !== 1 || !hosts[0] || /\s|[\\/@?#,]/.test(hosts[0])) return undefined;
+  const encrypted = Boolean((req.socket as { encrypted?: boolean } | undefined)?.encrypted);
+  return exactHttpOrigin(`${encrypted ? "https" : "http"}://${hosts[0]}`);
+}
+
+function validateWebSocketHandshake(
+  req: IncomingMessage,
+  parseWebSocketExtensions: ((value: string) => unknown) | undefined,
+): WebSocketHandshakeError | undefined {
+  if (req.httpVersion !== "1.1") {
+    return { status: 400, message: "WebSocket upgrades require HTTP/1.1." };
+  }
+  if (req.method !== "GET") {
+    return { status: 405, message: "WebSocket upgrades require GET.", headers: { allow: "GET" } };
+  }
+  if (BODY_FRAMING_HEADERS.some((name) => rawHeaderValues(req, name).length > 0)) {
+    return { status: 400, message: BODY_FRAMING_ERROR };
+  }
+  if (rawHeaderValues(req, "host").length !== 1) {
+    return { status: 400, message: "Invalid WebSocket Host header." };
+  }
+  if (rawHeaderValues(req, "upgrade").length !== 1) {
+    return { status: 400, message: "Invalid WebSocket Upgrade header." };
+  }
+  if (rawHeaderValues(req, "sec-websocket-version").length !== 1) {
+    return {
+      status: 426,
+      message: "Unsupported WebSocket version.",
+      headers: { "sec-websocket-version": "13" },
+    };
+  }
+  if (rawHeaderValues(req, "sec-websocket-key").length !== 1) {
+    return { status: 400, message: "Invalid Sec-WebSocket-Key header." };
+  }
+  if (rawHeaderValues(req, "origin").length > 1) {
+    return { status: 400, message: "Invalid WebSocket Origin header." };
+  }
+  if (req.headers.upgrade?.toLowerCase() !== "websocket") {
+    return { status: 400, message: "Invalid WebSocket Upgrade header." };
+  }
+  const connection = req.headers.connection;
+  if (!connection?.split(",").some((value) => value.trim().toLowerCase() === "upgrade")) {
+    return { status: 400, message: "Invalid WebSocket Connection header." };
+  }
+  if (req.headers["sec-websocket-version"] !== "13") {
+    return {
+      status: 426,
+      message: "Unsupported WebSocket version.",
+      headers: { "sec-websocket-version": "13" },
+    };
+  }
+  if (!webSocketRequestAuthority(req)) {
+    return { status: 400, message: "Invalid WebSocket Host header." };
+  }
+  const key = req.headers["sec-websocket-key"];
+  if (
+    typeof key !== "string" ||
+    !/^[+/0-9A-Za-z]{22}==$/.test(key) ||
+    Buffer.from(key, "base64").byteLength !== 16
+  ) {
+    return { status: 400, message: "Invalid Sec-WebSocket-Key header." };
+  }
+  const protocolHeader = req.headers["sec-websocket-protocol"];
+  if (protocolHeader !== undefined) {
+    const protocols = (Array.isArray(protocolHeader) ? protocolHeader.join(",") : protocolHeader)
+      .split(",")
+      .map((protocol) => protocol.trim());
+    const seen = new Set<string>();
+    for (const protocol of protocols) {
+      if (!HTTP_TOKEN.test(protocol) || seen.has(protocol)) {
+        return { status: 400, message: "Invalid Sec-WebSocket-Protocol header." };
+      }
+      seen.add(protocol);
+    }
+  }
+  const extensions = rawHeaderValues(req, "sec-websocket-extensions");
+  if (extensions.length > 0) {
+    if (!parseWebSocketExtensions) {
+      throw new Error("The vendored WebSocket extension parser is unavailable.");
+    }
+    try {
+      // RFC 6455 grammar has enough edge cases that a hand-rolled approximation will drift.
+      // Use the exact parser pinned by the application's Next transport, as Next itself does.
+      parseWebSocketExtensions(extensions.join(","));
+    } catch {
+      return { status: 400, message: "Invalid Sec-WebSocket-Extensions header." };
+    }
+  }
+  return undefined;
+}
+
+function validateWebSocketOrigin(
+  req: IncomingMessage,
+  allowedOrigins: readonly string[] = [],
+): WebSocketHandshakeError | undefined {
+  const origins = rawHeaderValues(req, "origin");
+  if (origins.length === 0) return undefined;
+  if (origins.length !== 1) {
+    return { status: 403, message: "WebSocket origin is not allowed." };
+  }
+  const origin = exactHttpOrigin(origins[0]!);
+  if (!origin) return { status: 403, message: "WebSocket origin is not allowed." };
+  const authority = webSocketRequestAuthority(req);
+  if (!authority) return { status: 400, message: "Invalid WebSocket Host header." };
+  if (allowedOrigins.includes(origin.origin) || authority.origin === origin.origin)
+    return undefined;
+  return { status: 403, message: "WebSocket origin is not allowed." };
+}
+
+function removePrivateRawRequestHeaders(req: IncomingMessage): void {
+  const privateNames = new Set<string>([
+    INTERNAL_SECRET_HEADER,
+    ...INTERNAL_DISPATCH_HEADERS,
+    ...UNTRUSTED_NEXT_REQUEST_HEADERS,
+  ]);
+  const isPrivate = (name: string) => {
+    const lower = name.toLowerCase();
+    return privateNames.has(lower) || lower.startsWith("x-middleware-");
+  };
+  // Node derives headersDistinct lazily from rawHeaders while retaining the parser's original
+  // field count. Materialize and sanitize it BEFORE compacting rawHeaders; doing this in the
+  // opposite order made Node read past the shortened array (`undefined.toLowerCase()`) only when
+  // a client actually supplied a private field.
+  const distinct = req.headersDistinct;
+  if (distinct) {
+    for (const name of Object.keys(distinct)) {
+      if (isPrivate(name)) delete distinct[name];
+    }
+  }
+  if (Array.isArray(req.rawHeaders)) {
+    let writeIndex = 0;
+    for (let readIndex = 0; readIndex < req.rawHeaders.length; readIndex += 2) {
+      const name = req.rawHeaders[readIndex];
+      if (!name || isPrivate(name)) continue;
+      req.rawHeaders[writeIndex++] = name;
+      if (readIndex + 1 < req.rawHeaders.length) {
+        req.rawHeaders[writeIndex++] = req.rawHeaders[readIndex + 1]!;
+      }
+    }
+    req.rawHeaders.length = writeIndex;
+  }
+}
+
 function parseHeaderMap(raw: string | undefined): Headers | undefined {
   if (!raw) return undefined;
   try {
-    const value = JSON.parse(raw) as Record<string, string | string[]>;
+    const value = JSON.parse(raw) as unknown;
+    if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
     const headers = new Headers();
-    for (const [name, item] of Object.entries(value)) {
-      if (Array.isArray(item)) item.forEach((entry) => headers.append(name, entry));
-      else if (typeof item === "string") headers.set(name, item);
+    for (const [name, item] of Object.entries(value as Record<string, unknown>)) {
+      if (Array.isArray(item) && item.every((entry) => typeof entry === "string")) {
+        item.forEach((entry) => headers.append(name, entry));
+      } else if (typeof item === "string") {
+        headers.set(name, item);
+      } else {
+        return undefined;
+      }
     }
     return headers;
   } catch {
@@ -146,42 +365,105 @@ function parseInvocationQuery(
   }
 }
 
+function responseHeadersRecord(
+  headers: Headers | undefined,
+): Record<string, string | string[]> | undefined {
+  if (!headers) return undefined;
+  const record: Record<string, string | string[]> = {};
+  for (const [name, value] of headers.entries()) {
+    if (name.toLowerCase() !== "set-cookie") record[name] = value;
+  }
+  const cookies = headers.getSetCookie();
+  if (cookies.length > 0) record["set-cookie"] = cookies;
+  return record;
+}
+
+function installWebSocketRegistryScope(req: IncomingMessage, scope: object): void {
+  // The generated entrypoint deliberately refuses a lifecycle scope supplied through ctx: that
+  // object can cross an Adapter boundary. Next's own router stamps the server-owned object on the
+  // raw request before calling the same entrypoint. The pool owns the raw socket, so mirror that
+  // boundary using Next's process-global request-meta symbol rather than importing a private Next
+  // module whose path would couple the adapter to one canary build.
+  const request = req as IncomingMessage & Record<symbol, unknown>;
+  const current = request[NEXT_REQUEST_META];
+  const metadata = current && typeof current === "object" ? { ...current } : {};
+  (metadata as Record<string, unknown>).webSocketRegistryScope = scope;
+  request[NEXT_REQUEST_META] = metadata;
+}
+
+function generatedUpgradeDisposition(outcome: unknown): UpgradeDisposition {
+  if (!outcome || typeof outcome !== "object" || typeof (outcome as any).upgraded !== "boolean") {
+    throw new TypeError("Next generated upgradeHandler returned an invalid upgrade outcome");
+  }
+  const { upgraded, statusCode } = outcome as GeneratedUpgradeOutcome;
+  if (
+    statusCode !== undefined &&
+    (!Number.isInteger(statusCode) || statusCode < 100 || statusCode > 599)
+  ) {
+    throw new TypeError("Next generated upgradeHandler returned an invalid status code");
+  }
+  if (
+    (upgraded && statusCode !== undefined && statusCode !== 101) ||
+    (!upgraded && statusCode === 101)
+  ) {
+    throw new TypeError("Next generated upgradeHandler returned an inconsistent upgrade outcome");
+  }
+  return upgraded ? "accepted" : "rejected";
+}
+
 /** Read the secret-gated phase-two routing verdict, then erase the transport vocabulary. */
 function trustedResolutionFromHeaders(req: IncomingMessage): ResolveResult | undefined {
+  const discardDispatch = () => {
+    for (const header of INTERNAL_DISPATCH_HEADERS) delete req.headers[header];
+  };
   const outputId =
     typeof req.headers["x-output-id"] === "string" ? req.headers["x-output-id"] : undefined;
   const middlewareVerdict =
     typeof req.headers["x-mw-evaluated"] === "string" ? req.headers["x-mw-evaluated"] : undefined;
   if (!outputId || !middlewareVerdict || !MW_EVALUATED_TRUSTED.has(middlewareVerdict)) {
-    for (const header of INTERNAL_DISPATCH_HEADERS) delete req.headers[header];
+    discardDispatch();
     return undefined;
   }
 
-  const routeMatches = parseJsonRecord(
-    typeof req.headers["x-route-matches"] === "string" ? req.headers["x-route-matches"] : undefined,
-  );
-  const resolvedHeaders = parseHeaderMap(
+  const routeMatchesRaw =
+    typeof req.headers["x-route-matches"] === "string" ? req.headers["x-route-matches"] : undefined;
+  const resolvedHeadersRaw =
     typeof req.headers["x-resolved-headers"] === "string"
       ? req.headers["x-resolved-headers"]
-      : undefined,
-  );
-  const middlewareRequestHeaders = parseHeaderMap(
+      : undefined;
+  const middlewareRequestHeadersRaw =
     typeof req.headers["x-mw-request-headers"] === "string"
       ? req.headers["x-mw-request-headers"]
-      : undefined,
-  );
+      : undefined;
+  const invocationQueryRaw =
+    typeof req.headers["x-invoke-query"] === "string" ? req.headers["x-invoke-query"] : undefined;
+  const routeMatches = parseJsonRecord(routeMatchesRaw);
+  const resolvedHeaders = parseHeaderMap(resolvedHeadersRaw);
+  const middlewareRequestHeaders = parseHeaderMap(middlewareRequestHeadersRaw);
   const invokePath =
     typeof req.headers["x-invoke-path"] === "string" ? req.headers["x-invoke-path"] : undefined;
-  const invocationQuery = parseInvocationQuery(
-    typeof req.headers["x-invoke-query"] === "string" ? req.headers["x-invoke-query"] : undefined,
-  );
+  const invocationQuery = parseInvocationQuery(invocationQueryRaw);
   const deadlineRaw = req.headers[INTERNAL_EXECUTION_DEADLINE_HEADER];
   const deadline = typeof deadlineRaw === "string" ? Number(deadlineRaw) : Number.NaN;
   const executionDeadlineAt = Number.isSafeInteger(deadline) && deadline > 0 ? deadline : undefined;
   const pool =
     typeof req.headers["x-upstream-pool"] === "string" ? req.headers["x-upstream-pool"] : undefined;
 
-  for (const header of INTERNAL_DISPATCH_HEADERS) delete req.headers[header];
+  // Optional means absent, not malformed. A trusted-but-corrupt extension verdict must not skip
+  // middleware while silently discarding its authoritative request-header replacement, rewrite
+  // query, route params, response headers, or inherited deadline. Re-resolve the whole request.
+  if (
+    (routeMatchesRaw !== undefined && routeMatches === null) ||
+    (resolvedHeadersRaw !== undefined && resolvedHeaders === undefined) ||
+    (middlewareRequestHeadersRaw !== undefined && middlewareRequestHeaders === undefined) ||
+    (invocationQueryRaw !== undefined && invocationQuery === undefined) ||
+    (deadlineRaw !== undefined && executionDeadlineAt === undefined)
+  ) {
+    discardDispatch();
+    return undefined;
+  }
+
+  discardDispatch();
   return {
     kind: "route",
     pool: pool ?? "",
@@ -280,14 +562,18 @@ function mergedResponseHeaderEntries(
   return [...merged.values()].flat();
 }
 
-async function readResponseBody(response: Response): Promise<Buffer> {
+async function readResponseBody(response: Response, deadlineAt: number): Promise<Buffer> {
   if (!response.body) return Buffer.alloc(0);
   const reader = response.body.getReader();
   const chunks: Buffer[] = [];
   let total = 0;
   try {
     for (;;) {
-      const { done, value } = await reader.read();
+      const { done, value } = await beforeDeadline(
+        reader.read(),
+        deadlineAt,
+        "rejection response body",
+      );
       if (done) break;
       total += value.byteLength;
       if (total > MAX_REJECTION_BODY_BYTES) {
@@ -296,6 +582,11 @@ async function readResponseBody(response: Response): Promise<Buffer> {
       }
       chunks.push(Buffer.from(value));
     }
+  } catch (error) {
+    // A middleware may return a stream which never produces a byte. Release its resources when
+    // the absolute handshake budget expires instead of leaving a detached reader behind.
+    void reader.cancel(error).catch(() => undefined);
+    throw error;
   } finally {
     reader.releaseLock();
   }
@@ -305,10 +596,11 @@ async function readResponseBody(response: Response): Promise<Buffer> {
 async function writeHttpResponse(
   socket: Duplex,
   response: Response,
+  deadlineAt: number,
   resolvedHeaders?: Headers,
 ): Promise<void> {
   if (socket.destroyed) return;
-  const body = await readResponseBody(response);
+  const body = await readResponseBody(response, deadlineAt);
   const lines = [
     `HTTP/1.1 ${response.status} ${STATUS_CODES[response.status] ?? ""}\r\n`,
     "Connection: close\r\n",
@@ -322,24 +614,51 @@ async function writeHttpResponse(
     });
   }
   lines.push("\r\n");
-  await new Promise<void>((resolve) => {
-    const done = () => resolve();
-    socket.once("close", done);
-    socket.once("error", done);
-    socket.end(Buffer.concat([Buffer.from(lines.join("")), body]), done);
-  });
+  try {
+    await beforeDeadline(
+      new Promise<void>((resolve) => {
+        const done = () => resolve();
+        socket.once("close", done);
+        socket.once("error", done);
+        socket.end(Buffer.concat([Buffer.from(lines.join("")), body]), done);
+      }),
+      deadlineAt,
+      "rejection response write",
+    );
+  } catch (error) {
+    if (!socket.destroyed) socket.destroy();
+    throw error;
+  }
 }
 
 async function rejectUpgrade(
   socket: Duplex,
   status: number,
+  deadlineAt: number,
   headers?: Record<string, string>,
   resolvedHeaders?: Headers,
 ): Promise<UpgradeDisposition> {
   await writeHttpResponse(
     socket,
     new Response(null, { status, ...(headers ? { headers } : {}) }),
+    deadlineAt,
     resolvedHeaders,
+  );
+  return "rejected";
+}
+
+async function rejectUpgradeWithMessage(
+  socket: Duplex,
+  error: WebSocketHandshakeError,
+  deadlineAt: number,
+): Promise<UpgradeDisposition> {
+  const headers = new Headers(error.headers);
+  headers.set("cache-control", RAW_HTTP_ERROR_CACHE_CONTROL);
+  headers.set("content-type", "text/plain; charset=utf-8");
+  await writeHttpResponse(
+    socket,
+    new Response(error.message, { status: error.status, headers }),
+    deadlineAt,
   );
   return "rejected";
 }
@@ -378,7 +697,8 @@ function forwardedUpgradeHeaders(
     if (
       lower === INTERNAL_SECRET_HEADER ||
       (INTERNAL_DISPATCH_HEADERS as readonly string[]).includes(lower) ||
-      (nominated.has(lower) && lower !== "upgrade")
+      HOP_BY_HOP_REQUEST_HEADERS.has(lower) ||
+      nominated.has(lower)
     ) {
       continue;
     }
@@ -393,6 +713,12 @@ function forwardedUpgradeHeaders(
     ? JSON.stringify(resolution.routeMatches)
     : "";
   headers["x-mw-evaluated"] = "ran";
+  const middlewareRequestHeaders = responseHeadersRecord(resolution.middlewareRequestHeaders);
+  if (middlewareRequestHeaders) {
+    headers["x-mw-request-headers"] = JSON.stringify(middlewareRequestHeaders);
+  }
+  const resolvedHeaders = responseHeadersRecord(resolution.resolvedHeaders);
+  if (resolvedHeaders) headers["x-resolved-headers"] = JSON.stringify(resolvedHeaders);
   if (resolution.invokePath) headers["x-invoke-path"] = resolution.invokePath;
   if (resolution.invocationQuery) {
     headers["x-invoke-query"] = JSON.stringify(resolution.invocationQuery);
@@ -507,7 +833,7 @@ async function proxyUpgradeToPool(
           `[pool-server] cross-pool WebSocket handshake to pool "${resolution.pool}" failed:`,
           error,
         );
-        void rejectUpgrade(socket, 502).finally(() => finish("rejected"));
+        void rejectUpgrade(socket, 502, deadlineAt).finally(() => finish("rejected"));
       }
     });
     proxyReq.end();
@@ -546,6 +872,9 @@ function handlerContext(
       ...(resolution.invocationQuery ? { query: resolution.invocationQuery } : {}),
       ...(params ? { params } : {}),
     },
+    ...(resolution.resolvedHeaders
+      ? { responseHeaders: responseHeadersRecord(resolution.resolvedHeaders) }
+      : {}),
   };
 }
 
@@ -556,12 +885,32 @@ export async function handleWebSocketUpgrade(
   socket: Duplex,
   head: Buffer,
 ): Promise<UpgradeDisposition> {
-  if (req.method !== "GET" || req.headers.upgrade?.toLowerCase() !== "websocket") {
-    return rejectUpgrade(socket, 426, { Upgrade: "websocket" });
-  }
-
   const timeoutMs = Math.max(1, deps.handshakeTimeoutMs ?? DEFAULT_HANDSHAKE_TIMEOUT_MS);
   const localDeadlineAt = Date.now() + timeoutMs;
+  if (
+    !rawHeaderValues(req, "upgrade").some((value) =>
+      value.split(",").some((protocol) => protocol.trim().toLowerCase() === "websocket"),
+    )
+  ) {
+    return rejectUpgrade(socket, 426, localDeadlineAt, { Upgrade: "websocket" });
+  }
+
+  // These checks intentionally precede proxy.ts/middleware. Apart from matching Next's owner
+  // ordering, it prevents malformed credentials, Origins, or framing from reaching application
+  // code which may have side effects or relax those same headers.
+  const handshakeError = validateWebSocketHandshake(req, deps.parseWebSocketExtensions);
+  if (handshakeError) {
+    return rejectUpgradeWithMessage(socket, handshakeError, localDeadlineAt);
+  }
+  const originError = validateWebSocketOrigin(req, deps.webSocketAllowedOrigins);
+  if (originError) return rejectUpgradeWithMessage(socket, originError, localDeadlineAt);
+
+  // The shared request trust boundary removed private fields from req.headers. Remove their raw
+  // parser views too before user code can inspect the request, then mark the equivalent Next
+  // filter complete. Middleware-generated x-middleware-set-cookie is added later and must survive
+  // into the generated request store; allowing Next to re-run its ingress filter would erase it.
+  removePrivateRawRequestHeaders(req);
+
   const trustedResolution = trustedResolutionFromHeaders(req);
   const publicUrl = (() => {
     try {
@@ -570,7 +919,7 @@ export async function handleWebSocketUpgrade(
       return undefined;
     }
   })();
-  if (!publicUrl) return rejectUpgrade(socket, 400);
+  if (!publicUrl) return rejectUpgrade(socket, 400, localDeadlineAt);
 
   let resolution: ResolveResult;
   try {
@@ -583,7 +932,11 @@ export async function handleWebSocketUpgrade(
       ));
   } catch (error) {
     console.error("[pool-server] WebSocket route resolution failed:", error);
-    return rejectUpgrade(socket, error instanceof HandshakeDeadlineError ? 504 : 500);
+    return rejectUpgrade(
+      socket,
+      error instanceof HandshakeDeadlineError ? 504 : 500,
+      localDeadlineAt,
+    );
   }
 
   switch (resolution.kind) {
@@ -591,16 +944,21 @@ export async function handleWebSocketUpgrade(
       return rejectUpgrade(
         socket,
         resolution.status,
+        localDeadlineAt,
         { Location: resolution.url.toString() },
         resolution.resolvedHeaders,
       );
     case "error":
-      return rejectUpgrade(socket, resolution.status);
+      return rejectUpgrade(socket, resolution.status, localDeadlineAt);
     case "not-found":
-      return rejectUpgrade(socket, 404, undefined, resolution.resolvedHeaders);
+      return rejectUpgradeWithMessage(
+        socket,
+        { status: 404, message: "Not Found" },
+        localDeadlineAt,
+      );
     case "middleware-response":
       try {
-        await writeHttpResponse(socket, resolution.response);
+        await writeHttpResponse(socket, resolution.response, localDeadlineAt);
       } catch (error) {
         console.error("[pool-server] WebSocket rejection response failed:", error);
         if (!socket.destroyed) socket.destroy();
@@ -609,13 +967,20 @@ export async function handleWebSocketUpgrade(
     case "external-rewrite":
       // A safe external raw-socket dial needs the same DNS rebinding and address-range checks as
       // the HTTP external-rewrite proxy. Do not turn an experimental feature into an SSRF bypass.
-      return rejectUpgrade(socket, 502);
+      return rejectUpgradeWithMessage(
+        socket,
+        {
+          status: 501,
+          message:
+            "External WebSocket rewrite targets are not proxied while webSocketRouteHandlers is enabled.",
+        },
+        localDeadlineAt,
+      );
     case "route":
       break;
   }
 
   if (!resolution.pool) resolution.pool = deps.poolName;
-  applyMiddlewareRequestHeaders(req, resolution.middlewareRequestHeaders);
 
   const deadlineAt = Math.min(
     localDeadlineAt,
@@ -625,12 +990,16 @@ export async function handleWebSocketUpgrade(
     return proxyUpgradeToPool(req, socket, head, resolution, deps, deadlineAt);
   }
 
+  applyMiddlewareRequestHeaders(req, resolution.middlewareRequestHeaders, {
+    preserveMiddlewareCookieHeader: true,
+  });
+
   if (!deps.handlerLoader.has(resolution.matchedPathname)) {
-    return rejectUpgrade(socket, 404);
+    return rejectUpgradeWithMessage(socket, { status: 404, message: "Not Found" }, deadlineAt);
   }
   const output = deps.handlerLoader.get(resolution.matchedPathname);
-  if (output?.runtime === "edge") {
-    return rejectUpgrade(socket, 501);
+  if (output?.type !== "APP_ROUTE" || output.runtime === "edge") {
+    return rejectUpgradeWithMessage(socket, { status: 404, message: "Not Found" }, deadlineAt);
   }
 
   let upgradeHandler;
@@ -642,15 +1011,25 @@ export async function handleWebSocketUpgrade(
     );
   } catch (error) {
     console.error("[pool-server] WebSocket route module load failed:", error);
-    return rejectUpgrade(socket, error instanceof HandshakeDeadlineError ? 504 : 500);
+    return rejectUpgrade(
+      socket,
+      error instanceof HandshakeDeadlineError ? 504 : 500,
+      deadlineAt,
+      undefined,
+      resolution.resolvedHeaders,
+    );
   }
-  if (!upgradeHandler) return rejectUpgrade(socket, 426, { Upgrade: "websocket" });
+  if (!upgradeHandler) {
+    return rejectUpgradeWithMessage(socket, { status: 404, message: "Not Found" }, deadlineAt);
+  }
 
   const context = handlerContext(req, resolution);
-  await beforeDeadline(
+  (req as IncomingMessage & Record<symbol, unknown>)[NEXT_WEBSOCKET_HEADERS_FILTERED] = true;
+  installWebSocketRegistryScope(req, deps.webSocketRegistryScope);
+  const outcome = await beforeDeadline(
     Promise.resolve(upgradeHandler(context, { node: { req, socket, head } })),
     deadlineAt,
     "generated handler",
   );
-  return "accepted";
+  return generatedUpgradeDisposition(outcome);
 }

--- a/tests/pool-server/dispatch-hardening.test.ts
+++ b/tests/pool-server/dispatch-hardening.test.ts
@@ -5,6 +5,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   applyMiddlewareRequestHeaders,
   createDispatcher,
+  installResolvedResponseHeaders,
   mergeResolvedHeadersIntoHeadersArg,
   mergeResponseHeaders,
 } from "../../src/pool-server/dispatch.js";
@@ -437,6 +438,58 @@ describe("applyMiddlewareRequestHeaders", () => {
     applyMiddlewareRequestHeaders(req, headers);
 
     expect(req.headers.cookie).toBe("app=existing; session=one; theme=dark");
+  });
+
+  it("preserves framework-authored middleware cookies for a generated WebSocket handoff", () => {
+    const req = mockReq("/", { cookie: "app=existing" });
+    const headers = new Headers({
+      cookie: "app=existing",
+      "x-middleware-set-cookie": "session=one; Path=/",
+    });
+
+    applyMiddlewareRequestHeaders(req, headers, { preserveMiddlewareCookieHeader: true });
+
+    expect(req.headers.cookie).toBe("app=existing");
+    expect(req.headers["x-middleware-set-cookie"]).toBe("session=one; Path=/");
+  });
+});
+
+describe("generated WebSocket fallback response headers", () => {
+  it("keeps Next's canonical 426 framing after routing-header inheritance", () => {
+    let written: unknown;
+    const res = {
+      writeHead(_status: number, headers: unknown) {
+        written = headers;
+        return res;
+      },
+    } as unknown as ServerResponse;
+    const resolved = new Headers({
+      connection: "x-routing-secret",
+      "content-length": "999999",
+      "x-routing-secret": "secret",
+      "x-response-layer": "routing",
+    });
+    resolved.append("set-cookie", "routing=present; Path=/");
+    installResolvedResponseHeaders(res, resolved);
+
+    res.writeHead(426, {
+      connection: "close",
+      "content-length": "51",
+      "content-type": "text/plain; charset=utf-8",
+      "cache-control": "private, no-cache, no-store, max-age=0, must-revalidate",
+      upgrade: "websocket",
+      "sec-websocket-version": "13",
+      "x-response-layer": "handler",
+    });
+
+    const headers = new Headers(written as HeadersInit);
+    expect(headers.get("connection")).toBe("close");
+    expect(headers.get("content-length")).toBe("51");
+    expect(headers.get("upgrade")).toBe("websocket");
+    expect(headers.get("sec-websocket-version")).toBe("13");
+    expect(headers.get("x-routing-secret")).toBeNull();
+    expect(headers.get("x-response-layer")).toBe("handler");
+    expect(headers.get("set-cookie")).toContain("routing=present");
   });
 });
 

--- a/tests/pool-server/handler-loader.test.ts
+++ b/tests/pool-server/handler-loader.test.ts
@@ -2,8 +2,28 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import {
   resolveRouteHandlerExport,
+  resolveUpgradeHandlerExport,
   createHandlerLoader,
 } from "../../src/pool-server/handler-loader.js";
+
+describe("resolveUpgradeHandlerExport", () => {
+  it("resolves Next's generated top-level entrypoint", () => {
+    const upgradeHandler = () => {};
+    expect(resolveUpgradeHandlerExport({ upgradeHandler })).toBe(upgradeHandler);
+  });
+
+  it("accepts the dynamic-import wrapper around CommonJS module.exports", () => {
+    const upgradeHandler = () => {};
+    expect(resolveUpgradeHandlerExport({ default: { upgradeHandler } })).toBe(upgradeHandler);
+  });
+
+  it("does not mistake a userland export for the generated adapter contract", () => {
+    const upgradeHandler = () => {};
+    expect(
+      resolveUpgradeHandlerExport({ routeModule: { userland: { upgradeHandler } } }),
+    ).toBeUndefined();
+  });
+});
 
 describe("resolveRouteHandlerExport", () => {
   it("resolves module.handler", () => {
@@ -153,6 +173,30 @@ describe("resolveRouteHandlerExport", () => {
 });
 
 describe("createHandlerLoader", () => {
+  it("imports one module for its HTTP and WebSocket entrypoints", async () => {
+    const handler = () => {};
+    const upgradeHandler = () => {};
+    const loadModule = vi.fn().mockResolvedValue({ handler, upgradeHandler });
+    const manifest = {
+      buildId: "test123",
+      poolName: "routes",
+      outputs: {
+        "/socket": {
+          id: "/socket",
+          filePath: "handlers/socket.js",
+          pathname: "/socket",
+          type: "APP_ROUTE",
+          runtime: "nodejs",
+        },
+      },
+    } as any;
+    const loader = createHandlerLoader(manifest, loadModule);
+
+    expect(await loader.load("/socket")).toBe(handler);
+    expect(await loader.loadUpgrade("/socket")).toBe(upgradeHandler);
+    expect(loadModule).toHaveBeenCalledOnce();
+  });
+
   it("loads and caches handler modules", async () => {
     const mockHandler = () => {};
     const loadModule = vi.fn().mockResolvedValue({ handler: mockHandler });

--- a/tests/pool-server/server-shutdown.test.ts
+++ b/tests/pool-server/server-shutdown.test.ts
@@ -14,6 +14,8 @@ import { describe, it, expect, afterEach } from "vitest";
 import net from "node:net";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { createPoolServer } from "../../src/pool-server/server.js";
+import { INTERNAL_DISPATCH_PROOF_HEADER } from "../../src/routing-common.js";
+import { signDispatch } from "../helpers/dispatch-proof.js";
 
 let pool: ReturnType<typeof createPoolServer> | null = null;
 afterEach(async () => {
@@ -56,7 +58,7 @@ describe("createPoolServer().stop()", () => {
     pool = null;
   });
 
-  it("applies the same secret-gated request boundary to upgrade traffic", async () => {
+  it("applies the same proof-gated request boundary to upgrade traffic", async () => {
     const seen: Array<Record<string, string | string[] | undefined>> = [];
     pool = createPoolServer({
       onRequest: () => undefined,
@@ -70,14 +72,14 @@ describe("createPoolServer().stop()", () => {
     });
     const { port } = await pool.start();
 
-    const send = (secret: string) =>
+    const send = (proof: string) =>
       new Promise<void>((resolve, reject) => {
         const socket = net.createConnection({ host: "127.0.0.1", port }, () => {
           socket.write(
             "GET /socket HTTP/1.1\r\nHost: localhost\r\nConnection: Upgrade\r\n" +
               "Upgrade: websocket\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n" +
               "Sec-WebSocket-Version: 13\r\nX-Output-Id: /admin\r\n" +
-              `X-Internal-Secret: ${secret}\r\n\r\n`,
+              `X-Internal-Dispatch-Proof: ${proof}\r\n\r\n`,
           );
         });
         socket.on("data", () => undefined);
@@ -85,12 +87,19 @@ describe("createPoolServer().stop()", () => {
         socket.once("error", reject);
       });
 
-    await send("wrong-secret");
-    await send("correct-secret");
+    const signed = signDispatch(
+      "correct-secret",
+      "GET",
+      "/socket",
+      { "x-output-id": "/admin" },
+      { authority: "localhost" },
+    );
+    await send("invalid-proof");
+    await send(signed[INTERNAL_DISPATCH_PROOF_HEADER]!);
     expect(seen[0]?.["x-output-id"]).toBeUndefined();
     expect(seen[1]?.["x-output-id"]).toBe("/admin");
-    expect(seen[0]?.["x-internal-secret"]).toBeUndefined();
-    expect(seen[1]?.["x-internal-secret"]).toBeUndefined();
+    expect(seen[0]?.[INTERNAL_DISPATCH_PROOF_HEADER]).toBeUndefined();
+    expect(seen[1]?.[INTERNAL_DISPATCH_PROOF_HEADER]).toBeUndefined();
   });
 
   it("settles with an idle keep-alive connection open (close() alone would not)", async () => {

--- a/tests/pool-server/server-shutdown.test.ts
+++ b/tests/pool-server/server-shutdown.test.ts
@@ -24,6 +24,75 @@ afterEach(async () => {
 });
 
 describe("createPoolServer().stop()", () => {
+  it("tracks upgraded sockets and closes them with WebSocket 1001 after the grace window", async () => {
+    pool = createPoolServer({
+      onRequest: () => undefined,
+      onUpgrade: (_req, socket) => {
+        socket.write(
+          "HTTP/1.1 101 Switching Protocols\r\n" +
+            "Connection: Upgrade\r\nUpgrade: websocket\r\n\r\n",
+        );
+        return "accepted";
+      },
+      port: 0,
+    });
+    const { port } = await pool.start();
+    const socket = net.createConnection({ host: "127.0.0.1", port });
+    const chunks: Buffer[] = [];
+    socket.on("data", (chunk) => chunks.push(Buffer.from(chunk)));
+    await new Promise<void>((resolve) => socket.once("connect", resolve));
+    socket.write(
+      "GET /socket HTTP/1.1\r\nHost: localhost\r\nConnection: Upgrade\r\n" +
+        "Upgrade: websocket\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n" +
+        "Sec-WebSocket-Version: 13\r\n\r\n",
+    );
+    await new Promise<void>((resolve) => socket.once("data", () => resolve()));
+
+    await pool.stop({ graceMs: 80 });
+    const received = Buffer.concat(chunks);
+    expect(received.toString("latin1")).toContain("101 Switching Protocols");
+    expect(received.subarray(-4)).toEqual(Buffer.from([0x88, 0x02, 0x03, 0xe9]));
+    socket.destroy();
+    pool = null;
+  });
+
+  it("applies the same secret-gated request boundary to upgrade traffic", async () => {
+    const seen: Array<Record<string, string | string[] | undefined>> = [];
+    pool = createPoolServer({
+      onRequest: () => undefined,
+      onUpgrade: (req, socket) => {
+        seen.push({ ...req.headers });
+        socket.end("HTTP/1.1 426 Upgrade Required\r\nConnection: close\r\n\r\n");
+        return "rejected";
+      },
+      internalSecret: "correct-secret",
+      port: 0,
+    });
+    const { port } = await pool.start();
+
+    const send = (secret: string) =>
+      new Promise<void>((resolve, reject) => {
+        const socket = net.createConnection({ host: "127.0.0.1", port }, () => {
+          socket.write(
+            "GET /socket HTTP/1.1\r\nHost: localhost\r\nConnection: Upgrade\r\n" +
+              "Upgrade: websocket\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n" +
+              "Sec-WebSocket-Version: 13\r\nX-Output-Id: /admin\r\n" +
+              `X-Internal-Secret: ${secret}\r\n\r\n`,
+          );
+        });
+        socket.on("data", () => undefined);
+        socket.once("close", () => resolve());
+        socket.once("error", reject);
+      });
+
+    await send("wrong-secret");
+    await send("correct-secret");
+    expect(seen[0]?.["x-output-id"]).toBeUndefined();
+    expect(seen[1]?.["x-output-id"]).toBe("/admin");
+    expect(seen[0]?.["x-internal-secret"]).toBeUndefined();
+    expect(seen[1]?.["x-internal-secret"]).toBeUndefined();
+  });
+
   it("settles with an idle keep-alive connection open (close() alone would not)", async () => {
     pool = createPoolServer({
       onRequest: (_req: IncomingMessage, res: ServerResponse) => {

--- a/tests/pool-server/websocket-upgrade.test.ts
+++ b/tests/pool-server/websocket-upgrade.test.ts
@@ -296,6 +296,55 @@ describe("handleWebSocketUpgrade", () => {
     acceptedSocket.socket.destroy();
   });
 
+  it("treats a wss handshake behind the TLS-terminating load balancer as same-origin", async () => {
+    // TLS terminates at the load balancer, so the pool's socket is plain http even though the
+    // browser dialled wss:// against an https site. The same-origin authority must come from the
+    // validated x-forwarded-proto witness — otherwise every https app would need to list itself
+    // in webSocketRouteHandlers.allowedOrigins.
+    const sameOrigin = dependencies({
+      upgradeHandler: async () => ({ upgraded: true, statusCode: 101 }),
+    });
+    const sameOriginReq = request(undefined, {
+      "x-forwarded-proto": "https",
+      origin: "https://example.com",
+    });
+    sameOriginReq.socket = { encrypted: false };
+    const sameOriginSocket = captureSocket();
+    await expect(
+      handleWebSocketUpgrade(
+        sameOrigin.deps,
+        sameOriginReq,
+        sameOriginSocket.socket,
+        Buffer.alloc(0),
+      ),
+    ).resolves.toBe("accepted");
+    expect(sameOrigin.deps.webSocketAllowedOrigins).toBeUndefined();
+    expect(sameOrigin.resolve).toHaveBeenCalledOnce();
+    sameOriginSocket.socket.destroy();
+
+    // The forwarded witness only fixes the scheme — a genuinely different origin is still denied.
+    const crossOrigin = dependencies({
+      upgradeHandler: async () => ({ upgraded: true, statusCode: 101 }),
+    });
+    const crossOriginReq = request(undefined, {
+      "x-forwarded-proto": "https",
+      origin: "https://attacker.example",
+    });
+    crossOriginReq.socket = { encrypted: false };
+    const crossOriginSocket = captureSocket();
+    await expect(
+      handleWebSocketUpgrade(
+        crossOrigin.deps,
+        crossOriginReq,
+        crossOriginSocket.socket,
+        Buffer.alloc(0),
+      ),
+    ).resolves.toBe("rejected");
+    expect(crossOriginSocket.text()).toContain("HTTP/1.1 403 Forbidden");
+    expect(crossOriginSocket.text()).toContain("WebSocket origin is not allowed.");
+    expect(crossOrigin.resolve).not.toHaveBeenCalled();
+  });
+
   it("preserves only framework-authored middleware cookies into the generated request", async () => {
     const middlewareRequestHeaders = new Headers({
       host: "example.com",

--- a/tests/pool-server/websocket-upgrade.test.ts
+++ b/tests/pool-server/websocket-upgrade.test.ts
@@ -2,6 +2,7 @@ import { createServer } from "node:http";
 import { Duplex, PassThrough } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
 import { handleWebSocketUpgrade } from "../../src/pool-server/websocket-upgrade.js";
+import { INTERNAL_DISPATCH_PROOF_HEADER, verifyDispatchProof } from "../../src/routing-common.js";
 
 function captureSocket() {
   const socket = new PassThrough();
@@ -357,10 +358,11 @@ describe("handleWebSocketUpgrade", () => {
     const upgradeHandler = vi.fn(async (_context, { node }) => {
       expect(node.req.headers["x-middleware-set-cookie"]).toBe("proxy-cookie=present; Path=/");
       expect(node.req.headers["x-nextjs-data"]).toBeUndefined();
+      expect(node.req.headers[INTERNAL_DISPATCH_PROOF_HEADER]).toBeUndefined();
       expect((node.req as any)[Symbol.for("next.websocket.upgrade-headers-filtered")]).toBe(true);
-      expect(node.req.rawHeaders.map((value: string) => value.toLowerCase())).not.toContain(
-        "x-middleware-set-cookie",
-      );
+      const rawNames = node.req.rawHeaders.map((value: string) => value.toLowerCase());
+      expect(rawNames).not.toContain("x-middleware-set-cookie");
+      expect(rawNames).not.toContain(INTERNAL_DISPATCH_PROOF_HEADER);
       return { upgraded: true, statusCode: 101 };
     });
     const { deps } = dependencies({
@@ -370,11 +372,13 @@ describe("handleWebSocketUpgrade", () => {
     const req = request(undefined, {
       "x-middleware-set-cookie": "forged=attacker; Path=/",
       "x-nextjs-data": "forged",
+      [INTERNAL_DISPATCH_PROOF_HEADER]: "forged",
     });
     // createPoolServer's shared trust boundary performs this normalized-header deletion before
     // handing the request to handleWebSocketUpgrade; keep the direct unit invocation faithful.
     delete req.headers["x-middleware-set-cookie"];
     delete req.headers["x-nextjs-data"];
+    delete req.headers[INTERNAL_DISPATCH_PROOF_HEADER];
     const { socket } = captureSocket();
 
     await expect(handleWebSocketUpgrade(deps, req, socket, Buffer.alloc(0))).resolves.toBe(
@@ -528,7 +532,20 @@ describe("handleWebSocketUpgrade", () => {
       );
       expect(siblingHeaders?.["x-output-id"]).toBe("/rooms/[room]");
       expect(siblingHeaders?.["x-mw-evaluated"]).toBe("ran");
-      expect(siblingHeaders?.["x-internal-secret"]).toBe("internal-secret");
+      expect(siblingHeaders?.["x-internal-secret"]).toBeUndefined();
+      const proof = siblingHeaders?.[INTERNAL_DISPATCH_PROOF_HEADER];
+      expect(typeof proof).toBe("string");
+      expect(
+        verifyDispatchProof(
+          "internal-secret",
+          {
+            method: clientRequest.method,
+            target: clientRequest.url,
+            headers: siblingHeaders ?? {},
+          },
+          proof as string,
+        ),
+      ).toBe(true);
       expect(siblingHeaders?.["x-authenticated-user"]).toBeUndefined();
       expect(siblingHeaders?.["x-mw-request-headers"]).toBe(
         JSON.stringify(Object.fromEntries(middlewareHeaders.entries())),

--- a/tests/pool-server/websocket-upgrade.test.ts
+++ b/tests/pool-server/websocket-upgrade.test.ts
@@ -1,0 +1,306 @@
+import { createServer } from "node:http";
+import { Duplex, PassThrough } from "node:stream";
+import { describe, expect, it, vi } from "vitest";
+import { handleWebSocketUpgrade } from "../../src/pool-server/websocket-upgrade.js";
+
+function captureSocket() {
+  const socket = new PassThrough();
+  const chunks: Buffer[] = [];
+  socket.on("data", (chunk: Buffer) => chunks.push(Buffer.from(chunk)));
+  return {
+    socket,
+    text: () => Buffer.concat(chunks).toString("latin1"),
+  };
+}
+
+class NetworkLikeSocket extends Duplex {
+  readonly writes: Buffer[] = [];
+
+  _read() {}
+
+  _write(chunk: Buffer, _encoding: BufferEncoding, callback: (error?: Error | null) => void) {
+    this.writes.push(Buffer.from(chunk));
+    callback();
+  }
+
+  receive(chunk: Buffer | string) {
+    this.push(chunk);
+  }
+
+  text() {
+    return Buffer.concat(this.writes).toString("latin1");
+  }
+}
+
+function request(url = "/rooms/alpha?existing=1", headers: Record<string, string> = {}) {
+  return {
+    method: "GET",
+    url,
+    headers: {
+      host: "example.com",
+      connection: "Upgrade",
+      upgrade: "websocket",
+      "sec-websocket-key": "dGhlIHNhbXBsZSBub25jZQ==",
+      "sec-websocket-version": "13",
+      ...headers,
+    },
+  } as any;
+}
+
+function dependencies(
+  options: {
+    resolution?: Record<string, unknown>;
+    upgradeHandler?: ((...args: any[]) => unknown) | undefined;
+    runtime?: "nodejs" | "edge";
+    handshakeTimeoutMs?: number;
+  } = {},
+) {
+  const resolution = {
+    kind: "route",
+    pool: "default",
+    matchedPathname: "/rooms/[room]",
+    routeMatches: { room: "alpha" },
+    resolvedHeaders: undefined,
+    ...options.resolution,
+  };
+  const resolve = vi.fn(async () => resolution as any);
+  const handlerLoader = {
+    has: vi.fn(() => true),
+    get: vi.fn(() => ({ runtime: options.runtime ?? "nodejs" })),
+    loadUpgrade: vi.fn(async () => options.upgradeHandler),
+  } as any;
+  return {
+    deps: {
+      resolve,
+      handlerLoader,
+      poolName: "default",
+      releaseName: "app",
+      buildId: "b1",
+      handshakeTimeoutMs: options.handshakeTimeoutMs,
+    } as any,
+    resolve,
+    handlerLoader,
+  };
+}
+
+describe("handleWebSocketUpgrade", () => {
+  it("invokes Next's generated entrypoint once with raw primitives and request metadata", async () => {
+    const upgradeHandler = vi.fn(async () => undefined);
+    const { deps } = dependencies({ upgradeHandler });
+    const req = request(undefined, { "x-forwarded-proto": "https" });
+    const { socket } = captureSocket();
+    const head = Buffer.from("early-frame");
+
+    await expect(handleWebSocketUpgrade(deps, req, socket, head)).resolves.toBe("accepted");
+
+    expect(upgradeHandler).toHaveBeenCalledOnce();
+    const [context, transport] = upgradeHandler.mock.calls[0]!;
+    expect(transport).toEqual({ node: { req, socket, head } });
+    expect(context.requestMeta).toMatchObject({
+      minimalMode: true,
+      outputId: "/rooms/[room]",
+      matchedPathname: "/rooms/[room]",
+      resolvedPathname: "/rooms/alpha",
+      initURL: "https://example.com/rooms/alpha?existing=1",
+      params: { room: "alpha" },
+    });
+    socket.destroy();
+  });
+
+  it("reuses a trusted phase-two verdict and does not execute middleware/routing twice", async () => {
+    const upgradeHandler = vi.fn(async (_context, { node }) => {
+      expect(node.req.headers["x-authenticated-user"]).toBe("david");
+      expect(node.req.headers["x-output-id"]).toBeUndefined();
+      expect(node.req.headers["x-mw-request-headers"]).toBeUndefined();
+    });
+    const { deps, resolve } = dependencies({ upgradeHandler });
+    const req = request("/socket", {
+      "x-output-id": "/rooms/[room]",
+      "x-upstream-pool": "default",
+      "x-route-matches": JSON.stringify({ room: "alpha" }),
+      "x-mw-evaluated": "ran",
+      "x-mw-request-headers": JSON.stringify({
+        host: "example.com",
+        connection: "Upgrade",
+        upgrade: "websocket",
+        "sec-websocket-key": "dGhlIHNhbXBsZSBub25jZQ==",
+        "sec-websocket-version": "13",
+        "x-authenticated-user": "david",
+      }),
+    });
+    const { socket } = captureSocket();
+
+    await expect(handleWebSocketUpgrade(deps, req, socket, Buffer.alloc(0))).resolves.toBe(
+      "accepted",
+    );
+    expect(resolve).not.toHaveBeenCalled();
+    expect(upgradeHandler).toHaveBeenCalledOnce();
+    socket.destroy();
+  });
+
+  it("falls back to local routing when an upstream middleware verdict is incomplete", async () => {
+    const upgradeHandler = vi.fn(async () => undefined);
+    const { deps, resolve } = dependencies({ upgradeHandler });
+    const req = request("/rooms/alpha", {
+      "x-output-id": "/forged",
+      "x-mw-evaluated": "error",
+    });
+    const { socket } = captureSocket();
+
+    await handleWebSocketUpgrade(deps, req, socket, Buffer.alloc(0));
+    expect(resolve).toHaveBeenCalledOnce();
+    expect(req.headers["x-output-id"]).toBeUndefined();
+    socket.destroy();
+  });
+
+  it("flushes 426 for an ordinary HTTP-only route", async () => {
+    const { deps } = dependencies({ upgradeHandler: undefined });
+    const { socket, text } = captureSocket();
+
+    await expect(handleWebSocketUpgrade(deps, request(), socket, Buffer.alloc(0))).resolves.toBe(
+      "rejected",
+    );
+    expect(text()).toContain("HTTP/1.1 426 Upgrade Required");
+    expect(text()).toContain("upgrade: websocket");
+  });
+
+  it("rejects non-WebSocket upgrades before routing", async () => {
+    const upgradeHandler = vi.fn();
+    const { deps, resolve } = dependencies({ upgradeHandler });
+    const req = request();
+    req.headers.upgrade = "h2c";
+    const { socket, text } = captureSocket();
+
+    await handleWebSocketUpgrade(deps, req, socket, Buffer.alloc(0));
+    expect(text()).toContain("HTTP/1.1 426 Upgrade Required");
+    expect(resolve).not.toHaveBeenCalled();
+    expect(upgradeHandler).not.toHaveBeenCalled();
+  });
+
+  it("relays a bounded middleware rejection with cookies but no internal headers", async () => {
+    const headers = new Headers({
+      "content-type": "text/plain",
+      "x-middleware-rewrite": "/private",
+      "x-visible": "yes",
+    });
+    headers.append("set-cookie", "a=1; Path=/");
+    headers.append("set-cookie", "b=2; Path=/");
+    const { deps } = dependencies({
+      resolution: {
+        kind: "middleware-response",
+        response: new Response("denied", { status: 401, headers }),
+      },
+    });
+    const { socket, text } = captureSocket();
+
+    await handleWebSocketUpgrade(deps, request(), socket, Buffer.alloc(0));
+    expect(text()).toContain("HTTP/1.1 401 Unauthorized");
+    expect(text()).toContain("denied");
+    expect(text()).toContain("x-visible: yes");
+    expect(text()).toContain("set-cookie: a=1; Path=/");
+    expect(text()).toContain("set-cookie: b=2; Path=/");
+    expect(text()).not.toContain("x-middleware-rewrite");
+  });
+
+  it("rejects Edge outputs before attempting a raw Node upgrade", async () => {
+    const upgradeHandler = vi.fn();
+    const { deps, handlerLoader } = dependencies({ runtime: "edge", upgradeHandler });
+    const { socket, text } = captureSocket();
+
+    await handleWebSocketUpgrade(deps, request(), socket, Buffer.alloc(0));
+    expect(text()).toContain("HTTP/1.1 501 Not Implemented");
+    expect(handlerLoader.loadUpgrade).not.toHaveBeenCalled();
+  });
+
+  it("tunnels a wrong-pool handshake with asserted headers, repeated cookies, and early data", async () => {
+    let siblingSocket: Duplex | undefined;
+    let siblingHeaders: Record<string, string | string[] | undefined> | undefined;
+    const fromClient: Buffer[] = [];
+    const sibling = createServer();
+    sibling.on("upgrade", (req, socket) => {
+      siblingSocket = socket;
+      siblingHeaders = { ...req.headers };
+      socket.on("data", (chunk) => fromClient.push(Buffer.from(chunk)));
+      socket.write(
+        "HTTP/1.1 101 Switching Protocols\r\nConnection: Upgrade\r\nUpgrade: websocket\r\n" +
+          "Set-Cookie: a=1; Path=/\r\nSet-Cookie: b=2; Path=/\r\n\r\nwelcome",
+      );
+    });
+    await new Promise<void>((resolve) => sibling.listen(0, "127.0.0.1", resolve));
+    const address = sibling.address();
+    if (!address || typeof address === "string") throw new Error("missing test server address");
+
+    const middlewareHeaders = new Headers({
+      host: "example.com",
+      connection: "Upgrade",
+      upgrade: "websocket",
+      "sec-websocket-key": "dGhlIHNhbXBsZSBub25jZQ==",
+      "sec-websocket-version": "13",
+      "x-authenticated-user": "david",
+    });
+    const { deps } = dependencies({
+      resolution: {
+        pool: "chat",
+        middlewareRequestHeaders: middlewareHeaders,
+        invokePath: "/rooms/alpha?joined=1",
+        invocationQuery: { joined: "1" },
+      },
+    });
+    deps.internalSecret = "internal-secret";
+    deps.resolvePoolEndpoint = () => ({ hostname: "127.0.0.1", port: address.port });
+    const socket = new NetworkLikeSocket();
+    const earlyFrame = Buffer.from([0x81, 0x00]);
+
+    try {
+      await expect(handleWebSocketUpgrade(deps, request(), socket, earlyFrame)).resolves.toBe(
+        "accepted",
+      );
+      expect(siblingHeaders?.["x-output-id"]).toBe("/rooms/[room]");
+      expect(siblingHeaders?.["x-mw-evaluated"]).toBe("ran");
+      expect(siblingHeaders?.["x-internal-secret"]).toBe("internal-secret");
+      expect(siblingHeaders?.["x-authenticated-user"]).toBe("david");
+      expect(siblingHeaders?.["x-invoke-query"]).toBe(JSON.stringify({ joined: "1" }));
+      expect(socket.text()).toContain("101 Switching Protocols");
+      expect(socket.text().toLowerCase()).toContain("set-cookie: a=1; path=/");
+      expect(socket.text().toLowerCase()).toContain("set-cookie: b=2; path=/");
+      expect(socket.text()).toContain("welcome");
+
+      socket.receive(Buffer.from("client-frame"));
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      expect(Buffer.concat(fromClient)).toEqual(
+        Buffer.concat([earlyFrame, Buffer.from("client-frame")]),
+      );
+    } finally {
+      socket.destroy();
+      siblingSocket?.destroy();
+      await new Promise<void>((resolve) => sibling.close(() => resolve()));
+    }
+  });
+
+  it("bounds a generated handler that never finishes accepting", async () => {
+    const upgradeHandler = vi.fn(() => new Promise(() => undefined));
+    const { deps } = dependencies({ upgradeHandler, handshakeTimeoutMs: 20 });
+    const { socket } = captureSocket();
+
+    await expect(handleWebSocketUpgrade(deps, request(), socket, Buffer.alloc(0))).rejects.toThrow(
+      /handshake deadline/,
+    );
+    socket.destroy();
+  });
+
+  it("bounds local route resolution before a module is selected", async () => {
+    const { deps, resolve, handlerLoader } = dependencies({ handshakeTimeoutMs: 20 });
+    resolve.mockImplementation(() => new Promise(() => undefined));
+    const { socket, text } = captureSocket();
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    try {
+      await expect(handleWebSocketUpgrade(deps, request(), socket, Buffer.alloc(0))).resolves.toBe(
+        "rejected",
+      );
+      expect(text()).toContain("HTTP/1.1 504 Gateway Timeout");
+      expect(handlerLoader.loadUpgrade).not.toHaveBeenCalled();
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+});

--- a/tests/pool-server/websocket-upgrade.test.ts
+++ b/tests/pool-server/websocket-upgrade.test.ts
@@ -33,17 +33,20 @@ class NetworkLikeSocket extends Duplex {
 }
 
 function request(url = "/rooms/alpha?existing=1", headers: Record<string, string> = {}) {
+  const requestHeaders = {
+    host: "example.com",
+    connection: "Upgrade",
+    upgrade: "websocket",
+    "sec-websocket-key": "dGhlIHNhbXBsZSBub25jZQ==",
+    "sec-websocket-version": "13",
+    ...headers,
+  };
   return {
     method: "GET",
+    httpVersion: "1.1",
     url,
-    headers: {
-      host: "example.com",
-      connection: "Upgrade",
-      upgrade: "websocket",
-      "sec-websocket-key": "dGhlIHNhbXBsZSBub25jZQ==",
-      "sec-websocket-version": "13",
-      ...headers,
-    },
+    headers: requestHeaders,
+    rawHeaders: Object.entries(requestHeaders).flatMap(([name, value]) => [name, value]),
   } as any;
 }
 
@@ -66,7 +69,7 @@ function dependencies(
   const resolve = vi.fn(async () => resolution as any);
   const handlerLoader = {
     has: vi.fn(() => true),
-    get: vi.fn(() => ({ runtime: options.runtime ?? "nodejs" })),
+    get: vi.fn(() => ({ runtime: options.runtime ?? "nodejs", type: "APP_ROUTE" })),
     loadUpgrade: vi.fn(async () => options.upgradeHandler),
   } as any;
   return {
@@ -76,6 +79,11 @@ function dependencies(
       poolName: "default",
       releaseName: "app",
       buildId: "b1",
+      webSocketRegistryScope: {},
+      parseWebSocketExtensions(value: string) {
+        if (value === "permessage-deflate; =") throw new SyntaxError("invalid extension");
+        return {};
+      },
       handshakeTimeoutMs: options.handshakeTimeoutMs,
     } as any,
     resolve,
@@ -85,7 +93,7 @@ function dependencies(
 
 describe("handleWebSocketUpgrade", () => {
   it("invokes Next's generated entrypoint once with raw primitives and request metadata", async () => {
-    const upgradeHandler = vi.fn(async () => undefined);
+    const upgradeHandler = vi.fn(async () => ({ upgraded: true, statusCode: 101 }));
     const { deps } = dependencies({ upgradeHandler });
     const req = request(undefined, { "x-forwarded-proto": "https" });
     const { socket } = captureSocket();
@@ -107,11 +115,48 @@ describe("handleWebSocketUpgrade", () => {
     socket.destroy();
   });
 
+  it("supplies Next's generated lifecycle scope, routing headers, and outcome contract", async () => {
+    const resolvedHeaders = new Headers({ "x-route-header": "present" });
+    resolvedHeaders.append("set-cookie", "route-a=1; Path=/");
+    resolvedHeaders.append("set-cookie", "route-b=2; Path=/");
+    const upgradeHandler = vi.fn(async (context, { node }) => {
+      const metadata = (node.req as any)[Symbol.for("NextInternalRequestMeta")];
+      expect(metadata.webSocketRegistryScope).toBe(deps.webSocketRegistryScope);
+      expect(context.responseHeaders).toEqual({
+        "set-cookie": ["route-a=1; Path=/", "route-b=2; Path=/"],
+        "x-route-header": "present",
+      });
+      return { upgraded: false, statusCode: 401 };
+    });
+    const { deps } = dependencies({
+      upgradeHandler,
+      resolution: { resolvedHeaders },
+    });
+    const { socket } = captureSocket();
+
+    await expect(handleWebSocketUpgrade(deps, request(), socket, Buffer.alloc(0))).resolves.toBe(
+      "rejected",
+    );
+    expect(upgradeHandler).toHaveBeenCalledOnce();
+    socket.destroy();
+  });
+
+  it("fails closed when a generated handler returns a malformed outcome", async () => {
+    const { deps } = dependencies({ upgradeHandler: async () => undefined });
+    const { socket } = captureSocket();
+
+    await expect(handleWebSocketUpgrade(deps, request(), socket, Buffer.alloc(0))).rejects.toThrow(
+      /invalid upgrade outcome/,
+    );
+    socket.destroy();
+  });
+
   it("reuses a trusted phase-two verdict and does not execute middleware/routing twice", async () => {
     const upgradeHandler = vi.fn(async (_context, { node }) => {
       expect(node.req.headers["x-authenticated-user"]).toBe("david");
       expect(node.req.headers["x-output-id"]).toBeUndefined();
       expect(node.req.headers["x-mw-request-headers"]).toBeUndefined();
+      return { upgraded: true, statusCode: 101 };
     });
     const { deps, resolve } = dependencies({ upgradeHandler });
     const req = request("/socket", {
@@ -139,7 +184,7 @@ describe("handleWebSocketUpgrade", () => {
   });
 
   it("falls back to local routing when an upstream middleware verdict is incomplete", async () => {
-    const upgradeHandler = vi.fn(async () => undefined);
+    const upgradeHandler = vi.fn(async () => ({ upgraded: true, statusCode: 101 }));
     const { deps, resolve } = dependencies({ upgradeHandler });
     const req = request("/rooms/alpha", {
       "x-output-id": "/forged",
@@ -153,22 +198,40 @@ describe("handleWebSocketUpgrade", () => {
     socket.destroy();
   });
 
-  it("flushes 426 for an ordinary HTTP-only route", async () => {
+  it("falls back to local routing when trusted dispatch metadata is malformed", async () => {
+    const upgradeHandler = vi.fn(async () => ({ upgraded: true, statusCode: 101 }));
+    const { deps, resolve } = dependencies({ upgradeHandler });
+    const req = request("/rooms/alpha", {
+      "x-output-id": "/rooms/[room]",
+      "x-mw-evaluated": "ran",
+      "x-mw-request-headers": JSON.stringify({ authorization: [123] }),
+    });
+    const { socket } = captureSocket();
+
+    await expect(handleWebSocketUpgrade(deps, req, socket, Buffer.alloc(0))).resolves.toBe(
+      "accepted",
+    );
+    expect(resolve).toHaveBeenCalledOnce();
+    expect(req.headers["x-mw-request-headers"]).toBeUndefined();
+    socket.destroy();
+  });
+
+  it("returns 404 when an App Route has no generated upgrade entrypoint", async () => {
     const { deps } = dependencies({ upgradeHandler: undefined });
     const { socket, text } = captureSocket();
 
     await expect(handleWebSocketUpgrade(deps, request(), socket, Buffer.alloc(0))).resolves.toBe(
       "rejected",
     );
-    expect(text()).toContain("HTTP/1.1 426 Upgrade Required");
-    expect(text()).toContain("upgrade: websocket");
+    expect(text()).toContain("HTTP/1.1 404 Not Found");
+    expect(text()).toContain("Not Found");
+    expect(text()).toContain("cache-control: private, no-cache, no-store");
   });
 
   it("rejects non-WebSocket upgrades before routing", async () => {
     const upgradeHandler = vi.fn();
     const { deps, resolve } = dependencies({ upgradeHandler });
-    const req = request();
-    req.headers.upgrade = "h2c";
+    const req = request(undefined, { upgrade: "h2c" });
     const { socket, text } = captureSocket();
 
     await handleWebSocketUpgrade(deps, req, socket, Buffer.alloc(0));
@@ -176,6 +239,124 @@ describe("handleWebSocketUpgrade", () => {
     expect(resolve).not.toHaveBeenCalled();
     expect(upgradeHandler).not.toHaveBeenCalled();
   });
+
+  it("rejects malformed handshake fields before middleware or route resolution", async () => {
+    for (const [headers, status, message] of [
+      [{ "sec-websocket-key": "invalid" }, 400, "Invalid Sec-WebSocket-Key header."],
+      [{ "sec-websocket-version": "12" }, 426, "Unsupported WebSocket version."],
+      [{ "sec-websocket-protocol": "chat, chat" }, 400, "Invalid Sec-WebSocket-Protocol header."],
+      [
+        { "sec-websocket-extensions": "permessage-deflate; =" },
+        400,
+        "Invalid Sec-WebSocket-Extensions header.",
+      ],
+    ] as const) {
+      const { deps, resolve } = dependencies({
+        upgradeHandler: async () => ({ upgraded: true, statusCode: 101 }),
+      });
+      const { socket, text } = captureSocket();
+
+      await handleWebSocketUpgrade(deps, request(undefined, headers), socket, Buffer.alloc(0));
+
+      expect(text()).toContain(`HTTP/1.1 ${status}`);
+      expect(text()).toContain(message);
+      expect(resolve).not.toHaveBeenCalled();
+    }
+  });
+
+  it("enforces same-origin and configured cross-origin policy before routing", async () => {
+    const denied = dependencies({
+      upgradeHandler: async () => ({ upgraded: true, statusCode: 101 }),
+    });
+    const deniedSocket = captureSocket();
+    await handleWebSocketUpgrade(
+      denied.deps,
+      request(undefined, { origin: "https://attacker.example" }),
+      deniedSocket.socket,
+      Buffer.alloc(0),
+    );
+    expect(deniedSocket.text()).toContain("HTTP/1.1 403 Forbidden");
+    expect(deniedSocket.text()).toContain("WebSocket origin is not allowed.");
+    expect(denied.resolve).not.toHaveBeenCalled();
+
+    const accepted = dependencies({
+      upgradeHandler: async () => ({ upgraded: true, statusCode: 101 }),
+    });
+    accepted.deps.webSocketAllowedOrigins = ["https://client.example"];
+    const acceptedSocket = captureSocket();
+    await expect(
+      handleWebSocketUpgrade(
+        accepted.deps,
+        request(undefined, { origin: "https://client.example" }),
+        acceptedSocket.socket,
+        Buffer.alloc(0),
+      ),
+    ).resolves.toBe("accepted");
+    expect(accepted.resolve).toHaveBeenCalledOnce();
+    acceptedSocket.socket.destroy();
+  });
+
+  it("preserves only framework-authored middleware cookies into the generated request", async () => {
+    const middlewareRequestHeaders = new Headers({
+      host: "example.com",
+      connection: "Upgrade",
+      upgrade: "websocket",
+      "sec-websocket-key": "dGhlIHNhbXBsZSBub25jZQ==",
+      "sec-websocket-version": "13",
+      "x-middleware-set-cookie": "proxy-cookie=present; Path=/",
+    });
+    const upgradeHandler = vi.fn(async (_context, { node }) => {
+      expect(node.req.headers["x-middleware-set-cookie"]).toBe("proxy-cookie=present; Path=/");
+      expect(node.req.headers["x-nextjs-data"]).toBeUndefined();
+      expect((node.req as any)[Symbol.for("next.websocket.upgrade-headers-filtered")]).toBe(true);
+      expect(node.req.rawHeaders.map((value: string) => value.toLowerCase())).not.toContain(
+        "x-middleware-set-cookie",
+      );
+      return { upgraded: true, statusCode: 101 };
+    });
+    const { deps } = dependencies({
+      upgradeHandler,
+      resolution: { middlewareRequestHeaders },
+    });
+    const req = request(undefined, {
+      "x-middleware-set-cookie": "forged=attacker; Path=/",
+      "x-nextjs-data": "forged",
+    });
+    // createPoolServer's shared trust boundary performs this normalized-header deletion before
+    // handing the request to handleWebSocketUpgrade; keep the direct unit invocation faithful.
+    delete req.headers["x-middleware-set-cookie"];
+    delete req.headers["x-nextjs-data"];
+    const { socket } = captureSocket();
+
+    await expect(handleWebSocketUpgrade(deps, req, socket, Buffer.alloc(0))).resolves.toBe(
+      "accepted",
+    );
+    expect(upgradeHandler).toHaveBeenCalledOnce();
+    socket.destroy();
+  });
+
+  it.each(["content-length", "transfer-encoding", "expect", "trailer"])(
+    "rejects the ambiguous %s framing header before routing",
+    async (name) => {
+      const { deps, resolve, handlerLoader } = dependencies({
+        upgradeHandler: async () => ({ upgraded: true, statusCode: 101 }),
+      });
+      const { socket, text } = captureSocket();
+
+      await expect(
+        handleWebSocketUpgrade(
+          deps,
+          request(undefined, { [name]: name === "content-length" ? "0" : "present" }),
+          socket,
+          Buffer.alloc(0),
+        ),
+      ).resolves.toBe("rejected");
+      expect(text()).toContain("HTTP/1.1 400 Bad Request");
+      expect(text()).toContain("WebSocket upgrade requests cannot include HTTP body framing.");
+      expect(resolve).not.toHaveBeenCalled();
+      expect(handlerLoader.loadUpgrade).not.toHaveBeenCalled();
+    },
+  );
 
   it("relays a bounded middleware rejection with cookies but no internal headers", async () => {
     const headers = new Headers({
@@ -202,13 +383,42 @@ describe("handleWebSocketUpgrade", () => {
     expect(text()).not.toContain("x-middleware-rewrite");
   });
 
-  it("rejects Edge outputs before attempting a raw Node upgrade", async () => {
+  it("fails closed with Next's external-rewrite response instead of dialing the target", async () => {
+    const { deps } = dependencies({
+      resolution: { kind: "external-rewrite", url: new URL("http://127.0.0.1:9/socket") },
+    });
+    const { socket, text } = captureSocket();
+
+    await handleWebSocketUpgrade(deps, request(), socket, Buffer.alloc(0));
+
+    expect(text()).toContain("HTTP/1.1 501 Not Implemented");
+    expect(text()).toContain(
+      "External WebSocket rewrite targets are not proxied while webSocketRouteHandlers is enabled.",
+    );
+  });
+
+  it("returns 404 for a non-App-Route output", async () => {
+    const { deps, handlerLoader } = dependencies({
+      upgradeHandler: async () => ({ upgraded: true, statusCode: 101 }),
+    });
+    handlerLoader.get.mockReturnValue({ runtime: "nodejs", type: "APP_PAGE" });
+    const { socket, text } = captureSocket();
+
+    await handleWebSocketUpgrade(deps, request(), socket, Buffer.alloc(0));
+
+    expect(text()).toContain("HTTP/1.1 404 Not Found");
+    expect(text()).toContain("Not Found");
+    expect(handlerLoader.loadUpgrade).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 for Edge outputs before attempting a raw Node upgrade", async () => {
     const upgradeHandler = vi.fn();
     const { deps, handlerLoader } = dependencies({ runtime: "edge", upgradeHandler });
     const { socket, text } = captureSocket();
 
     await handleWebSocketUpgrade(deps, request(), socket, Buffer.alloc(0));
-    expect(text()).toContain("HTTP/1.1 501 Not Implemented");
+    expect(text()).toContain("HTTP/1.1 404 Not Found");
+    expect(text()).toContain("Not Found");
     expect(handlerLoader.loadUpgrade).not.toHaveBeenCalled();
   });
 
@@ -232,16 +442,22 @@ describe("handleWebSocketUpgrade", () => {
 
     const middlewareHeaders = new Headers({
       host: "example.com",
-      connection: "Upgrade",
+      connection: "keep-alive, Upgrade, x-remove-on-hop",
+      "keep-alive": "timeout=5",
+      "proxy-authorization": "Basic must-not-cross",
       upgrade: "websocket",
       "sec-websocket-key": "dGhlIHNhbXBsZSBub25jZQ==",
       "sec-websocket-version": "13",
       "x-authenticated-user": "david",
+      "x-remove-on-hop": "private",
     });
+    const resolvedHeaders = new Headers({ "x-route-header": "present" });
+    resolvedHeaders.append("set-cookie", "route=1; Path=/");
     const { deps } = dependencies({
       resolution: {
         pool: "chat",
         middlewareRequestHeaders: middlewareHeaders,
+        resolvedHeaders,
         invokePath: "/rooms/alpha?joined=1",
         invocationQuery: { joined: "1" },
       },
@@ -250,16 +466,31 @@ describe("handleWebSocketUpgrade", () => {
     deps.resolvePoolEndpoint = () => ({ hostname: "127.0.0.1", port: address.port });
     const socket = new NetworkLikeSocket();
     const earlyFrame = Buffer.from([0x81, 0x00]);
+    const clientRequest = request(undefined, {
+      connection: "keep-alive, Upgrade, x-remove-on-hop",
+      "keep-alive": "timeout=5",
+      "proxy-authorization": "Basic must-not-cross",
+      "x-remove-on-hop": "private",
+    });
 
     try {
-      await expect(handleWebSocketUpgrade(deps, request(), socket, earlyFrame)).resolves.toBe(
+      await expect(handleWebSocketUpgrade(deps, clientRequest, socket, earlyFrame)).resolves.toBe(
         "accepted",
       );
       expect(siblingHeaders?.["x-output-id"]).toBe("/rooms/[room]");
       expect(siblingHeaders?.["x-mw-evaluated"]).toBe("ran");
       expect(siblingHeaders?.["x-internal-secret"]).toBe("internal-secret");
-      expect(siblingHeaders?.["x-authenticated-user"]).toBe("david");
+      expect(siblingHeaders?.["x-authenticated-user"]).toBeUndefined();
+      expect(siblingHeaders?.["x-mw-request-headers"]).toBe(
+        JSON.stringify(Object.fromEntries(middlewareHeaders.entries())),
+      );
       expect(siblingHeaders?.["x-invoke-query"]).toBe(JSON.stringify({ joined: "1" }));
+      expect(siblingHeaders?.["x-resolved-headers"]).toBe(
+        JSON.stringify({ "x-route-header": "present", "set-cookie": ["route=1; Path=/"] }),
+      );
+      expect(siblingHeaders?.["keep-alive"]).toBeUndefined();
+      expect(siblingHeaders?.["proxy-authorization"]).toBeUndefined();
+      expect(siblingHeaders?.["x-remove-on-hop"]).toBeUndefined();
       expect(socket.text()).toContain("101 Switching Protocols");
       expect(socket.text().toLowerCase()).toContain("set-cookie: a=1; path=/");
       expect(socket.text().toLowerCase()).toContain("set-cookie: b=2; path=/");
@@ -286,6 +517,35 @@ describe("handleWebSocketUpgrade", () => {
       /handshake deadline/,
     );
     socket.destroy();
+  });
+
+  it("bounds and cancels a middleware rejection body that never produces bytes", async () => {
+    let cancelled = false;
+    const body = new ReadableStream<Uint8Array>({
+      pull: () => new Promise(() => undefined),
+      cancel() {
+        cancelled = true;
+      },
+    });
+    const { deps } = dependencies({
+      handshakeTimeoutMs: 20,
+      resolution: {
+        kind: "middleware-response",
+        response: new Response(body, { status: 401 }),
+      },
+    });
+    const { socket } = captureSocket();
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    try {
+      await expect(handleWebSocketUpgrade(deps, request(), socket, Buffer.alloc(0))).resolves.toBe(
+        "rejected",
+      );
+      expect(cancelled).toBe(true);
+      expect(socket.destroyed).toBe(true);
+    } finally {
+      errorSpy.mockRestore();
+    }
   });
 
   it("bounds local route resolution before a module is selected", async () => {


### PR DESCRIPTION
## What

This is a newer implementation of #2 for the adapter's current pool-server and routing architecture.

- consume Next's generated Node.js `upgradeHandler(ctx, { node: { req, socket, head } })` entrypoint, matching the adapter-facing contract used by adapter-vercel
- route WebSocket handshakes through trusted extension dispatch or fail-safe local resolution, with middleware and rewrites evaluated exactly once
- tunnel a handshake to its owning pool when route classification selects a different pool
- share the imported route module between HTTP and WebSocket entrypoints so module initialization and route-wide state are not duplicated
- track upgraded sockets through bounded pod shutdown and send close code `1001` before forced teardown
- document the compatible experimental `NextResponse.upgrade()` route shape and deployment boundaries

## Why

#2 proved the direction, but it predates the current routing protocol, request trust boundary, multi-pool dispatcher, deployment lifecycle, and target-composition work. Its fixture also supplied a handwritten `upgradeHandler`, so it could pass without proving that Next generated the adapter entrypoint.

This implementation leaves the public API and WebSocket runtime in Next. The adapter owns only the persistent Node transport, routing, cross-pool handoff, and lifecycle around the generated entrypoint.

## How

The pool server handles Node's separate HTTP `upgrade` event and passes the original `req`, `socket`, and `head` objects to the generated route export.

Before proxy.ts or route code can execute, the adapter validates the HTTP/1.1 WebSocket handshake, framing, subprotocol syntax, the exact extension grammar from the application's pinned `next/dist/compiled/ws`, and same-origin/configured-origin policy. Client-supplied Next and adapter routing headers are removed from normalized, distinct, and raw header views. Framework-authored middleware cookies are preserved after that boundary.

Secret-authenticated phase-two routing is reused only when complete and well-formed. Missing, malformed, or untrusted state triggers full local resolution, preserving the middleware fail-safe invariant. Cross-pool forwarding strips hop-by-hop and Connection-nominated fields, carries middleware request replacements and routing response headers in authenticated dispatch metadata, preserves repeated `Set-Cookie`, forwards early `head` bytes, and propagates the existing absolute deadline.

Only generated Node App Route entrypoints can claim an upgrade. Missing, Pages/App Page, Edge, and HTTP-only outputs return Next-compatible `404 Not Found`. External rewrites fail closed with Next's `501` response instead of creating an SSRF bypass. Generated handler outcomes are validated before the socket is marked accepted.

Ordinary HTTP requests still use the normal dispatcher. When a route returns `NextResponse.upgrade()` over HTTP, the generated sanitized `426 Upgrade Required` response remains authoritative: routing headers cannot reintroduce Connection, framing, cache, or private fields after Next removes them.

## Stack

This PR is now rebased directly onto the current `main`; the merged release/GitOps line (#43, #44, #46, and #48) is no longer part of its diff. It is the base of the remaining draft stack:

1. #47 — generated WebSocket upgrade dispatch
2. #49 — generic Envoy streaming timeout parity
3. #50 — protocol-aware pool shutdown
4. #51 — real-Envoy rollout conformance
5. #53 — Turbopack production filesystem cache
6. #54 — direct shared static-content staging

## Deployment lifecycle follow-up

The portable lifecycle concerns found during this review are implemented in #49, #50, and #51. GKE `GCPBackendPolicy.connectionDraining` remains provider-specific and out of scope for this stack. Neither platform can transfer an established socket to another pod; seamless continuity still requires client reconnection plus application-owned resume state.

## Testing

- `npm run build`
- `npm test` - 2,895 passed, 19 skipped
- `npx tsc --noEmit`
- `npm run lint`
- `npm run fmt:check`
- `git diff --check`
- focused WebSocket/response-boundary coverage - 54 passed

The focused tests cover generated top-level and CJS-wrapped exports, lifecycle registry scope, generated outcome validation, trusted routing reuse, malformed-metadata fallback, pre-routing handshake and origin rejection, middleware-cookie provenance, private-header filtering, App Route ownership, exact 404/501 responses, bounded rejection bodies, cross-pool metadata/header/early-data transport, and handshake deadlines.

### Upstream compatibility run

I also ran the first functional describe from Next's current WebSocket Route Handler stack at commit `6251af8e240844bdd8419b50176d41d86b64f3ab` through the deploy adapter: 16 passed, 2 failed, 5 skipped.

Every WebSocket transport contract reached by the adapter passed, including generated handler execution, rejection serialization, malformed-handshake ordering, origin policy, non-Node ownership, forged internal-header filtering, middleware cookies, protocols, rewrites, dynamic behavior, external-rewrite refusal, redirects, request-store lifetime, HTTP 426 sanitization, and Edge behavior.

The two remaining failures are existing harness/parity work outside this transport:

- the ordinary HTTP App Route rewrite baseline exposes a rewrite-added query value (`from=proxy`) that `next start` hides; the test stops at that HTTP assertion before comparing the WebSocket result
- the deploy harness does not append live pool logs to `next.cliOutput`; the expected detached-hook report is present exactly once in the captured server log

This was a compatibility run, not an unmodified upstream pass. The Next branch currently rejects every `adapterPath` when WebSocket Route Handlers are enabled and does not yet expose the adapter capability named by that error, so the local external checkout used a narrow guard bypass. Immutable assets were disabled for this run because file-installing that branch retained the published 16.2.3 SWC package beside Next 16.3.1-canary.10.

## Draft status

Keep this as a draft. The adapter side is implemented and exercised with the real generated entrypoint, but it should not be marked ready until Next exposes the adapter capability/contract, the branch runs without a core guard bypass, and the remaining integration baseline is reconciled.

