### PR TITLE
Preserve streamed responses through Envoy

### DIFF
--- a/docs/targets.md
+++ b/docs/targets.md
@@ -198,6 +198,13 @@ target: defineTarget({
 
 - **Gateway class** must be controlled by `gateway.envoyproxy.io/gatewayclass-controller`—`deploy` verifies the extension policy reports `Accepted=True` before cutting traffic. A non-Envoy class would program the Gateway and then silently never call the routing service.
 - **Verified Envoy Gateway range: >=1.5.4 <1.9.** The adapter's full surface (ext_proc, ClientTrafficPolicy, deploy gates, cutover, rollback) is live-verified on Envoy Gateway v1.5.4, v1.5.5, and v1.8.3 — identical manifests Accepted on all, no adapter-visible behavior change between 1.5.5 and 1.8.3 (1.6/1.7 are untested but inside the range). `deploy` and `doctor` print a soft warning (never a failure) when the detected controller image is outside this range.
+- **Streaming timeout parity:** generated application rules set `timeouts.request: 0s`. Envoy's
+  default is a 15-second whole-response deadline, which is inappropriate for Route Handler
+  streams, RSC, and SSE because it expires even while a response is making progress. Disabling
+  that total deadline does not make dead requests immortal: the pool still bounds time to response
+  headers and route `maxDuration`, and Envoy retains its stream-idle timeout. Applications using
+  SSE should send periodic comment heartbeats frequently enough for their operator's gateway/CDN
+  idle timeout.
 - **Upgrading Envoy Gateway 1.5.x → 1.8.x in place: apply the CRDs first.** `helm upgrade` never touches the chart's `crds/` subchart, and Envoy Gateway ≥ 1.8 unconditionally watches `ListenerSet` — so an in-place upgrade crashloops the new controller with `no matches for kind "ListenerSet" in version "gateway.networking.k8s.io/v1"`. Server-side-apply the chart's CRD bundle **before** upgrading the controller (verified live: applied over live CRDs with no data loss, traffic served throughout):
 
   ```bash

--- a/src/emit/templates/gateway.ts
+++ b/src/emit/templates/gateway.ts
@@ -108,6 +108,7 @@ export function renderHTTPRoute({
   pools,
   routingManifest,
   cdnFilterName,
+  disableRequestTimeout = false,
 }: {
   releaseName: string;
   hosts: HostConfig[];
@@ -115,6 +116,17 @@ export function renderHTTPRoute({
   routingManifest: RoutingManifest;
   /** Name of a GCPHTTPFilter to attach to every rule (enables Cloud CDN). */
   cdnFilterName?: string | undefined;
+  /**
+   * Disable the Gateway's whole-response deadline on application rules. Envoy's default route
+   * timeout is 15 seconds and remains armed until the COMPLETE response arrives, which truncates
+   * SSE, RSC and other streamed responses even while bytes are flowing. The pool independently
+   * bounds time-to-headers and route maxDuration; Envoy's stream-idle timeout remains the
+   * progress/dead-peer bound after this total deadline is disabled.
+   *
+   * Provider-specific on purpose: the generic Envoy provider opts in, while GKE keeps its
+   * provider-owned backend timeout behavior and does not receive an unsupported semantic change.
+   */
+  disableRequestTimeout?: boolean;
 }): string {
   assertSafeReleaseName(releaseName);
   for (const host of hosts) assertSafeHostname(host.hostname);
@@ -146,6 +158,16 @@ export function renderHTTPRoute({
     : "";
   const hostnames = hosts.map((h) => h.hostname);
   const defaultPoolName = [...pools.keys()][0] ?? "default";
+  // Gateway API defines 0s as "disabled". Keep this literal provider-owned rather than exposing
+  // an arbitrary Duration string that would need a second injection-sensitive config surface.
+  const requestTimeoutYaml = disableRequestTimeout
+    ? `
+      # Envoy defaults a route to a 15s WHOLE-response timeout. Next Route Handlers may return
+      # long-lived Response streams (notably text/event-stream), so keep only progress/idle and
+      # pool-owned execution bounds instead of truncating a healthy stream at a wall-clock limit.
+      timeouts:
+        request: 0s`
+    : "";
 
   // Phase 1: simple path-based routing.
   // We MUST stay under 16 rules for Gateway API.
@@ -246,7 +268,7 @@ export function renderHTTPRoute({
               # N61: QUOTED. An unquoted pool name like "on"/"no"/"y"/"off"/"true"/"123"
               # renders a YAML boolean/int here; "helm template" accepts it and the
               # apiserver then rejects the chart (HTTPHeaderMatch.value is a string).
-              value: "${poolName}"
+              value: "${poolName}"${requestTimeoutYaml}
       backendRefs:
         - name: ${backendName}
           port: 3000${filtersYaml}`;
@@ -267,6 +289,7 @@ export function renderHTTPRoute({
     const backendName = sanitizeK8sName(`${releaseName}-${rule.poolName}`);
     return `    - matches:
         - path: { type: ${rule.matchType}, value: "${encodeGatewayPath(rule.path)}" }
+${requestTimeoutYaml}
       backendRefs:
         - name: ${backendName}
           port: 3000${filtersYaml}`;
@@ -276,6 +299,7 @@ export function renderHTTPRoute({
     const backendName = sanitizeK8sName(`${releaseName}-${catchAllRule.poolName}`);
     return `    - matches:
         - path: { type: ${catchAllRule.matchType}, value: "${encodeGatewayPath(catchAllRule.path)}" }
+${requestTimeoutYaml}
       backendRefs:
         - name: ${backendName}
           port: 3000${filtersYaml}`;

--- a/src/providers/generic.ts
+++ b/src/providers/generic.ts
@@ -65,6 +65,11 @@ export const genericProvider: ProviderAdapter = {
       hosts,
       pools,
       routingManifest,
+      // Envoy otherwise applies its 15s route timeout until the COMPLETE response arrives. That
+      // silently truncates SSE/RSC/Route Handler streams even though the pool correctly forwards
+      // response headers and chunks as they arrive. 0s disables only the total deadline; Envoy's
+      // stream-idle timeout and the pool's response-head/maxDuration budgets remain in force.
+      disableRequestTimeout: true,
     });
 
     return files;

--- a/tests/emit/generic-chart.test.ts
+++ b/tests/emit/generic-chart.test.ts
@@ -128,6 +128,18 @@ describe("generic gateway listeners under merged gateways", () => {
 });
 
 describe("generic provider — complete chart", () => {
+  it("disables Envoy's whole-response timeout on every application rule", () => {
+    const route = genericChart()["templates/http-route.yaml"]!;
+    const ruleCount = (route.match(/- matches:/g) ?? []).length;
+    const disabledTimeoutCount = (route.match(/request: 0s/g) ?? []).length;
+
+    // Envoy's 15s route default waits for the COMPLETE response and therefore truncates SSE and
+    // other healthy streams. Each generated application rule must carry the override: omitting it
+    // on only the catch-all/header fast path makes behavior depend on which route won at the edge.
+    expect(ruleCount).toBeGreaterThan(0);
+    expect(disabledTimeoutCount).toBe(ruleCount);
+  });
+
   it("emits the ext_proc routing tier even with no GCP infrastructure", () => {
     // The routing tier IS the adapter's middleware story. Emitting a chart without it means
     // every request silently falls back to pool-local middleware — the app still serves, so

--- a/tests/emit/templates/gateway.test.ts
+++ b/tests/emit/templates/gateway.test.ts
@@ -130,6 +130,20 @@ describe("renderHTTPRoute rule cap", () => {
 });
 
 describe("renderHTTPRoute CDN filter injection", () => {
+  it("leaves provider timeout behavior untouched unless explicitly disabled", () => {
+    const common = {
+      releaseName: "nextjs",
+      hosts,
+      pools: makePools(2),
+      routingManifest: makeManifest({ "/dashboard/page": "pool1" }),
+    };
+    expect(renderHTTPRoute(common)).not.toContain("request: 0s");
+
+    const portable = renderHTTPRoute({ ...common, disableRequestTimeout: true });
+    const ruleCount = (portable.match(/- matches:/g) ?? []).length;
+    expect((portable.match(/request: 0s/g) ?? []).length).toBe(ruleCount);
+  });
+
   it("attaches the ExtensionRef filter to every rule when cdnFilterName is set", () => {
     const pools = makePools(2);
     const yaml = renderHTTPRoute({


### PR DESCRIPTION
## What

- set `timeouts.request: 0s` on every application rule emitted for the generic Envoy Gateway target
- keep the timeout behavior provider-owned: GKE output is unchanged
- cover path, internal pool-header, and catch-all rules in the template and generated-chart tests
- document the remaining idle-progress and application execution bounds

## Why

Envoy applies a 15-second total route timeout by default. That deadline remains active until the entire response completes, so healthy Next.js Route Handler streams, RSC, and SSE can be truncated even while bytes are flowing.

Gateway API defines `0s` as disabled. The generic target should remove that whole-response deadline and retain the separate bounds that match the actual failure modes: pool time-to-headers and route `maxDuration`, plus Envoy's stream-idle timeout.

## How

`renderHTTPRoute` accepts a provider-owned `disableRequestTimeout` switch. The generic provider opts in and the template injects the literal timeout into every generated application rule. The literal is deliberately not exposed as arbitrary user configuration, avoiding another duration-validation and YAML-injection surface.

## Stack

1. #47 — generated WebSocket upgrade dispatch
2. this PR — portable streaming timeout parity
3. #50 — protocol-aware pool shutdown
4. #51 — real-Envoy rollout conformance and lifecycle docs

This PR remains draft while #47 is draft.

## Scope

This changes only the generic Envoy Gateway target. It does not add or change GKE `GCPBackendPolicy`/connection-draining configuration; that provider-specific concern remains explicitly out of scope, as noted on #47.

## Testing

- focused gateway/chart tests: 85 passed
- stack-head `npm test`: 2,901 passed, 20 skipped
- `npx tsc --noEmit`
- `npm run lint`
- `npm run fmt:check`
- `npm run build`
- `git diff --check`
