### PR TITLE
Drain pool protocols without truncating streams

### DIFF
--- a/src/pool-server/index.ts
+++ b/src/pool-server/index.ts
@@ -3859,7 +3859,11 @@ export async function startPoolServer(): Promise<ReturnType<typeof createPoolSer
   let shuttingDown = false;
   const SHUTDOWN_GRACE_MS = Math.max(
     100,
-    parseInt(process.env.ADAPTER_K8S_SHUTDOWN_GRACE_MS ?? "", 10) || 15_000,
+    // deployment.ts gives the process 90s after the 120s preStop inside the 210s pod grace.
+    // Spend 60s on application work and retain 30s for close-frame flushing, runtime cleanup,
+    // kubelet scheduling delay, and the hard-exit cushion. The old 15s budget then cut HTTP/SSE
+    // streams at its halfway mark (7.5s), despite the pod already reserving far more time.
+    parseInt(process.env.ADAPTER_K8S_SHUTDOWN_GRACE_MS ?? "", 10) || 60_000,
   );
   const shutdown = async () => {
     if (shuttingDown) return;
@@ -3878,8 +3882,8 @@ export async function startPoolServer(): Promise<ReturnType<typeof createPoolSer
       process.exit(0);
     }, SHUTDOWN_GRACE_MS + 1_000);
     hardExit.unref?.();
-    // Drops idle keep-alive sockets at once, tears down anything still streaming at the halfway
-    // mark, swallows the "already closing" rejection, and always settles — see server.stop().
+    // Drops idle keep-alive sockets at once, lets finite responses use the whole budget, then
+    // closes SSE/WebSockets protocol-appropriately and always settles — see server.stop().
     await server.stop({ graceMs: SHUTDOWN_GRACE_MS });
     clearTimeout(hardExit);
     process.exit(0);

--- a/src/pool-server/server.ts
+++ b/src/pool-server/server.ts
@@ -285,11 +285,19 @@ interface ActiveResponseState {
   terminalAction?: "end-sse" | "force-close";
 }
 
+/**
+ * One drain outcome per tracked response, and one per tracked socket. The HTTP categories
+ * (completed, clientClosed, sseEnded, sseForced, httpForceClosed) are mutually exclusive and never
+ * sum past httpAtStart — an operator reading the single "drain complete" line after an incident has
+ * to be able to add them up, so a response that receives an SSE EOF and is then destroyed because
+ * the EOF never flushed must land in exactly one of them (sseForced), not in two.
+ */
 interface DrainMetrics {
   httpAtStart: number;
   httpCompleted: number;
   httpClientClosed: number;
   sseEnded: number;
+  sseForced: number;
   httpForceClosed: number;
   webSocketsAtStart: number;
   webSocketsPeerClosed: number;
@@ -438,7 +446,16 @@ export function createPoolServer(options: PoolServerOptions) {
       if (responseState.settled) return;
       responseState.settled = true;
       activeResponses.delete(res);
-      if (!drainMetrics || responseState.terminalAction) return;
+      if (!drainMetrics) return;
+      // Adapter-initiated terminal actions are counted where they are initiated — except the SSE
+      // EOF, whose outcome is only known once the response settles. Counting it here keeps a
+      // stream that flushed (sseEnded) apart from one still queued when the flush window expired,
+      // which the terminal phase counts as sseForced after flipping terminalAction.
+      if (responseState.terminalAction === "end-sse") {
+        drainMetrics.sseEnded += 1;
+        return;
+      }
+      if (responseState.terminalAction) return;
       if (finished || res.writableFinished) drainMetrics.httpCompleted += 1;
       else drainMetrics.httpClientClosed += 1;
     };
@@ -535,6 +552,10 @@ export function createPoolServer(options: PoolServerOptions) {
           const state = upgradedSockets.get(socket);
           if (state && disposition === "accepted") state.accepted = true;
           if (disposition === "rejected" && !socket.destroyed && !socket.writableEnded) {
+            // The SERVER is ending this handshake. Without the flag a rejection that lands after
+            // drain begins is reported as webSocketsPeerClosed — a voluntary peer departure the
+            // peer never made — because the close listener treats every unsignalled close as one.
+            if (state) state.serverSignalled = true;
             socket.end();
           }
         })
