### PR TITLE
Verify portable rollout continuity

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,9 +285,13 @@ Current boundaries are deliberate:
   pub/sub when messages must span pods.
 - Connections are not durable across deploys, rollbacks, HPA scale-down, node replacement, or load
   balancer maintenance. Clients must reconnect, and should use a keepalive appropriate for their
-  ingress/load-balancer timeout.
+  ingress/load-balancer timeout. State continuity needs an application cursor/session token and
+  shared replay/pub-sub; a live connection cannot be transferred between pods.
 - During shutdown the pod stops accepting upgrades, gives established sockets the configured
   bounded shutdown window, sends close code `1001` (going away), and then force-closes survivors.
+
+The same rollout contract covers finite response streams and SSE, including clean SSE EOF and
+`Last-Event-ID` replay guidance. See [deploy lifecycle](./docs/lifecycle.md#long-lived-requests-during-cutover).
 
 Treat this as an experimental compatibility surface until the Next.js API and its upstream e2e
 suite are published. Exposure components supplied by an operator must preserve HTTP/1.1 WebSocket

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -20,6 +20,42 @@ Each deploy creates a new versioned Deployment alongside the previous one. Traff
 
 `/readyz` is the pod's own verdict: it answers 503 until instrumentation registration has succeeded and at least one route module has imported. The selector value comes from the same sanitizer that stamps the pod label—a mismatch would drain the Service to zero endpoints, which is why both sides derive from one function.
 
+### Long-lived requests during cutover
+
+A cutover changes where **new** connections go; it cannot move a live TCP connection or an
+in-memory handler from one pod to another. Existing connections remain on the previous pod while,
+after the selector change has propagated through the data plane, new connections select the new
+build. The previous pod first receives Kubernetes' `preStop` window, then SIGTERM; on SIGTERM it
+stops readiness and new work, closes idle keep-alives, and gives active protocols a 60-second
+drain window. The pod's 210-second termination grace leaves a 30-second cushion after the
+120-second `preStop` and application drain phases.
+
+The terminal behavior is protocol-specific:
+
+- A finite HTTP/RSC stream may use the full application drain window. If it still has not
+  completed, the adapter resets it; ending it normally would make a truncated representation look
+  complete. The client must retry requests for which that is safe.
+- An SSE response may use the full window, then receives a clean EOF so `EventSource` can
+  reconnect. Durable continuity remains an application contract: send `id:` fields, resume from
+  `Last-Event-ID`, keep replayable events in shared storage, and emit comment heartbeats more
+  frequently than every proxy/CDN idle timeout. The adapter does not fabricate events or migrate
+  process memory.
+- An established WebSocket may use the full window, then receives close code `1001` (going away)
+  before bounded forced teardown. Clients should reconnect with jittered backoff and send an
+  application cursor/session token when missed state matters. Cross-pod topics and replay require
+  shared pub/sub or storage; socket state itself is not transferable.
+
+For the generic Envoy target, generated application rules disable Envoy's 15-second total route
+deadline with `timeouts.request: 0s`; the gateway's stream-idle timeout still detects a connection
+that stops making progress. Other exposure layers supplied by an operator need equivalent
+streaming and WebSocket behavior. Provider-specific GKE backend draining/timeout policy is not
+changed by this portable contract.
+
+This is graceful degradation, not an exactly-once guarantee. An involuntary node loss, process
+crash, exhausted grace period, or abrupt load-balancer reset can still break a connection without
+EOF/1001. Application-level IDs, idempotency, replay, and reconnect logic are what make those
+failures recoverable.
+
 ## Rollback
 
 `npx adapter-k8s rollback` returns to the previous build: pools scale back up, the routing tier reverts to that build's image and manifest snapshot, and the Service selectors patch back. It is symmetric—running it again rolls forward. Deploys resolve images by digest; the routing tier's rollback path currently reconstructs its image reference from the build tag (digest-pinned rollback is on the [roadmap](../README.md#roadmap)).

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -109,9 +109,16 @@ The specific behaviors the architecture exists to get right, each confirmed agai
   remaining PPR resume-data consistency case.
 - **Performance is unverified.** No load testing, no throughput tuning, no published benchmarks. This is the "operational hardening" the README's status refers to.
 - **The generic provider is younger** than the GKE one and has correspondingly less real-world exposure, though it passes the same unit suite and its live verification covered the full request path.
+- **Portable rollout continuity is data-plane tested, not yet cluster-rollout verified.** A
+  Docker-gated suite runs real Envoy in front of an old/new pool selector. It differentially
+  verifies disabled total route timeouts, an old-build finite stream completing through cutover,
+  SSE ending cleanly and resuming from `Last-Event-ID` on the new build, and WebSocket `1001`
+  followed by a new-build reconnect. It does not replace a live Kubernetes EndpointSlice,
+  controller, or involuntary node-loss test.
 - **WebSocket Route Handlers are transport-tested, not yet framework-e2e verified.** The pool has
   real-socket coverage for generated `upgradeHandler` dispatch, trusted and local routing,
-  cross-pool tunnelling, repeated handshake headers, and bounded shutdown. The public
+  cross-pool tunnelling, repeated handshake headers, bounded shutdown, and the portable rollout
+  path above. The public
   `NextResponse.upgrade()` API and its upstream e2e fixture are still experimental/unpublished;
   that suite must pass against the exact Next branch before this support is called framework
   verified.

--- a/skills/deploy/SKILL.md
+++ b/skills/deploy/SKILL.md
@@ -61,6 +61,17 @@ npx adapter-k8s tail              # color-coded logs from all workloads
 
 Any gate failure prints `Traffic was NOT switched — the previous build's pools are still serving`, restores the edge, and exits 1.
 
+### Long-lived requests at cutover
+
+The Service-selector flip sends new connections to the new build; it does not transfer an open
+connection or handler state between pods. The old pool drains finite HTTP/RSC responses for up to
+60 seconds after SIGTERM, ends surviving SSE responses with a clean EOF, and sends established
+WebSockets close code `1001` before forced teardown. SSE clients need event `id` fields plus shared
+replay storage for `Last-Event-ID`; WebSocket clients need reconnect/backoff and application-level
+resume state. An abrupt node/process failure can bypass those graceful signals. See
+`docs/lifecycle.md#long-lived-requests-during-cutover` in the package repository for the full
+contract.
+
 ## Post-Deploy Verification
 
 ```bash

--- a/tests/emit/templates/generic-gateway.servercheck.test.ts
+++ b/tests/emit/templates/generic-gateway.servercheck.test.ts
@@ -8,6 +8,8 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { renderGenericGateway } from "../../../src/emit/templates/generic-gateway.js";
 import { renderEnvoyExtensionPolicy } from "../../../src/emit/templates/envoy-extension-policy.js";
+import { renderHTTPRoute } from "../../../src/emit/templates/gateway.js";
+import type { PoolDefinition, RoutingManifest } from "../../../src/types.js";
 
 const ctx = process.env.K8S_VALIDATE_CONTEXT;
 
@@ -43,5 +45,33 @@ describe.skipIf(!ctx)("generic templates validate against a real API server", ()
       renderEnvoyExtensionPolicy({ releaseName: "validate-app", routeName: "validate-app-route" }),
     );
     expect(out).toContain("envoyextensionpolicy");
+  });
+
+  it("HTTPRoute accepts disabled request timeouts on every application rule", () => {
+    const pools = new Map<string, PoolDefinition>([
+      ["default", { name: "default", outputs: [], config: { routes: ["appPages"] } }],
+    ]);
+    const manifest: RoutingManifest = {
+      routeGraph: { rsc: {} } as RoutingManifest["routeGraph"],
+      pathnames: [],
+      i18n: null,
+      buildId: "validate-build",
+      builtAt: "2026-08-12T00:00:00.000Z",
+      basePath: "",
+      middleware: null,
+      poolAssignments: { "/": "default" },
+      pprRoutes: {},
+      nextVersion: "16.3.0",
+    };
+    const out = apply(
+      renderHTTPRoute({
+        releaseName: "validate-app",
+        hosts: [{ hostname: "a.example.com", tls: { enabled: false } }],
+        pools,
+        routingManifest: manifest,
+        disableRequestTimeout: true,
+      }),
+    );
+    expect(out).toContain("httproute");
   });
 });

--- a/tests/pool-server/portable-rollout.integration.test.ts
+++ b/tests/pool-server/portable-rollout.integration.test.ts
@@ -1,0 +1,482 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { get as httpGet, type IncomingMessage, type ServerResponse } from "node:http";
+import net, { type Server as NetServer, type Socket } from "node:net";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createPoolServer } from "../../src/pool-server/server.js";
+
+// Portable rollout conformance against a real Envoy data plane. Unit assertions prove that the
+// generated HTTPRoute contains `request: 0s`; this differential test proves Envoy interprets it
+// as intended, and that its HTTP/1.1 proxying preserves the pool's protocol-specific drain
+// behavior. The TCP selector models a Kubernetes Service/EndpointSlice at the relevant boundary:
+// an accepted connection remains pinned to its old pod, while connections accepted after the
+// selector flip reach the new pod.
+
+function docker(args: string[]): string {
+  return (
+    execFileSync("docker", args, { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }) || ""
+  ).trim();
+}
+
+function dockerLogs(containerName: string): string {
+  const result = spawnSync("docker", ["logs", containerName], { encoding: "utf8" });
+  return `${result.stdout ?? ""}${result.stderr ?? ""}`.trim();
+}
+
+let dockerAvailable = false;
+try {
+  docker(["ps"]);
+  dockerAvailable = true;
+} catch {
+  dockerAvailable = false;
+}
+
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+function websocketFrame(payload: string): Buffer {
+  const bytes = Buffer.from(payload);
+  if (bytes.length > 125) throw new Error("Test WebSocket payload exceeds one short frame");
+  return Buffer.concat([Buffer.from([0x81, bytes.length]), bytes]);
+}
+
+function websocketHandler(build: string) {
+  return (req: IncomingMessage, socket: NodeJS.WritableStream) => {
+    const key = req.headers["sec-websocket-key"];
+    if (typeof key !== "string") {
+      socket.end("HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n");
+      return "rejected" as const;
+    }
+    const accept = createHash("sha1")
+      .update(`${key}258EAFA5-E914-47DA-95CA-C5AB0DC85B11`)
+      .digest("base64");
+    socket.write(
+      "HTTP/1.1 101 Switching Protocols\r\n" +
+        "Connection: Upgrade\r\n" +
+        "Upgrade: websocket\r\n" +
+        `Sec-WebSocket-Accept: ${accept}\r\n\r\n`,
+    );
+    socket.write(websocketFrame(build));
+    return "accepted" as const;
+  };
+}
+
+interface SseEvent {
+  id?: string;
+  data: string;
+}
+
+function openEventStream(port: number, lastEventId?: string) {
+  const events: SseEvent[] = [];
+  let pending = "";
+  let resolveConnected!: () => void;
+  let rejectConnected!: (error: Error) => void;
+  let resolveEnded!: () => void;
+  let rejectEnded!: (error: Error) => void;
+  const connected = new Promise<void>((resolve, reject) => {
+    resolveConnected = resolve;
+    rejectConnected = reject;
+  });
+  const ended = new Promise<void>((resolve, reject) => {
+    resolveEnded = resolve;
+    rejectEnded = reject;
+  });
+
+  const request = httpGet(
+    {
+      host: "127.0.0.1",
+      port,
+      path: "/events",
+      headers: {
+        accept: "text/event-stream",
+        ...(lastEventId ? { "last-event-id": lastEventId } : {}),
+      },
+    },
+    (response) => {
+      if (response.statusCode !== 200) {
+        const error = new Error(`SSE response returned ${response.statusCode}`);
+        rejectConnected(error);
+        rejectEnded(error);
+        response.resume();
+        return;
+      }
+      resolveConnected();
+      response.setEncoding("utf8");
+      response.on("data", (chunk: string) => {
+        pending += chunk.replaceAll("\r\n", "\n");
+        for (let boundary = pending.indexOf("\n\n"); boundary !== -1; ) {
+          const record = pending.slice(0, boundary);
+          pending = pending.slice(boundary + 2);
+          const data: string[] = [];
+          let id: string | undefined;
+          for (const line of record.split("\n")) {
+            if (line.startsWith(":")) continue;
+            if (line.startsWith("id:")) id = line.slice(3).trimStart();
+            if (line.startsWith("data:")) data.push(line.slice(5).trimStart());
+          }
+          if (data.length > 0) events.push({ id, data: data.join("\n") });
+          boundary = pending.indexOf("\n\n");
+        }
+      });
+      response.once("end", resolveEnded);
+      response.once("aborted", () => rejectEnded(new Error("SSE response was aborted")));
+      response.once("error", rejectEnded);
+    },
+  );
+  request.once("error", (error) => {
+    rejectConnected(error);
+    rejectEnded(error);
+  });
+
+  return { connected, ended, events, destroy: () => request.destroy() };
+}
+
+function openWebSocket(port: number) {
+  const socket = net.createConnection({ host: "127.0.0.1", port });
+  let received = Buffer.alloc(0);
+  let upgraded = false;
+  let messageSettled = false;
+  let closeSettled = false;
+  let resolveMessage!: (message: string) => void;
+  let rejectMessage!: (error: Error) => void;
+  let resolveCloseCode!: (code: number | undefined) => void;
+  const message = new Promise<string>((resolve, reject) => {
+    resolveMessage = resolve;
+    rejectMessage = reject;
+  });
+  const closeCode = new Promise<number | undefined>((resolve) => (resolveCloseCode = resolve));
+
+  const settleClose = (code: number | undefined) => {
+    if (closeSettled) return;
+    closeSettled = true;
+    resolveCloseCode(code);
+  };
+  socket.once("connect", () => {
+    socket.write(
+      "GET /socket HTTP/1.1\r\n" +
+        "Host: adapter.test\r\n" +
+        "Connection: Upgrade\r\n" +
+        "Upgrade: websocket\r\n" +
+        "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n" +
+        "Sec-WebSocket-Version: 13\r\n\r\n",
+    );
+  });
+  socket.on("data", (chunk) => {
+    received = Buffer.concat([received, chunk]);
+    if (!upgraded) {
+      const boundary = received.indexOf("\r\n\r\n");
+      if (boundary === -1) return;
+      const headers = received.subarray(0, boundary).toString("latin1");
+      if (!headers.startsWith("HTTP/1.1 101")) {
+        const error = new Error(`WebSocket upgrade failed: ${headers.split("\r\n")[0]}`);
+        messageSettled = true;
+        rejectMessage(error);
+        socket.destroy();
+        return;
+      }
+      upgraded = true;
+      received = received.subarray(boundary + 4);
+    }
+
+    while (received.length >= 2) {
+      const opcode = received[0]! & 0x0f;
+      let payloadLength = received[1]! & 0x7f;
+      let offset = 2;
+      if (payloadLength === 126) {
+        if (received.length < 4) return;
+        payloadLength = received.readUInt16BE(2);
+        offset = 4;
+      }
+      if (received.length < offset + payloadLength) return;
+      const payload = received.subarray(offset, offset + payloadLength);
+      received = received.subarray(offset + payloadLength);
+      if (opcode === 0x1 && !messageSettled) {
+        messageSettled = true;
+        resolveMessage(payload.toString("utf8"));
+      }
+      if (opcode === 0x8) {
+        settleClose(payload.length >= 2 ? payload.readUInt16BE(0) : undefined);
+      }
+    }
+  });
+  socket.once("close", () => {
+    if (!messageSettled) {
+      messageSettled = true;
+      rejectMessage(new Error("WebSocket closed before its first message"));
+    }
+    settleClose(undefined);
+  });
+  socket.once("error", (error) => {
+    if (!messageSettled) {
+      messageSettled = true;
+      rejectMessage(error);
+    }
+  });
+
+  return { socket, message, closeCode };
+}
+
+function closeNetServer(server: NetServer | undefined): Promise<void> {
+  if (!server) return Promise.resolve();
+  return new Promise((resolve) => server.close(() => resolve()));
+}
+
+describe.skipIf(!dockerAvailable)("portable rollout continuity (real Envoy)", () => {
+  const containerName = `adapter-k8s-portable-rollout-${process.pid}`;
+  const previousPrivateOrigin = process.env.__NEXT_PRIVATE_ORIGIN;
+  const eventLog: SseEvent[] = [{ id: "1", data: "before-cutover" }];
+  const selectorSockets = new Set<Socket>();
+  let activePoolPort = 0;
+  let finiteStarted!: () => void;
+  let finiteStartedPromise = new Promise<void>((resolve) => (finiteStarted = resolve));
+  let oldPool: ReturnType<typeof createPoolServer>;
+  let newPool: ReturnType<typeof createPoolServer>;
+  let newPoolPort = 0;
+  let selector: NetServer | undefined;
+  let envoyPort = 0;
+
+  const requestHandler = (build: "old" | "new") => {
+    return async (req: IncomingMessage, res: ServerResponse) => {
+      if (req.url === "/timeout-control" || req.url === "/finite") {
+        res.writeHead(200, { "content-type": "text/plain" });
+        res.write(`${build}:first\n`);
+        if (req.url === "/finite" && build === "old") finiteStarted();
+        await sleep(450);
+        res.end(`${build}:last\n`);
+        return;
+      }
+      if (req.url === "/events") {
+        res.writeHead(200, {
+          "content-type": "text/event-stream; charset=utf-8",
+          "cache-control": "no-cache",
+        });
+        res.flushHeaders();
+        const lastEventId = Number(req.headers["last-event-id"] ?? 0);
+        for (const event of eventLog) {
+          if (Number(event.id) > lastEventId) {
+            res.write(`id: ${event.id}\ndata: ${event.data}\n\n`);
+          }
+        }
+        if (build === "new") {
+          res.end();
+          return;
+        }
+        const heartbeat = setInterval(() => res.write(": heartbeat\n\n"), 25);
+        res.once("close", () => clearInterval(heartbeat));
+        return;
+      }
+      res.writeHead(200, { "content-type": "text/plain" });
+      res.end(build);
+    };
+  };
+
+  beforeAll(async () => {
+    oldPool = createPoolServer({
+      onRequest: requestHandler("old"),
+      onUpgrade: websocketHandler("old"),
+      readiness: () => ({ ready: true, reason: "ready" }),
+      port: 0,
+    });
+    newPool = createPoolServer({
+      onRequest: requestHandler("new"),
+      onUpgrade: websocketHandler("new"),
+      readiness: () => ({ ready: true, reason: "ready" }),
+      port: 0,
+    });
+    const [{ port: oldPort }, { port: newPort }] = await Promise.all([
+      oldPool.start(),
+      newPool.start(),
+    ]);
+    activePoolPort = oldPort;
+    newPoolPort = newPort;
+
+    selector = net.createServer((client) => {
+      const upstream = net.createConnection({ host: "127.0.0.1", port: activePoolPort });
+      selectorSockets.add(client);
+      selectorSockets.add(upstream);
+      client.pipe(upstream);
+      upstream.pipe(client);
+      const destroyBoth = () => {
+        client.destroy();
+        upstream.destroy();
+      };
+      client.once("error", destroyBoth);
+      upstream.once("error", destroyBoth);
+      client.once("close", () => {
+        selectorSockets.delete(client);
+        upstream.destroy();
+      });
+      upstream.once("close", () => {
+        selectorSockets.delete(upstream);
+        client.destroy();
+      });
+    });
+    await new Promise<void>((resolve, reject) => {
+      selector!.once("error", reject);
+      selector!.listen(0, "0.0.0.0", resolve);
+    });
+    const selectorAddress = selector.address();
+    if (!selectorAddress || typeof selectorAddress === "string") {
+      throw new Error("Could not determine selector port");
+    }
+
+    const envoyConfig = `static_resources:
+  listeners:
+    - name: listener
+      address:
+        socket_address: { address: 0.0.0.0, port_value: 18080 }
+      filter_chains:
+        - filters:
+            - name: envoy.filters.network.http_connection_manager
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                stat_prefix: portable_rollout_test
+                upgrade_configs:
+                  - upgrade_type: websocket
+                route_config:
+                  name: routes
+                  virtual_hosts:
+                    - name: app
+                      domains: ["*"]
+                      routes:
+                        - match: { prefix: "/timeout-control" }
+                          route:
+                            cluster: stable-service
+                            timeout: 0.150s
+                        - match: { prefix: "/" }
+                          route:
+                            cluster: stable-service
+                            timeout: 0s
+                            upgrade_configs:
+                              - upgrade_type: websocket
+                http_filters:
+                  - name: envoy.filters.http.router
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+  clusters:
+    - name: stable-service
+      connect_timeout: 1s
+      type: STRICT_DNS
+      typed_extension_protocol_options:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          common_http_protocol_options:
+            max_requests_per_connection: 1
+          explicit_http_config:
+            http_protocol_options: {}
+      load_assignment:
+        cluster_name: stable-service
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: host.docker.internal
+                      port_value: ${selectorAddress.port}
+`;
+
+    docker([
+      "run",
+      "-d",
+      "--name",
+      containerName,
+      "--add-host",
+      "host.docker.internal:host-gateway",
+      "-p",
+      "127.0.0.1::18080",
+      // Envoy Gateway 1.5.x, the adapter's oldest supported controller line, bundles Envoy 1.35.
+      // Exercise the floor of the compatibility range rather than an unrelated latest image.
+      "envoyproxy/envoy:v1.35-latest",
+      "--config-yaml",
+      envoyConfig,
+      "--log-level",
+      "warning",
+    ]);
+    envoyPort = Number(docker(["port", containerName, "18080/tcp"]).split(":").pop());
+
+    let lastObservation = "no response";
+    for (let attempt = 0; attempt < 100; attempt++) {
+      try {
+        const response = await fetch(`http://127.0.0.1:${envoyPort}/who`, {
+          signal: AbortSignal.timeout(500),
+        });
+        const body = await response.text();
+        lastObservation = `${response.status} ${body}`;
+        if (body === "old") return;
+      } catch (error) {
+        // Envoy may still be binding or waiting for its first DNS resolution.
+        lastObservation = String(error);
+      }
+      await sleep(100);
+    }
+    throw new Error(
+      `Envoy on ${envoyPort} did not become ready (${lastObservation}); ` +
+        `state=${docker(["inspect", "--format", "{{json .State}}", containerName])}:\n` +
+        dockerLogs(containerName),
+    );
+  }, 120_000);
+
+  afterAll(async () => {
+    try {
+      docker(["rm", "-f", containerName]);
+    } catch {
+      // The container may already have exited after a configuration failure.
+    }
+    for (const socket of selectorSockets) socket.destroy();
+    await Promise.all([
+      oldPool?.stop({ graceMs: 50 }).catch(() => undefined),
+      newPool?.stop({ graceMs: 50 }).catch(() => undefined),
+      closeNetServer(selector),
+    ]);
+    if (previousPrivateOrigin === undefined) delete process.env.__NEXT_PRIVATE_ORIGIN;
+    else process.env.__NEXT_PRIVATE_ORIGIN = previousPrivateOrigin;
+  });
+
+  it("preserves finite streams and gives SSE/WebSocket clients resumable cutover signals", async () => {
+    // Differential control: the same 450ms handler fails under an ordinary total route timeout,
+    // proving the successful /finite request below relies on Envoy's `timeout: 0s` behavior.
+    const timedOut = await fetch(`http://127.0.0.1:${envoyPort}/timeout-control`);
+    let controlBody: string | undefined;
+    try {
+      controlBody = await timedOut.text();
+    } catch {
+      // Once upstream headers are committed, Envoy can only reset the response at the timeout;
+      // before headers it would synthesize 504. Either form must not look like a complete body.
+    }
+    expect(controlBody).not.toBe("old:first\nold:last\n");
+
+    const oldSse = openEventStream(envoyPort);
+    await oldSse.connected;
+    await expect.poll(() => oldSse.events).toEqual([{ id: "1", data: "before-cutover" }]);
+    const oldWebSocket = openWebSocket(envoyPort);
+    await expect(oldWebSocket.message).resolves.toBe("old");
+
+    finiteStartedPromise = new Promise<void>((resolve) => (finiteStarted = resolve));
+    const finiteResponsePromise = fetch(`http://127.0.0.1:${envoyPort}/finite`);
+    await finiteStartedPromise;
+
+    eventLog.push({ id: "2", data: "after-cutover" });
+    activePoolPort = newPoolPort;
+    const drain = oldPool.stop({ graceMs: 650 });
+
+    const newRequest = await fetch(`http://127.0.0.1:${envoyPort}/who`);
+    await expect(newRequest.text()).resolves.toBe("new");
+
+    const finiteResponse = await finiteResponsePromise;
+    expect(finiteResponse.status).toBe(200);
+    await expect(finiteResponse.text()).resolves.toBe("old:first\nold:last\n");
+    await expect(oldSse.ended).resolves.toBeUndefined();
+    await expect(oldWebSocket.closeCode).resolves.toBe(1001);
+    await drain;
+
+    // The adapter supplies a reconnectable boundary, not application state migration. This
+    // client sends the standard SSE cursor and the new pod replays from shared event history.
+    const resumedSse = openEventStream(envoyPort, oldSse.events.at(-1)?.id);
+    await resumedSse.connected;
+    await resumedSse.ended;
+    expect(resumedSse.events).toEqual([{ id: "2", data: "after-cutover" }]);
+
+    const newWebSocket = openWebSocket(envoyPort);
+    await expect(newWebSocket.message).resolves.toBe("new");
+    newWebSocket.socket.destroy();
+  });
+});


