### PR TITLE
Enable Turbopack production filesystem cache

### DIFF
--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -4,6 +4,19 @@ The `adapter-k8s` CLI is a convenience wrapper: everything `deploy` does can be 
 
 ## The pipeline shape
 
+The adapter enables Next's experimental Turbopack filesystem cache for production builds unless
+the app explicitly sets `experimental.turbopackFileSystemCacheForBuild: false`. On a persistent
+worker, subsequent builds reuse compiler artifacts from `<distDir>/cache` automatically. On an
+ephemeral CI runner, restore that directory before `next build` and save it afterward; otherwise
+every build remains cold. For the default `distDir`, cache `.next/cache` with a key that includes
+the lockfile, Next version, Node version, operating system, and CPU architecture, and use a
+lockfile-based restore prefix so source changes can still reuse valid entries.
+
+This is a compilation cache, not a cross-build prerender cache. Next still evaluates
+`generateStaticParams` and generates the configured static pages on each build. Large route sets
+should use a bounded prerender subset plus on-demand generation/ISR when rebuilding every route is
+not required.
+
 ```yaml
 # GitHub Actions example
 jobs:

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -1419,6 +1419,27 @@ export function createK8sAdapter(userConfig?: K8sAdapterConfig): NextAdapter {
         };
       }
 
+      // Turbopack's production filesystem cache is still opt-in in Next 16. The adapter runs
+      // after Next has loaded next.config but before compilation, so this is the only adapter
+      // hook that can avoid repeating unchanged compilation work across builds. The cache lives
+      // under <distDir>/cache; local builds reuse it naturally, while ephemeral CI runners must
+      // restore that directory before `next build` (see docs/ci-cd.md). It does NOT reuse static
+      // generation output: generateStaticParams/prerendering still run according to Next's own
+      // build semantics.
+      //
+      // Keep an explicit app choice authoritative. This matters while the Next feature remains
+      // experimental: an app that encounters an upstream cache invalidation bug must be able to
+      // turn it off without replacing the adapter.
+      {
+        const userBuildCache = (
+          nextConfig.experimental as { turbopackFileSystemCacheForBuild?: boolean } | undefined
+        )?.turbopackFileSystemCacheForBuild;
+        modified.experimental = {
+          ...(modified.experimental as Record<string, unknown> | undefined),
+          turbopackFileSystemCacheForBuild: userBuildCache ?? true,
+        };
+      }
+
       // Local build profile: cap workers and memory for constrained environments
       // (e2e tests, local emulation). Set ADAPTER_K8S_BUILD_CPUS to activate.
       const buildCpus = parseInt(process.env.ADAPTER_K8S_BUILD_CPUS ?? "", 10);

--- a/tests/adapter-config.test.ts
+++ b/tests/adapter-config.test.ts
@@ -66,6 +66,38 @@ describe("createK8sAdapter config normalization", () => {
   });
 });
 
+describe("Turbopack production filesystem cache", () => {
+  it("enables cross-build compilation caching by default", async () => {
+    const adapter = createK8sAdapter(validConfig);
+    const modified = (await adapter.modifyConfig!({} as any, {} as any)) as {
+      experimental?: { turbopackFileSystemCacheForBuild?: boolean };
+    };
+
+    expect(modified.experimental?.turbopackFileSystemCacheForBuild).toBe(true);
+  });
+
+  it("preserves an explicit app opt-out and unrelated experimental settings", async () => {
+    const adapter = createK8sAdapter(validConfig);
+    const modified = (await adapter.modifyConfig!(
+      {
+        experimental: {
+          turbopackFileSystemCacheForBuild: false,
+          optimizePackageImports: ["example-package"],
+        },
+      } as any,
+      {} as any,
+    )) as {
+      experimental?: {
+        turbopackFileSystemCacheForBuild?: boolean;
+        optimizePackageImports?: string[];
+      };
+    };
+
+    expect(modified.experimental?.turbopackFileSystemCacheForBuild).toBe(false);
+    expect(modified.experimental?.optimizePackageImports).toEqual(["example-package"]);
+  });
+});
+
 // N50 (review #22): `nextConfig.generateBuildId ?? (() => …)` never fell through, because
 // Next's DEFAULT config value for generateBuildId is a FUNCTION — `() => null`
 // (next/dist/server/config-shared.js). So the adapter's "K8s-friendly" generator had never


### PR DESCRIPTION
## Summary

- enable `experimental.turbopackFileSystemCacheForBuild` through the adapter `modifyConfig` hook
- preserve an explicit application opt-out and unrelated experimental settings
- document restoring `<distDir>/cache` on ephemeral CI workers and clarify that this does not cache prerender output

## Why

Next 16 keeps Turbopack production filesystem caching opt-in. Adapter builds otherwise repeat unchanged compilation work even when the build environment preserves `.next/cache`. Enabling the flag at the adapter boundary gives local persistent workers automatic reuse and allows CI systems to restore the compiler cache without every consuming app having to discover the flag.

This deliberately does not claim to optimize `generateStaticParams` or static generation. Large prerender sets still need bounded generation plus ISR/on-demand rendering, or a separate future design for safe cross-build prerender reuse.

## Verification

- `npm test` (140 files passed, 2 skipped; 2919 tests passed, 4 skipped)
- `npx tsc --noEmit`
- `npm run lint`
- `git diff --check`