### PR TITLE
Stage shared static content once

### DIFF
--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -2133,14 +2133,6 @@ export function createK8sAdapter(userConfig?: K8sAdapterConfig): NextAdapter {
       // `@next/routing` / sharp gaps were the same crash-at-runtime shapes the traced-assets
       // branch already guarded against.
       const stageCommonRuntimeFiles = async (poolName: string, isShared: boolean) => {
-        // public/ files (favicon, robots, arbitrary static assets). They are NOT in Next's
-        // staticFiles output, so nothing else stages them, and the pool's public-file fast
-        // path 404s without them. Enumerate with the same helper the router uses.
-        for (const publicPathname of collectPublicPathnames(projectDir)) {
-          const rel = `public${publicPathname}`; // publicPathname starts with "/"
-          await stageFile(projectDir, path.join(projectDir, rel), rel, poolName, isShared);
-        }
-
         // @next/routing (the pool server's local route resolution — the fail-safe path).
         // Resolve adapter-first (it is the adapter's own dependency); a silent skip ships an
         // image that crashes with "Cannot find module '@next/routing'".
@@ -2195,6 +2187,35 @@ export function createK8sAdapter(userConfig?: K8sAdapterConfig): NextAdapter {
           isShared,
           imageTargetPlatform,
         );
+      };
+
+      // Build-emitted static files and prerenders are route-independent content. They must be
+      // visible in every pool because a public/static pathname can arrive at any route owner,
+      // but copying a large corpus into every pool only to hash it back into the shared OCI base
+      // makes staging scale as `static files × pools`. Defer these files until the image-layout
+      // decision is known: compatible multi-pool builds stage them directly into the shared
+      // content layer once; standalone layouts retain the historical per-pool copies.
+      const stageStaticRuntimeFiles = async (
+        poolName: string,
+        stageDirOverride?: string,
+      ): Promise<void> => {
+        for (const asset of staticManifest) {
+          const absPath = path.resolve(projectDir, asset.filePath);
+          await stageFile(projectDir, absPath, asset.filePath, poolName, false, stageDirOverride);
+          // Runtime sibling files the manifest doesn't carry (`.meta` — see
+          // prerenderSiblingFiles). stageFile skips missing sources, so a prerender without one
+          // costs nothing.
+          for (const sibling of prerenderSiblingFiles(asset)) {
+            await stageFile(
+              projectDir,
+              path.resolve(projectDir, sibling),
+              sibling,
+              poolName,
+              false,
+              stageDirOverride,
+            );
+          }
+        }
       };
 
       if (skipStaging) {
@@ -2261,6 +2282,7 @@ export function createK8sAdapter(userConfig?: K8sAdapterConfig): NextAdapter {
         );
 
         const sharpStaging = await stageCommonRuntimeFiles("shared", true);
+        await stageStaticRuntimeFiles("shared", path.join(projectDir, absSharedStageDir));
         await pruneSharpContext(path.join(projectDir, absSharedStageDir));
 
         // Keep .env secrets out of the shared image (built from this context).
@@ -2344,25 +2366,6 @@ export function createK8sAdapter(userConfig?: K8sAdapterConfig): NextAdapter {
               poolName,
               false,
             );
-          }
-
-          // Stage static/public/prerender files into EVERY pool image, not just
-          // the default one. static-assets.json is written to every pool's config
-          // (so every dispatcher knows these paths), and the gateway routes a
-          // shared URL prefix to whichever pool owns a route under it — which may
-          // be a non-default pool. If the files lived only in the default pool,
-          // a public asset under such a prefix would 404 on the pool that
-          // actually receives it. (Phase 4 CDN/GCS offload will move these off
-          // the pods entirely and make this staging unnecessary.)
-          for (const asset of staticManifest) {
-            const absPath = path.resolve(projectDir, asset.filePath);
-            await stageFile(projectDir, absPath, asset.filePath, poolName);
-            // Runtime sibling files the manifest doesn't carry (`.meta` — see
-            // prerenderSiblingFiles). stageFile skips missing sources, so a prerender
-            // without one costs nothing.
-            for (const sibling of prerenderSiblingFiles(asset)) {
-              await stageFile(projectDir, path.resolve(projectDir, sibling), sibling, poolName);
-            }
           }
 
           // The build's fetch-cache (`<distDir>/cache/fetch-cache`) — `next start`'s
@@ -2492,7 +2495,10 @@ export function createK8sAdapter(userConfig?: K8sAdapterConfig): NextAdapter {
           );
         }
 