@@ -619,6 +640,7 @@ export function createPoolServer(options: PoolServerOptions) {
           httpCompleted: 0,
           httpClientClosed: 0,
           sseEnded: 0,
+          sseForced: 0,
           httpForceClosed: 0,
           webSocketsAtStart: upgradedSockets.size,
           webSocketsPeerClosed: 0,
@@ -653,7 +675,9 @@ export function createPoolServer(options: PoolServerOptions) {
           if (res.writableEnded || res.destroyed) continue;
           if (state.eventStream) {
             state.terminalAction = "end-sse";
-            drainMetrics.sseEnded += 1;
+            // Counted on settle (sseEnded) or in the final destroy loop (sseForced), not here: a
+            // client that is not reading leaves this EOF queued past the flush window, and the
+            // same stream must not be reported as both cleanly ended and force-closed.
             // Do not invent an SSE data/control event: event IDs and replay semantics belong to
             // the application. A clean HTTP EOF is sufficient for EventSource to reconnect.
             res.end();
@@ -704,8 +728,13 @@ export function createPoolServer(options: PoolServerOptions) {
         for (const [res, state] of activeResponses) {
           if (!res.destroyed) {
             if (state.terminalAction !== "force-close") {
+              // An SSE EOF still queued here never reached the client, so it belongs in its own
+              // category rather than in httpForced on top of the sseEnded it would otherwise also
+              // be credited with. Flipping terminalAction first keeps settleResponse from
+              // counting the destroy that follows a second time.
+              if (state.terminalAction === "end-sse") drainMetrics.sseForced += 1;
+              else drainMetrics.httpForceClosed += 1;
               state.terminalAction = "force-close";
-              drainMetrics.httpForceClosed += 1;
             }
             res.destroy();
           }
@@ -720,7 +749,7 @@ export function createPoolServer(options: PoolServerOptions) {
           `[pool-server] drain complete in ${elapsedMs}ms: ` +
             `http=${drainMetrics.httpAtStart} completed=${drainMetrics.httpCompleted} ` +
             `clientClosed=${drainMetrics.httpClientClosed} sseEnded=${drainMetrics.sseEnded} ` +
-            `httpForced=${drainMetrics.httpForceClosed}; ` +
+            `sseForced=${drainMetrics.sseForced} httpForced=${drainMetrics.httpForceClosed}; ` +
             `webSockets=${drainMetrics.webSocketsAtStart} ` +
             `peerClosed=${drainMetrics.webSocketsPeerClosed} ` +
             `signalled=${drainMetrics.webSocketsSignalled} ` +

--- a/src/pool-server/server.ts
+++ b/src/pool-server/server.ts
@@ -278,6 +278,59 @@ export interface PoolServerOptions {
   poolName?: string;
 }
 
+interface ActiveResponseState {
+  settled: boolean;
+  eventStream: boolean;
+  /** Terminal action initiated by the adapter, rather than the handler or peer. */
+  terminalAction?: "end-sse" | "force-close";
+}
+
+interface DrainMetrics {
+  httpAtStart: number;
+  httpCompleted: number;
+  httpClientClosed: number;
+  sseEnded: number;
+  httpForceClosed: number;
+  webSocketsAtStart: number;
+  webSocketsPeerClosed: number;
+  webSocketsSignalled: number;
+  webSocketsForceClosed: number;
+}
+
+function isEventStreamContentType(value: unknown): boolean {
+  const contentType = Array.isArray(value) ? value.join(",") : String(value ?? "");
+  return /^\s*text\/event-stream(?:\s*;|\s*$)/i.test(contentType);
+}
+
+/** Read one header from any of Node's writeHead header argument shapes. */
+function writeHeadHeaderValue(args: unknown[], wantedName: string): unknown {
+  const headers = args[typeof args[0] === "string" ? 1 : 0];
+  if (Array.isArray(headers)) {
+    if (headers.length > 0 && Array.isArray(headers[0])) {
+      const tuple = (headers as Array<[unknown, unknown]>).find(
+        ([name]) => String(name).toLowerCase() === wantedName,
+      );
+      return tuple?.[1];
+    }
+    for (let index = 0; index + 1 < headers.length; index += 2) {
+      if (String(headers[index]).toLowerCase() === wantedName) return headers[index + 1];
+    }
+    return undefined;
+  }
+  if (headers && typeof headers === "object") {
+    const key = Object.keys(headers).find((name) => name.toLowerCase() === wantedName);
+    return key === undefined ? undefined : (headers as Record<string, unknown>)[key];
+  }
+  return undefined;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise<void>((resolve) => {
+    const timer = setTimeout(resolve, Math.max(1, ms));
+    timer.unref?.();
+  });
+}
+
 export function createPoolServer(options: PoolServerOptions) {
   const {
     onRequest,
@@ -298,6 +351,17 @@ export function createPoolServer(options: PoolServerOptions) {
   // client. Log it once per transition; the probe consumer (kubelet, HealthCheckPolicy,
   // cutover gate) reads only the status code.
   let lastLoggedNotReady: string | undefined;
+
+  // N88. HTTP responses and protocol upgrades have different ownership in Node. Ordinary
+  // responses stay attached to the HTTP server; upgraded sockets do not. Track both explicitly so
+  // shutdown can let finite responses complete, end SSE with a reconnectable EOF, and close a
+  // WebSocket with RFC 6455 code 1001 instead of applying one blunt socket operation to all three.
+  const activeResponses = new Map<ServerResponse, ActiveResponseState>();
+  const upgradedSockets = new Map<Duplex, { accepted: boolean; serverSignalled: boolean }>();
+  let draining = false;
+  let drainMetrics: DrainMetrics | undefined;
+  let stopPromise: Promise<void> | undefined;
+
   const server: Server = createServer(async (req, res) => {
     // Probes bypass all routing — unless the app itself owns the pathname (see appOwnsProbePath).
     // The pathname is parsed rather than compared to the raw target so `/healthz?x=1` is still a
@@ -312,7 +376,9 @@ export function createPoolServer(options: PoolServerOptions) {
         res.end(JSON.stringify({ status: "ok" }));
         return;
       }
-      const state = readiness?.() ?? { ready: false, reason: "readiness state not wired" };
+      const state = draining
+        ? { ready: false, reason: "shutting down" }
+        : (readiness?.() ?? { ready: false, reason: "readiness state not wired" });
       if (!state.ready && state.reason !== lastLoggedNotReady) {
         lastLoggedNotReady = state.reason;
         console.warn(`[pool-server] /readyz unavailable: ${state.reason}`);
@@ -328,11 +394,56 @@ export function createPoolServer(options: PoolServerOptions) {
       return;
     }
 
+    // server.close() stops NEW TCP connections, but an already-established HTTP/1.1 connection
+    // can pipeline another request across the signal boundary. Refuse that new unit of work while
+    // allowing the response already in flight on the same connection to finish.
+    if (draining) {
+      res.writeHead(503, {
+        "content-type": "text/plain",
+        "cache-control": "no-store",
+        connection: "close",
+        "retry-after": "1",
+      });
+      res.end("Service Unavailable");
+      return;
+    }
+
     applyRequestTrustBoundary(req, res, {
       internalSecret,
       trustInternalHeaders,
       proofHeaderNames,
     });
+
+    const responseState: ActiveResponseState = { settled: false, eventStream: false };
+    activeResponses.set(res, responseState);
+    // ServerResponse.getHeader() no longer exposes committed headers on every supported Node
+    // version. Capture Content-Type at the public mutation boundary so the terminal drain phase
+    // does not need private `_header` parsing or unreliable heuristics based on the pathname.
+    const originalSetHeader = res.setHeader.bind(res);
+    res.setHeader = ((name: string, value: number | string | readonly string[]) => {
+      if (name.toLowerCase() === "content-type") {
+        responseState.eventStream = isEventStreamContentType(value);
+      }
+      return originalSetHeader(name, value);
+    }) as ServerResponse["setHeader"];
+    const originalTrackedWriteHead = res.writeHead.bind(res);
+    (res as any).writeHead = function (statusCode: number, ...args: unknown[]) {
+      const contentType = writeHeadHeaderValue(args, "content-type");
+      if (contentType !== undefined) {
+        responseState.eventStream = isEventStreamContentType(contentType);
+      }
+      return originalTrackedWriteHead(statusCode, ...(args as [never]));
+    };
+    const settleResponse = (finished: boolean) => {
+      if (responseState.settled) return;
+      responseState.settled = true;
+      activeResponses.delete(res);
+      if (!drainMetrics || responseState.terminalAction) return;
+      if (finished || res.writableFinished) drainMetrics.httpCompleted += 1;
+      else drainMetrics.httpClientClosed += 1;
+    };
+    res.once("finish", () => settleResponse(true));
+    res.once("close", () => settleResponse(false));
 
     const start = performance.now();
     const method = metricHttpMethod(req.method);
@@ -393,8 +504,6 @@ export function createPoolServer(options: PoolServerOptions) {
   // Node removes upgraded connections from ordinary HTTP connection management. Keep explicit
   // ownership so a rollout has a bounded, protocol-aware shutdown instead of either leaking the
   // process until SIGKILL or dropping every connection without a close frame.
-  const upgradedSockets = new Map<Duplex, { accepted: boolean }>();
-  let draining = false;
   if (onUpgrade) {
     server.on("upgrade", (req, socket, head) => {
       if (draining) {
@@ -409,8 +518,14 @@ export function createPoolServer(options: PoolServerOptions) {
         trustInternalHeaders,
         proofHeaderNames,
       });
-      upgradedSockets.set(socket, { accepted: false });
-      socket.once("close", () => upgradedSockets.delete(socket));
+      const socketState = { accepted: false, serverSignalled: false };
+      upgradedSockets.set(socket, socketState);
+      socket.once("close", () => {
+        upgradedSockets.delete(socket);
+        if (drainMetrics && !socketState.serverSignalled) {
+          drainMetrics.webSocketsPeerClosed += 1;
+        }
+      });
       // Client resets are normal for long-lived connections and must never become an uncaught
       // EventEmitter error that terminates the whole pool.
       socket.on("error", () => undefined);
@@ -484,62 +599,136 @@ export function createPoolServer(options: PoolServerOptions) {
      * client leaves". `process.exit(0)` after it was therefore unreachable, so every rollout
      * waited out `terminationGracePeriodSeconds` and died to SIGKILL instead.
      *
-     * This form always settles: stop accepting, drop idle keep-alive sockets immediately, and at
-     * the halfway mark tear down whatever is still streaming so `close()` can complete. Errors
-     * are swallowed — "already closing" and "never started" are the only outcomes, and neither
-     * should stop a caller from exiting.
+     * This form always settles: stop accepting, drop idle keep-alive sockets immediately, let
+     * active responses use the COMPLETE grace window, then close each surviving protocol
+     * honestly. SSE receives a normal EOF (EventSource can reconnect); an incomplete finite body
+     * is reset rather than pretending truncated bytes are complete; established WebSockets get
+     * RFC 6455 code 1001 before forced teardown. Errors are swallowed — "already closing" and
+     * "never started" are the only outcomes, and neither should stop a caller from exiting.
      */
     async stop(options: { graceMs?: number } = {}): Promise<void> {
-      const graceMs = Math.max(1, options.graceMs ?? 15_000);
-      draining = true;
-      const closed = new Promise<void>((resolve) => server.close(() => resolve()));
-      // An idle keep-alive socket alone is enough to keep close() pending forever.
-      server.closeIdleConnections?.();
-      const forceClose = setTimeout(() => server.closeAllConnections?.(), Math.floor(graceMs / 2));
-      forceClose.unref?.();
-      const deadline = Date.now() + graceMs;
-      while (upgradedSockets.size > 0 && Date.now() < deadline) {
-        await new Promise<void>((resolve) => {
-          const t = setTimeout(resolve, Math.min(100, Math.max(1, deadline - Date.now())));
-          t.unref?.();
-        });
-      }
+      if (stopPromise) return stopPromise;
 
-      if (upgradedSockets.size > 0) {
-        // RFC 6455 close code 1001: endpoint is going away (rollout, rollback, HPA scale-down).
-        // Pending handshakes are still HTTP, so only established sockets receive a WS frame.
-        const goingAway = Buffer.from([0x88, 0x02, 0x03, 0xe9]);
-        for (const [socket, state] of upgradedSockets) {
-          try {
-            if (!socket.destroyed) {
-              if (state.accepted) socket.write(goingAway);
-              else socket.end();
-            }
-          } catch {
-            // The peer disappeared between the set iteration and the write.
+      stopPromise = (async () => {
+        const graceMs = Math.max(1, options.graceMs ?? 60_000);
+        const startedAt = Date.now();
+        const deadline = startedAt + graceMs;
+        draining = true;
+        drainMetrics = {
+          httpAtStart: activeResponses.size,
+          httpCompleted: 0,
+          httpClientClosed: 0,
+          sseEnded: 0,
+          httpForceClosed: 0,
+          webSocketsAtStart: upgradedSockets.size,
+          webSocketsPeerClosed: 0,
+          webSocketsSignalled: 0,
+          webSocketsForceClosed: 0,
+        };
+
+        let serverClosed = false;
+        const closed = new Promise<void>((resolve) => {
+          // Ignore ERR_SERVER_NOT_RUNNING: stop() is deliberately settle-always and idempotent.
+          server.close(() => {
+            serverClosed = true;
+            resolve();
+          });
+        });
+        // An idle keep-alive socket alone is enough to keep close() pending forever, and carries no
+        // in-flight work worth preserving.
+        server.closeIdleConnections?.();
+
+        // Wait for every tracked protocol to leave voluntarily. Polling is deliberate and bounded:
+        // finish/close can race each other and Node offers no single event spanning HTTP responses,
+        // half-read requests, and upgraded sockets.
+        while (Date.now() < deadline) {
+          if (activeResponses.size === 0 && upgradedSockets.size === 0 && serverClosed) break;
+          await delay(Math.min(25, Math.max(1, deadline - Date.now())));
+        }
+
+        // The deadline belongs to application work, so no finite response is cut at an arbitrary
+        // halfway point. Only survivors reach this protocol-aware terminal phase.
+        let terminalFlushRequired = false;
+        for (const [res, state] of activeResponses) {
+          if (res.writableEnded || res.destroyed) continue;
+          if (state.eventStream) {
+            state.terminalAction = "end-sse";
+            drainMetrics.sseEnded += 1;
+            // Do not invent an SSE data/control event: event IDs and replay semantics belong to
+            // the application. A clean HTTP EOF is sufficient for EventSource to reconnect.
+            res.end();
+            terminalFlushRequired = true;
+          } else {
+            state.terminalAction = "force-close";
+            drainMetrics.httpForceClosed += 1;
+            // A normal end would falsely authenticate a partial finite body as complete.
+            res.destroy();
           }
         }
-        // Give the close frame a short opportunity to flush, while remaining inside the caller's
-        // already-bounded signal path.
-        await new Promise<void>((resolve) => {
-          const t = setTimeout(resolve, Math.min(250, Math.max(1, graceMs)));
-          t.unref?.();
-        });
-        for (const socket of upgradedSockets.keys()) {
-          if (!socket.destroyed) socket.destroy();
-        }
-      }
 
-      // Last resort for ordinary HTTP: even closeAllConnections can be defeated by platform/Node
-      // behavior, so never wait past the same bound after explicitly closing upgraded sockets.
-      await Promise.race([
-        closed,
-        new Promise<void>((resolve) => {
-          const t = setTimeout(resolve, Math.max(1, deadline - Date.now()));
-          t.unref?.();
-        }),
-      ]);
-      clearTimeout(forceClose);
+        if (upgradedSockets.size > 0) {
+          // RFC 6455 close code 1001: endpoint is going away (rollout, rollback, HPA scale-down).
+          // Pending handshakes are still HTTP, so only established sockets receive a WS frame.
+          const goingAway = Buffer.from([0x88, 0x02, 0x03, 0xe9]);
+          for (const [socket, state] of upgradedSockets) {
+            try {
+              if (!socket.destroyed) {
+                state.serverSignalled = true;
+                if (state.accepted) {
+                  drainMetrics.webSocketsSignalled += 1;
+                  socket.write(goingAway);
+                } else {
+                  socket.end();
+                }
+                terminalFlushRequired = true;
+              }
+            } catch {
+              // The peer disappeared between the set iteration and the write.
+            }
+          }
+        }
+
+        // The process signal path has a one-second hard-exit cushion. Spend at most 250ms of it
+        // flushing SSE EOF / WebSocket close frames, then make termination deterministic.
+        // server.close() does not own upgraded sockets and may resolve while their close frames
+        // are still queued. Give terminal protocol bytes their own bounded flush window instead
+        // of racing that unrelated callback (a fast callback otherwise wins with a 0ms flush).
+        if (terminalFlushRequired) await delay(Math.min(250, graceMs));
+        for (const [socket, state] of upgradedSockets) {
+          if (!socket.destroyed) {
+            state.serverSignalled = true;
+            drainMetrics.webSocketsForceClosed += 1;
+            socket.destroy();
+          }
+        }
+        for (const [res, state] of activeResponses) {
+          if (!res.destroyed) {
+            if (state.terminalAction !== "force-close") {
+              state.terminalAction = "force-close";
+              drainMetrics.httpForceClosed += 1;
+            }
+            res.destroy();
+          }
+        }
+        // Catches a connection still receiving headers and therefore not yet represented by a
+        // ServerResponse. Node intentionally excludes upgraded sockets; those were handled above.
+        server.closeAllConnections?.();
+        await Promise.race([closed, delay(250)]);
+
+        const elapsedMs = Date.now() - startedAt;
+        console.log(
+          `[pool-server] drain complete in ${elapsedMs}ms: ` +
+            `http=${drainMetrics.httpAtStart} completed=${drainMetrics.httpCompleted} ` +
+            `clientClosed=${drainMetrics.httpClientClosed} sseEnded=${drainMetrics.sseEnded} ` +
+            `httpForced=${drainMetrics.httpForceClosed}; ` +
+            `webSockets=${drainMetrics.webSocketsAtStart} ` +
+            `peerClosed=${drainMetrics.webSocketsPeerClosed} ` +
+            `signalled=${drainMetrics.webSocketsSignalled} ` +
+            `wsForced=${drainMetrics.webSocketsForceClosed}`,
+        );
+      })();
+
+      return stopPromise;
     },
 
     get server() {

--- a/tests/pool-server/server-shutdown.test.ts
+++ b/tests/pool-server/server-shutdown.test.ts
@@ -10,7 +10,7 @@
 //     waited out `terminationGracePeriodSeconds` and died to SIGKILL.
 // `stop()` is the settle-always form the signal handler now uses. Real sockets throughout: the
 // bug only exists at the socket layer, so a mock could not have caught it.
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, afterEach, vi } from "vitest";
 import net from "node:net";
 import { get as httpGet, type IncomingMessage, type ServerResponse } from "node:http";
 import { createPoolServer } from "../../src/pool-server/server.js";
@@ -23,7 +23,28 @@ afterEach(async () => {
     await pool.stop({ graceMs: 200 });
     pool = null;
   }
+  vi.restoreAllMocks();
 });
+
+/**
+ * The single "drain complete" line is the whole post-incident record of a rollout, so its counts
+ * are asserted as parsed numbers rather than as a substring match.
+ */
+function captureDrainLog(): () => Record<string, number> {
+  const lines: string[] = [];
+  vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+    lines.push(args.map(String).join(" "));
+  });
+  return () => {
+    const line = lines.find((value) => value.includes("drain complete"));
+    if (!line) throw new Error(`no drain-complete log line in: ${JSON.stringify(lines)}`);
+    const counts: Record<string, number> = {};
+    for (const [, key, value] of line.matchAll(/([A-Za-z]+)=(\d+)/g)) {
+      counts[key] = Number(value);
+    }
+    return counts;
+  };
+}
 
 describe("createPoolServer().stop()", () => {
   it("tracks upgraded sockets and closes them with WebSocket 1001 after the grace window", async () => {
@@ -272,6 +293,102 @@ describe("createPoolServer().stop()", () => {
     expect(received).toContain("503 Service Unavailable");
     expect(received.toLowerCase()).toContain("retry-after: 1");
     socket.destroy();
+    pool = null;
+  });
+
+  it("counts an SSE stream whose EOF never flushed once, not as both sseEnded and httpForced", async () => {
+    // A client that stops reading closes its TCP receive window, so the drain's res.end() sits in
+    // the socket buffer past the 250ms flush window and the response is still active when the
+    // final destroy loop runs. That loop used to credit the same stream to httpForced on top of
+    // the sseEnded it already had, so the categories summed to 2 for a single response.
+    // Tracked through the public writable contract rather than a sleep: `drain` firing would mean
+    // the buffers absorbed everything, and the wait below then fails loudly instead of asserting
+    // the fixed counts against a response that actually flushed.
+    let backpressured = false;
+    pool = createPoolServer({
+      onRequest: (_req: IncomingMessage, res: ServerResponse) => {
+        res.writeHead(200, { "content-type": "text/event-stream" });
+        res.flushHeaders();
+        res.on("drain", () => (backpressured = false));
+        // Enough volume that no loopback socket buffer can swallow the whole body — the writes
+        // that do not fit stay queued in userland for as long as the client refuses to read.
+        const chunk = `: ${"x".repeat(256 * 1024)}\n\n`;
+        for (let index = 0; index < 96; index += 1) {
+          if (!res.write(chunk)) backpressured = true;
+        }
+      },
+      port: 0,
+    });
+    const { port } = await pool.start();
+
+    const socket = net.createConnection({ host: "127.0.0.1", port });
+    await new Promise<void>((resolve) => socket.once("connect", resolve));
+    socket.write("GET /events HTTP/1.1\r\nHost: localhost\r\n\r\n");
+    // Never read: no 'data' listener and no resume(), so the receive window fills and stays shut.
+    socket.pause();
+    while (!backpressured) await new Promise<void>((resolve) => setTimeout(resolve, 10));
+
+    const readDrainLog = captureDrainLog();
+    await pool.stop({ graceMs: 120 });
+    const counts = readDrainLog();
+
+    expect(counts.http).toBe(1);
+    expect(counts.sseForced).toBe(1);
+    expect(counts.sseEnded).toBe(0);
+    expect(counts.httpForced).toBe(0);
+    expect(
+      counts.completed +
+        counts.clientClosed +
+        counts.sseEnded +
+        counts.sseForced +
+        counts.httpForced,
+    ).toBe(counts.http);
+    socket.destroy();
+    pool = null;
+  });
+
+  it("does not report a server-rejected upgrade as a voluntary peer close", async () => {
+    let releaseUpgrade!: (disposition: "accepted" | "rejected") => void;
+    const disposition = new Promise<"accepted" | "rejected">((resolve) => {
+      releaseUpgrade = resolve;
+    });
+    let upgradeEntered!: () => void;
+    const entered = new Promise<void>((resolve) => (upgradeEntered = resolve));
+    pool = createPoolServer({
+      onRequest: () => undefined,
+      onUpgrade: () => {
+        upgradeEntered();
+        return disposition;
+      },
+      port: 0,
+    });
+    const { port } = await pool.start();
+
+    const socket = net.createConnection({ host: "127.0.0.1", port });
+    socket.on("data", () => undefined);
+    socket.on("error", () => undefined);
+    const clientClosed = new Promise<void>((resolve) => socket.once("close", () => resolve()));
+    await new Promise<void>((resolve) => socket.once("connect", resolve));
+    socket.write(
+      "GET /socket HTTP/1.1\r\nHost: localhost\r\nConnection: Upgrade\r\n" +
+        "Upgrade: websocket\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n" +
+        "Sec-WebSocket-Version: 13\r\n\r\n",
+    );
+    await entered;
+
+    const readDrainLog = captureDrainLog();
+    const drain = pool.stop({ graceMs: 400 });
+    // Resolve the handshake DURING the drain wait loop: the rejection's socket.end() is the only
+    // server-initiated close that runs before the terminal WebSocket phase, and it used to leave
+    // serverSignalled false so the close listener booked it as peerClosed.
+    await new Promise<void>((resolve) => setTimeout(resolve, 50));
+    releaseUpgrade("rejected");
+    await clientClosed;
+    await drain;
+    const counts = readDrainLog();
+
+    expect(counts.webSockets).toBe(1);
+    expect(counts.peerClosed).toBe(0);
     pool = null;
   });
 

--- a/tests/pool-server/server-shutdown.test.ts
+++ b/tests/pool-server/server-shutdown.test.ts
@@ -12,7 +12,7 @@
 // bug only exists at the socket layer, so a mock could not have caught it.
 import { describe, it, expect, afterEach } from "vitest";
 import net from "node:net";
-import type { IncomingMessage, ServerResponse } from "node:http";
+import { get as httpGet, type IncomingMessage, type ServerResponse } from "node:http";
 import { createPoolServer } from "../../src/pool-server/server.js";
 import { INTERNAL_DISPATCH_PROOF_HEADER } from "../../src/routing-common.js";
 import { signDispatch } from "../helpers/dispatch-proof.js";
@@ -130,33 +130,147 @@ describe("createPoolServer().stop()", () => {
     pool = null;
   });
 
-  it("settles while a response is actively streaming, and tears the stream down", async () => {
-    let clientSawBytes = 0;
+  it("lets a finite stream finish after the old halfway cutoff", async () => {
     pool = createPoolServer({
       onRequest: (_req: IncomingMessage, res: ServerResponse) => {
         res.writeHead(200, { "content-type": "text/plain" });
         res.flushHeaders();
-        // Never ends on its own — the SSE-shaped case.
-        const timer = setInterval(() => res.write("tick\n"), 20);
+        res.write("first\n");
+        // With graceMs=500 the former halfway close fired at 250ms and truncated this response.
+        setTimeout(() => res.end("last\n"), 350);
+      },
+      port: 0,
+    });
+    const { port } = await pool.start();
+
+    let responseStarted!: () => void;
+    const started = new Promise<void>((resolve) => (responseStarted = resolve));
+    const body = new Promise<string>((resolve, reject) => {
+      httpGet({ host: "127.0.0.1", port, path: "/finite" }, (res) => {
+        let value = "";
+        responseStarted();
+        res.on("data", (chunk) => (value += String(chunk)));
+        res.on("end", () => resolve(value));
+        res.on("aborted", () => reject(new Error("finite response aborted")));
+        res.on("error", reject);
+      }).on("error", reject);
+    });
+    await started;
+
+    const drain = pool.stop({ graceMs: 500 });
+    await expect(body).resolves.toBe("first\nlast\n");
+    await drain;
+    pool = null;
+  });
+
+  it("keeps SSE open for the full grace window, then ends it cleanly", async () => {
+    pool = createPoolServer({
+      onRequest: (_req: IncomingMessage, res: ServerResponse) => {
+        res.writeHead(200, { "content-type": "text/event-stream; charset=utf-8" });
+        res.flushHeaders();
+        const timer = setInterval(() => res.write(": heartbeat\n\n"), 20);
         res.on("close", () => clearInterval(timer));
       },
       port: 0,
     });
     const { port } = await pool.start();
 
-    const socket = net.createConnection({ host: "127.0.0.1", port });
-    await new Promise<void>((resolve) => socket.on("connect", () => resolve()));
-    socket.write("GET /stream HTTP/1.1\r\nHost: localhost\r\n\r\n");
-    socket.on("data", (chunk) => {
-      clientSawBytes += chunk.length;
+    let responseStarted!: () => void;
+    const started = new Promise<void>((resolve) => (responseStarted = resolve));
+    let clientSawBytes = 0;
+    const ended = new Promise<void>((resolve, reject) => {
+      httpGet({ host: "127.0.0.1", port, path: "/events" }, (res) => {
+        responseStarted();
+        res.on("data", (chunk) => (clientSawBytes += chunk.length));
+        res.on("end", resolve);
+        res.on("aborted", () => reject(new Error("SSE response aborted")));
+        res.on("error", reject);
+      }).on("error", reject);
     });
-    await new Promise((resolve) => setTimeout(resolve, 120));
-    expect(clientSawBytes).toBeGreaterThan(0);
+    await started;
 
-    const started = Date.now();
-    await pool.stop({ graceMs: 400 });
-    // Settled, and well inside the grace window rather than hanging on the open stream.
-    expect(Date.now() - started).toBeLessThan(2_000);
+    const drainStartedAt = Date.now();
+    const drain = pool.stop({ graceMs: 300 });
+    await ended;
+    expect(Date.now() - drainStartedAt).toBeGreaterThanOrEqual(260);
+    expect(clientSawBytes).toBeGreaterThan(0);
+    await drain;
+    pool = null;
+  });
+
+  it("resets an unfinished finite body at the deadline instead of authenticating truncation", async () => {
+    pool = createPoolServer({
+      onRequest: (_req: IncomingMessage, res: ServerResponse) => {
+        res.writeHead(200, { "content-type": "application/octet-stream" });
+        res.write("partial-body");
+        // Never finishes: a normal res.end() during drain would make the client accept these bytes
+        // as the complete representation even though the handler promised more.
+      },
+      port: 0,
+    });
+    const { port } = await pool.start();
+
+    let responseStarted!: () => void;
+    const started = new Promise<void>((resolve) => (responseStarted = resolve));
+    const aborted = new Promise<boolean>((resolve, reject) => {
+      httpGet({ host: "127.0.0.1", port, path: "/finite-never-ends" }, (res) => {
+        responseStarted();
+        res.on("data", () => undefined);
+        res.on("aborted", () => resolve(true));
+        res.on("end", () => resolve(false));
+        res.on("error", (error) => {
+          if ((error as NodeJS.ErrnoException).code === "ECONNRESET") resolve(true);
+          else reject(error);
+        });
+      }).on("error", reject);
+    });
+    await started;
+
+    const drainStartedAt = Date.now();
+    const drain = pool.stop({ graceMs: 180 });
+    await expect(aborted).resolves.toBe(true);
+    expect(Date.now() - drainStartedAt).toBeGreaterThanOrEqual(150);
+    await drain;
+    pool = null;
+  });
+
+  it("rejects pipelined work that arrives on an existing connection after drain starts", async () => {
+    let firstResponse!: ServerResponse;
+    let firstStarted!: () => void;
+    const started = new Promise<void>((resolve) => (firstStarted = resolve));
+    let requestCount = 0;
+    pool = createPoolServer({
+      onRequest: (_req: IncomingMessage, res: ServerResponse) => {
+        requestCount += 1;
+        if (requestCount === 1) {
+          firstResponse = res;
+          res.writeHead(200, { "content-type": "text/plain" });
+          res.write("first");
+          firstStarted();
+          return;
+        }
+        res.end("application handled second request");
+      },
+      port: 0,
+    });
+    const { port } = await pool.start();
+
+    const socket = net.createConnection({ host: "127.0.0.1", port });
+    let received = "";
+    socket.on("data", (chunk) => (received += chunk.toString("latin1")));
+    await new Promise<void>((resolve) => socket.once("connect", resolve));
+    socket.write("GET /one HTTP/1.1\r\nHost: localhost\r\n\r\n");
+    await started;
+
+    const drain = pool.stop({ graceMs: 250 });
+    socket.write("GET /two HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
+    firstResponse.end();
+    await new Promise<void>((resolve) => socket.once("close", () => resolve()));
+    await drain;
+
+    expect(requestCount).toBe(1);
+    expect(received).toContain("503 Service Unavailable");
+    expect(received.toLowerCase()).toContain("retry-after: 1");
     socket.destroy();
     pool = null;
   });


### PR DESCRIPTION
## What

- track active HTTP responses and upgraded WebSocket sockets separately
- make draining readiness fail immediately and reject new keep-alive/pipelined work after SIGTERM
- let finite responses use the complete 60-second application grace window
- end surviving SSE responses with a clean EOF, reset incomplete finite bodies, and signal established WebSockets with close code `1001`
- make shutdown bounded and idempotent, with structured protocol outcome counters

## Why

An established connection cannot be transferred to a replacement pod. The adapter can still preserve honest protocol semantics during a rollout: finish finite work when possible, give reconnecting protocols an explicit boundary, and never make truncated bytes look like a complete response.

The prior shutdown path used a single socket-level strategy and an early cutoff. It could truncate a finite stream halfway through its advertised grace, could not distinguish SSE from a finite body, and Node's upgraded sockets require separate ownership from ordinary HTTP responses.

## How

The pool records response lifecycle state using Node's public `setHeader`/`writeHead` surfaces and recognizes `text/event-stream` without private header parsing. On drain it closes the listener and idle connections, then waits for active HTTP and WebSocket work for the full grace period.

At the deadline:

- SSE gets `res.end()` without a fabricated event, allowing standard reconnect behavior
- an incomplete finite response is destroyed/reset instead of falsely completing
- an established WebSocket gets RFC 6455 close code `1001`, with a dedicated bounded flush window before forced teardown

The SIGTERM default becomes 60 seconds. Together with the chart's existing 120-second `preStop` and 210-second pod termination grace, this leaves a 30-second hard-exit cushion.

## Stack

1. #47 — generated WebSocket upgrade dispatch
2. #49 — generic Envoy total-timeout parity
3. this PR — protocol-aware pool shutdown
4. #51 — real-Envoy rollout conformance and lifecycle docs

This PR remains draft while its stack bases are draft.

## Boundaries

The adapter supplies a graceful reconnect boundary, not connection migration or application replay. SSE IDs/history, WebSocket resume cursors, shared pub/sub, idempotency, and recovery from abrupt node/process loss remain application responsibilities. No GKE load-balancer policy is added here.

## Testing

- focused pool server/shutdown tests: 36 passed
- stack-head `npm test`: 2,901 passed, 20 skipped
- `npx tsc --noEmit`
- `npm run lint`
- `npm run fmt:check`
- `npm run build`
- `git diff --check`