### PR DESCRIPTION
## What

- add a Docker-gated conformance test with real Envoy 1.35 in front of old/new pool servers
- differentially prove that `timeout: 0s` preserves a streamed response that an ordinary total timeout truncates
- prove an old-build finite stream completes through selector cutover
- prove SSE receives clean EOF and resumes on the new build using `Last-Event-ID`
- prove WebSocket receives close code `1001` and reconnects to the new build
- document the portable rollout contract in lifecycle, verification, README, and the packaged deploy skill
- add optional API-server validation for the generated `HTTPRoute` timeout field

## Why

Unit tests can validate rendered YAML and socket behavior in isolation, but they cannot show that a real Envoy data plane preserves those semantics together during a backend replacement. This closes that gap without claiming a full Kubernetes rollout test.

## How

The test runs Envoy 1.35, the floor of the adapter's supported Envoy Gateway line, in front of a small TCP selector. The selector models the relevant Kubernetes Service/EndpointSlice boundary: an accepted connection stays pinned to the old pool while connections accepted after the cutover reach the new pool.

The fixture opens a finite stream, SSE stream, and WebSocket against the old pool, flips the selector, and drains it. It then verifies completion or the correct reconnect signal and reconnects the stateful protocols to the new pool. SSE replay is intentionally implemented by the fixture application, demonstrating the responsibility boundary rather than hiding it in the adapter.

## Stack

1. #47 — generated WebSocket upgrade dispatch
2. #49 — generic Envoy total-timeout parity
3. #50 — protocol-aware pool shutdown
4. this PR — rollout conformance and lifecycle contract

This PR remains draft while its stack bases are draft.

## Coverage boundary

This is a real-Envoy data-plane test, not a live Kubernetes controller, EndpointSlice propagation, involuntary node-loss, or GKE test. The docs state that limitation explicitly. GKE backend draining/timeouts remain out of scope.

## Testing

- real Envoy 1.35 rollout conformance: passed
- stack-head `npm test`: 2,901 passed, 20 skipped
- `npx tsc --noEmit`
- `npm run lint`
- `npm run fmt:check`
- `npm run build`
- `git diff --check`