-        if (pools.size > 1) {
+        if (pools.size === 1) {
+          const poolName = pools.keys().next().value as string;
+          await stageStaticRuntimeFiles(poolName);
+        } else if (pools.size > 1) {
           const sharpDecisions = new Set(
             poolSharpStaging.map((staging) =>
               staging.staged
@@ -2503,6 +2509,7 @@ export function createK8sAdapter(userConfig?: K8sAdapterConfig): NextAdapter {
             ),
           );
           if (sharpDecisions.size > 1) {
+            for (const poolName of pools.keys()) await stageStaticRuntimeFiles(poolName);
             console.warn(
               `[adapter-k8s] Pool staging produced different sharp requirements ` +
                 `(${[...sharpDecisions].join(", ")}); keeping standalone pool images so each ` +
@@ -2519,6 +2526,8 @@ export function createK8sAdapter(userConfig?: K8sAdapterConfig): NextAdapter {
 
             const baseContext = path.join(projectDir, poolBaseDir);
             const shared = await factorSharedPoolFiles(poolContexts, baseContext);
+            const sharedContentContext = path.join(baseContext, "content");
+            await stageStaticRuntimeFiles("pool-base", sharedContentContext);
             await writeOutputFile(projectDir, ".dockerignore", generateDockerignore(), poolBaseDir);
             await writeOutputFile(
               projectDir,

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -2198,8 +2198,14 @@ export function createK8sAdapter(userConfig?: K8sAdapterConfig): NextAdapter {
       const stageStaticRuntimeFiles = async (
         poolName: string,
         stageDirOverride?: string,
+        includeFilePath?: (filePath: string) => boolean,
       ): Promise<void> => {
         for (const asset of staticManifest) {
+          // A caller whose context already holds part of the corpus filters those entries out.
+          // stageFile does not dedupe against a bulk `cp`: stagedPaths only records its own
+          // copies, and its exists-check skips a destination only when the realpaths MATCH, so an
+          // already-present copy is overwritten rather than left alone.
+          if (includeFilePath && !includeFilePath(asset.filePath)) continue;
           const absPath = path.resolve(projectDir, asset.filePath);
           await stageFile(projectDir, absPath, asset.filePath, poolName, false, stageDirOverride);
           // Runtime sibling files the manifest doesn't carry (`.meta` — see
@@ -2282,7 +2288,25 @@ export function createK8sAdapter(userConfig?: K8sAdapterConfig): NextAdapter {
         );
 
         const sharpStaging = await stageCommonRuntimeFiles("shared", true);
-        await stageStaticRuntimeFiles("shared", path.join(projectDir, absSharedStageDir));
+        // Only the entries the wholesale distDir `cp` above did NOT place. That copy already put
+        // every distDir-resident manifest entry — `static/**`, and each prerender's `.html` /
+        // `.segments` / `.meta` — at exactly the destination stageFile computes, and stageFile
+        // overwrites a non-identical destination instead of skipping it, so staging them again
+        // copies the whole corpus twice. On the 94k-route builds this staging exists to make
+        // cheap, that is the hot path. `public/` (never inside distDir) and any out-of-dist entry
+        // still need staging; `<distDir>/cache` is excluded from the cp, so anything under it
+        // stays eligible here.
+        const distDirStagedPrefix = distDirRel + path.sep;
+        const distCacheStagedPrefix = path.join(distDirRel, "cache") + path.sep;
+        await stageStaticRuntimeFiles(
+          "shared",
+          path.join(projectDir, absSharedStageDir),
+          (filePath) => {
+            const normalized = path.normalize(filePath);
+            if (!normalized.startsWith(distDirStagedPrefix)) return true;
+            return normalized.startsWith(distCacheStagedPrefix);
+          },
+        );
         await pruneSharpContext(path.join(projectDir, absSharedStageDir));
 
         // Keep .env secrets out of the shared image (built from this context).

--- a/tests/adapter-build-context.test.ts
+++ b/tests/adapter-build-context.test.ts
@@ -219,6 +219,9 @@ describe("pool build context staging", () => {
     expect(
       existsSync(path.join(output, "pool-base/fetch-cache/.k8s-adapter/fetch-cache-seed/entry")),
     ).toBe(true);
+    expect(existsSync(path.join(output, "pool-base/content/public/logo.png"))).toBe(true);
+    expect(existsSync(path.join(output, "pools/web/context/public/logo.png"))).toBe(false);
+    expect(existsSync(path.join(output, "pools/api/context/public/logo.png"))).toBe(false);
     expect(existsSync(path.join(output, "pools/web/context/.next/server/app/page.js"))).toBe(true);
     expect(
       existsSync(path.join(output, "pools/api/context/.next/server/app/api/hello/route.js")),

--- a/tests/adapter-shared-static-staging.test.ts
+++ b/tests/adapter-shared-static-staging.test.ts
@@ -1,0 +1,173 @@
+// tests/adapter-shared-static-staging.test.ts
+//
+// The shared-image strategy copies the whole distDir into `shared-context/<distDir>` in one `cp`,
+// which already lands every distDir-resident static-manifest entry — `static/**` and each
+// prerender's `.html`/`.segments`/`.meta` — at exactly the path the per-entry staging would use.
+// stageFile does not dedupe against that copy (stagedPaths only records its own writes, and its
+// exists-check skips a destination only when the realpaths MATCH), so re-staging the manifest
+// copied the entire corpus a second time — on a 94k-route build, the very cost this staging pass
+// exists to remove. Only `public/` is genuinely missing from the dist copy.
+//
+// copyFile is wrapped rather than stubbed: the build runs for real against a temp project, and the
+// wrapper only records destinations so duplicate I/O is observable instead of inferred.
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  mockAppPage,
+  mockOutputs,
+  mockPrerender,
+  mockRouting,
+  mockStaticFile,
+} from "./helpers/mock-outputs.js";
+import type { K8sAdapterConfig } from "../src/types.js";
+
+const copiedDestinations = vi.hoisted(() => [] as string[]);
+
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs/promises")>();
+  return {
+    ...actual,
+    copyFile: async (source: string, dest: string, mode?: number) => {
+      copiedDestinations.push(String(dest));
+      return actual.copyFile(source, dest, mode);
+    },
+  };
+});
+
+const { createK8sAdapter } = await import("../src/adapter.js");
+
+const sharedConfig: K8sAdapterConfig = {
+  pools: { ssr: { routes: ["appPages"] } },
+  containerStrategy: "shared-image",
+  provider: {
+    gke: {
+      gateway: {
+        type: "gateway-api",
+        className: "gke",
+        hosts: [{ hostname: "example.com", tls: { enabled: true } }],
+      },
+    },
+  },
+};
+
+let projectDir: string;
+let bundleDir: string;
+const savedEnv: Record<string, string | undefined> = {};
+const ENV_KEYS = ["ADAPTER_K8S_BUNDLE_DIR", "ADAPTER_K8S_INTERNAL_SECRET_KEY", "SOURCE_DATE_EPOCH"];
+
+beforeEach(() => {
+  copiedDestinations.length = 0;
+  for (const key of ENV_KEYS) savedEnv[key] = process.env[key];
+  projectDir = mkdtempSync(path.join(os.tmpdir(), "adapter-shared-static-"));
+  bundleDir = mkdtempSync(path.join(os.tmpdir(), "adapter-bundles-"));
+  writeFileSync(path.join(bundleDir, "pool-server.cjs"), "// pool server");
+  writeFileSync(path.join(bundleDir, "routing-service.cjs"), "// routing service");
+  writeFileSync(path.join(bundleDir, "cache-handler.cjs"), "// cache handler");
+  process.env.ADAPTER_K8S_BUNDLE_DIR = bundleDir;
+  process.env.ADAPTER_K8S_INTERNAL_SECRET_KEY = "unit-test-key";
+  process.env.SOURCE_DATE_EPOCH = "1750000000";
+});
+
+afterEach(() => {
+  rmSync(projectDir, { recursive: true, force: true });
+  rmSync(bundleDir, { recursive: true, force: true });
+  for (const key of ENV_KEYS) {
+    if (savedEnv[key] === undefined) delete process.env[key];
+    else process.env[key] = savedEnv[key]!;
+  }
+});
+
+const writeFile = (rel: string, content = "x") => {
+  const abs = path.join(projectDir, rel);
+  mkdirSync(path.dirname(abs), { recursive: true });
+  writeFileSync(abs, content);
+  return abs;
+};
+
+/** One of every corpus shape the manifest carries: a build static file, a prerender with its
+ * `.meta` sibling, and a public file (the only one the distDir copy cannot supply). */
+function seedProject() {
+  writeFile("package.json", JSON.stringify({ name: "app", type: "module" }));
+  writeFile(".next/BUILD_ID", "b12345");
+  writeFile(".next/server/app/page.js", "module.exports={}");
+  writeFile(".next/static/chunk-a.js", "static-a");
+  writeFile(".next/server/app/blog/post.html", "<html>post</html>");
+  writeFile(".next/server/app/blog/post.meta", '{"status":200}');
+  writeFile("public/logo.png", "png-bytes");
+  writeFile("node_modules/next/package.json", JSON.stringify({ name: "next", version: "16.2.10" }));
+  writeFile("node_modules/next/dist/server/setup-node-env.js", "//");
+  return path.join(projectDir, ".next");
+}
+
+async function build() {
+  const distDir = seedProject();
+  const adapter = createK8sAdapter(structuredClone(sharedConfig));
+  await adapter.onBuildComplete!({
+    buildId: "b12345",
+    routing: mockRouting(),
+    outputs: mockOutputs({
+      appPages: [
+        mockAppPage({ pathname: "/", filePath: path.join(distDir, "server/app/page.js") }),
+      ],
+      staticFiles: [
+        mockStaticFile({
+          pathname: "/_next/static/chunk-a.js",
+          filePath: path.join(distDir, "static/chunk-a.js"),
+        }),
+      ],
+      prerenders: [
+        mockPrerender({
+          pathname: "/blog/post",
+          fallback: { filePath: path.join(distDir, "server/app/blog/post.html") } as never,
+        }),
+      ],
+    }),
+    projectDir,
+    repoRoot: projectDir,
+    distDir,
+    config: {},
+    nextVersion: "16.2.0",
+  } as never);
+}
+
+const sharedContext = (rel: string) =>
+  path.join(projectDir, ".k8s-adapter/output/shared-context", rel);
+
+describe("shared-image static staging", () => {
+  it("does not re-copy the distDir corpus the wholesale dist copy already staged", async () => {
+    await build();
+
+    // Whatever the copy strategy, the image must still hold every manifest entry — that is the
+    // property the per-entry staging pass exists for, and a filter must not erode it.
+    const manifest = JSON.parse(
+      readFileSync(sharedContext("config/static-assets.json"), "utf-8"),
+    ) as Array<{ filePath: string }>;
+    expect(manifest.map((entry) => entry.filePath).sort()).toEqual(
+      [".next/static/chunk-a.js", ".next/server/app/blog/post.html", "public/logo.png"].sort(),
+    );
+    for (const entry of manifest) {
+      expect(existsSync(sharedContext(entry.filePath)), entry.filePath).toBe(true);
+    }
+    // The prerender sibling reaches the image through the dist copy rather than stageFile.
+    expect(readFileSync(sharedContext(".next/server/app/blog/post.meta"), "utf-8")).toBe(
+      '{"status":200}',
+    );
+
+    // No SECOND write to any dist-resident entry: `cp` places them, and a copyFile to the same
+    // destination would be the duplicate I/O this staging pass is supposed to avoid.
+    const duplicated = copiedDestinations.filter((dest) =>
+      [
+        ".next/static/chunk-a.js",
+        ".next/server/app/blog/post.html",
+        ".next/server/app/blog/post.meta",
+      ].some((rel) => dest === sharedContext(rel)),
+    );
+    expect(duplicated).toEqual([]);
+
+    // public/ is the one shape the dist copy cannot supply, so it must still be staged per entry.
+    expect(copiedDestinations).toContain(sharedContext("public/logo.png"));
+    expect(readFileSync(sharedContext("public/logo.png"), "utf-8")).toBe("png-bytes");
+  });
+});


### PR DESCRIPTION
## What?

- defer public, static, and prerender file staging until the traced-assets image layout is known
- write route-independent content directly into the shared pool base for compatible multi-pool builds
- preserve per-pool staging for single-pool builds and native-runtime layouts that cannot share a parent

Stack: #51 → #53 → this PR.

## Why?

The existing shared-parent layout removes duplicate bytes from the final pool contexts, but only after the adapter has copied the complete static corpus into every pool and hashed every duplicate. Large prerender sets therefore make adapter build work scale as `static files × pool count`.

The testbed already demonstrates the multiplier with only 339 prerenders: four pre-factoring pool contexts total about 1.36 GB and 45,356 files. A 94,163-route corpus would make that staging path dominate artifact generation.

A separate static HTTP container would add another network hop and routing authority. This change keeps the existing single-hop pool runtime and uses the shared OCI parent the adapter already builds.

## How?

A single staging helper owns public/static/prerender files and their `.meta` siblings. For compatible multi-pool traced-assets builds it targets `pool-base/content` after runtime dependency factoring; otherwise it targets each standalone pool context. Tests assert shared content exists only in the base while route handlers remain disjoint deltas.

## Verification

- `npm test` — 2919 passed, 4 skipped
- `npx tsc --noEmit`
- `npm run lint`
- `npm run fmt -- --check`
- focused build-context and pool-layout suites — 31 passed
- `git diff --check`