### PR TITLE
Validate ConfigMap-sourced image coordinates at the point of consumption

### DIFF
--- a/src/cli/migrate.ts
+++ b/src/cli/migrate.ts
@@ -29,7 +29,7 @@
 import readline from "node:readline";
 import { existsSync, readFileSync } from "node:fs";
 import { EXEC_TIMEOUTS, execCapture, execOrThrow } from "./exec.js";
-import { infrastructurePath } from "./infrastructure-validation.js";
+import { assertSafeInfrastructure, infrastructurePath } from "./infrastructure-validation.js";
 import { sanitizeForTerminal } from "./terminal.js";
 import { resolveK8sNamespace, assertSafeReleaseName } from "../emit/templates/utils.js";
 import { keepAtBirthAnnotationEntries } from "../emit/templates/utils.js";
@@ -140,6 +140,11 @@ export async function runMigrate(options: MigrateOptions): Promise<void> {
   const infra: Record<string, string | undefined> = existsSync(infraPath)
     ? JSON.parse(readFileSync(infraPath, "utf-8"))
     : {};
+  // S13 (SECURITY): the same idiom destroy/describe/doctor/tail/rollback already apply —
+  // infrastructure.json is operator-mutable (a poisoned checkout can carry one), and
+  // projectId/region below reach a `gcloud` argv. Validate at the point of read, before
+  // any subprocess is built from it.
+  assertSafeInfrastructure(infra);
   const namespace = resolveK8sNamespace(infra.namespace);
 
   // Invariant 6 / destroy's C1 guard, verbatim idiom: pin the kubectl context before any

--- a/src/cli/state.ts
+++ b/src/cli/state.ts
@@ -3,7 +3,8 @@ import { existsSync, readFileSync, writeFileSync, renameSync, mkdirSync } from "
 import path from "node:path";
 import { stateFileName } from "./infrastructure-validation.js";
 import { execCapture, execCaptureStdin } from "./exec.js";
-import { resolveK8sNamespace } from "../emit/templates/utils.js";
+import { BUILD_ID_RE, resolveK8sNamespace } from "../emit/templates/utils.js";
+import { DIGEST_RE } from "../pipeline/digests.js";
 import type { TargetPlatform } from "../target-platform.js";
 
 const STATE_DIR = ".k8s-adapter";
@@ -179,7 +180,22 @@ function isAdapterState(value: unknown): value is AdapterState {
   if (!value || typeof value !== "object" || Array.isArray(value)) return false;
   const v = value as Record<string, unknown>;
   if (typeof v.buildId !== "string" || v.buildId === "") return false;
-  return v.previousBuildId === null || typeof v.previousBuildId === "string";
+  if (!(v.previousBuildId === null || typeof v.previousBuildId === "string")) return false;
+  // The state ConfigMap is operator-mutable (any namespace actor with configmaps/update can
+  // rewrite it), and routingImageDigests flows — via revertRoutingServiceToBuild — into the
+  // image reference of a `kubectl patch` on the routing Deployment. edge.ts validates at the
+  // consumption point; this is the belt-and-braces half: a state blob whose digests are not
+  // sha256:<64 hex> (or whose keys are not build ids) reads as "unknown", never as deployable
+  // truth (N20: unknown must fail closed, not read as a first deploy).
+  if (v.routingImageDigests !== undefined) {
+    if (typeof v.routingImageDigests !== "object" || v.routingImageDigests === null) return false;
+    if (Array.isArray(v.routingImageDigests)) return false;
+    for (const [key, digest] of Object.entries(v.routingImageDigests)) {
+      if (!BUILD_ID_RE.test(key)) return false;
+      if (typeof digest !== "string" || !DIGEST_RE.test(digest)) return false;
+    }
+  }
+  return true;
 }
 
 function generationOf(state: AdapterState): number {
@@ -215,8 +231,9 @@ function readLocalState(projectDir: string): AdapterState | null {
   }
   if (!isAdapterState(parsed)) {
     throw new LocalStateReadError(
-      `Local deploy state ${filePath} is missing a string "buildId" / "previousBuildId" — ` +
-        `refusing to treat it as "no deploys yet". Fix or delete the file.`,
+      `Local deploy state ${filePath} is missing a string "buildId" / "previousBuildId", ` +
+        `or carries a malformed "routingImageDigests" — refusing to treat it as "no deploys ` +
+        `yet". Fix or delete the file.`,
     );
   }
   return parsed;
@@ -543,7 +560,9 @@ function parseStateConfigMap(
     return {
       state: null,
       resourceVersion,
-      error: `ConfigMap ${cmName}'s state.json is missing a string "buildId" / "previousBuildId"`,
+      error:
+        `ConfigMap ${cmName}'s state.json is missing a string "buildId" / "previousBuildId", ` +
+        `or carries a malformed "routingImageDigests"`,
     };
   }
   return { state, resourceVersion };

--- a/src/cutover/edge.ts
+++ b/src/cutover/edge.ts
@@ -7,7 +7,12 @@
 // re-exports them so its import surface (and the tests that mock it) are unchanged.
 import { EXEC_TIMEOUTS, execCapture, execCaptureStdin } from "../cli/exec.js";
 import { sanitizeForTerminal } from "../cli/terminal.js";
-import { resolveK8sNamespace } from "../emit/templates/utils.js";
+import {
+  assertSafeBuildId,
+  assertSafeImageRegistry,
+  resolveK8sNamespace,
+} from "../emit/templates/utils.js";
+import { DIGEST_RE } from "../pipeline/digests.js";
 import {
   ROUTING_MANIFEST_SNAPSHOT_COMPONENT,
   ROUTING_MANIFEST_VOLUME_NAME,
@@ -421,8 +426,17 @@ export async function revertRoutingServiceToBuild(opts: {
   /** The target build's recorded platform. Unknown legacy builds leave the selector alone. */
   targetPlatform?: TargetPlatform | undefined;
 }): Promise<void> {
-  const { releaseName, targetBuildId, registry, targetImageDigest, targetPlatform } = opts;
+  const { releaseName, targetBuildId, registry, targetPlatform } = opts;
   const namespace = resolveK8sNamespace(opts.namespace);
+  // SECURITY: every input that forms the image reference below is ConfigMap-sourced on the
+  // GitOps path (the emit-metadata CM mounts `registry`; the state CM carries
+  // `routingImageDigests`) and is therefore mutable by any namespace actor with
+  // configmaps/update — the exact actor the S1/S9 digest-pin defenses exist against. An
+  // unvalidated registry/digest pair here is an arbitrary-image injection into the routing
+  // Deployment via `kubectl patch`, and the routing pod starts with the release's internal
+  // dispatch secret. Validate at the point of consumption (AGENTS.md), even though the
+  // writers validated at write time.
+  assertSafeBuildId(targetBuildId);
   const deployName = routingServiceDeploymentName(releaseName);
   // N68: same distinction as retention — a read failure here used to return silently, i.e.
   // report "this release has no routing tier" and let the caller believe the edge was
@@ -445,6 +459,30 @@ export async function revertRoutingServiceToBuild(opts: {
         `reference cannot be formed. Restore it (re-run \`npx adapter-k8s init\`) and ` +
         `re-run the rollback. Traffic was NOT switched.`,
     );
+  }
+  assertSafeImageRegistry(registry);
+
+  // Digest when the deploy that pushed this build recorded one; tag otherwise (a build from
+  // before digests were recorded, where the tag is all that identifies it). A recorded digest
+  // that is not sha256:<64 hex> came out of an operator-mutable ConfigMap and is NOT a
+  // digest — refuse to put it in an image reference and revert by tag instead, exactly like
+  // a pre-digest build (availability is preserved; the injection vector is not).
+  let targetImageDigest: string | undefined;
+  if (opts.targetImageDigest === undefined) {
+    console.warn(
+      `  ! No recorded routing-image digest for build ${targetBuildId} — reverting the edge by ` +
+        `TAG. A retag of that tag would change what the edge runs on its next restart; the ` +
+        `next deploy records a digest so a later rollback can pin it.`,
+    );
+  } else if (!DIGEST_RE.test(opts.targetImageDigest)) {
+    console.warn(
+      `  ! Ignoring the recorded routing-image digest for build ${targetBuildId}: ` +
+        `${JSON.stringify(opts.targetImageDigest)} is not sha256:<64 hex>. Deploy state is ` +
+        `operator-mutable, so a malformed digest never reaches an image reference. ` +
+        `Reverting by TAG.`,
+    );
+  } else {
+    targetImageDigest = opts.targetImageDigest;
   }
 
   // Exactly what the edge is serving BEFORE this function changes anything, so a failed
@@ -480,18 +518,9 @@ export async function revertRoutingServiceToBuild(opts: {
     );
   }
 
-  // Digest when the deploy that pushed this build recorded one; tag otherwise (a build from
-  // before digests were recorded, where the tag is all that identifies it).
   const image = targetImageDigest
     ? `${registry}/routing-service@${targetImageDigest}`
     : `${registry}/routing-service:${targetBuildId}`;
-  if (!targetImageDigest) {
-    console.warn(
-      `  ! No recorded routing-image digest for build ${targetBuildId} — reverting the edge by ` +
-        `TAG. A retag of that tag would change what the edge runs on its next restart; the ` +
-        `next deploy records a digest so a later rollback can pin it.`,
-    );
-  }
   if (!targetPlatform) {
     console.warn(
       `  ! No recorded target platform for build ${targetBuildId}. This build predates ` +

--- a/src/cutover/from-cluster.ts
+++ b/src/cutover/from-cluster.ts
@@ -20,10 +20,14 @@ import { EXEC_TIMEOUTS, execCapture } from "../cli/exec.js";
 import { type AdapterState } from "../cli/state.js";
 import {
   assertSafeBuildId,
+  assertSafeImageRegistry,
   assertSafeNamespace,
+  assertSafePoolName,
+  assertSafeProjectId,
   assertSafeReleaseName,
   sanitizeK8sName,
 } from "../emit/templates/utils.js";
+import { DIGEST_RE } from "../pipeline/digests.js";
 import { parseTargetPlatform, type TargetPlatform } from "../target-platform.js";
 import type { EmitMetadata } from "../cli/emit.js";
 import type { CutoverInputs } from "./inputs.js";
@@ -89,12 +93,30 @@ export function readJobEmitMetadata(metadataPath: string): JobEmitMetadata {
   if (typeof meta.registry !== "string" || !meta.registry) {
     throw new Error(`emit-metadata.json has no registry — the edge revert could not run.`);
   }
+  // The registry joins a digest below to form the routing image a `kubectl patch` puts on
+  // the routing Deployment — an unvalidated value is an arbitrary-image injection into the
+  // pod that holds the release's dispatch secret. Same for every other value that lands in
+  // a kubectl/gcloud argv or a label selector: the battery runs HERE, on the
+  // operator-mutable ConfigMap read, even though emit validated at write time.
+  assertSafeImageRegistry(meta.registry);
+  const digests = meta.digests ?? {};
+  for (const [key, digest] of Object.entries(digests)) {
+    if (typeof digest !== "string" || !DIGEST_RE.test(digest)) {
+      throw new Error(
+        `emit-metadata.json digest for "${key}" is not sha256:<64 hex> — refusing to ` +
+          `promote on an image reference emit did not produce.`,
+      );
+    }
+  }
   if (!Array.isArray(meta.poolTopology) || meta.poolTopology.length === 0) {
     throw new Error(`emit-metadata.json has no poolTopology — refusing to promote.`);
   }
+  for (const pool of meta.poolTopology) assertSafePoolName(pool);
   if (typeof meta.defaultPool !== "string" || !meta.defaultPool) {
     throw new Error(`emit-metadata.json has no defaultPool — refusing to promote.`);
   }
+  assertSafePoolName(meta.defaultPool);
+  if (meta.projectId != null) assertSafeProjectId(meta.projectId);
   const platformRaw = meta.targetPlatforms?.[meta.buildId];
   if (typeof platformRaw !== "string") {
     throw new Error(
@@ -108,7 +130,7 @@ export function readJobEmitMetadata(metadataPath: string): JobEmitMetadata {
     releaseName: meta.releaseName,
     namespace: meta.namespace,
     registry: meta.registry,
-    digests: meta.digests ?? {},
+    digests,
     poolTopology: meta.poolTopology,
     defaultPool: meta.defaultPool,
     builtTargetPlatform: parseTargetPlatform(platformRaw, "emit-metadata targetPlatforms"),

--- a/src/cutover/from-cluster.ts
+++ b/src/cutover/from-cluster.ts
@@ -116,6 +116,12 @@ export function readJobEmitMetadata(metadataPath: string): JobEmitMetadata {
     throw new Error(`emit-metadata.json has no defaultPool — refusing to promote.`);
   }
   assertSafePoolName(meta.defaultPool);
+  if (!meta.poolTopology.includes(meta.defaultPool)) {
+    throw new Error(
+      `emit-metadata.json defaultPool must name one of its poolTopology entries; got ` +
+        `${JSON.stringify(meta.defaultPool)} — refusing to promote.`,
+    );
+  }
   if (meta.projectId != null) assertSafeProjectId(meta.projectId);
   const platformRaw = meta.targetPlatforms?.[meta.buildId];
   if (typeof platformRaw !== "string") {

--- a/src/emit/templates/utils.ts
+++ b/src/emit/templates/utils.ts
@@ -320,7 +320,9 @@ const IMAGE_REGISTRY_RE =
   /^[a-z0-9]+([._-][a-z0-9]+)*(:[0-9]{1,5})?(\/[a-z0-9]+([._-][a-z0-9]+)*)*$/;
 // Next.js build ids (default or from `generateBuildId()` — commonly a git ref in CI).
 // Excludes helm `--set` metacharacters (`,` `\`) and YAML/template breakouts (`"` `'` `{`).
-const BUILD_ID_RE = /^[A-Za-z0-9._-]{1,128}$/;
+// Exported for non-throwing call sites (type guards such as cli/state.ts's isAdapterState)
+// that need the same charset without the assert's error path.
+export const BUILD_ID_RE = /^[A-Za-z0-9._-]{1,128}$/;
 const NAMESPACE_RE = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
 // GCS bucket naming rules (https://cloud.google.com/storage/docs/buckets#naming).
 const BUCKET_RE = /^[a-z0-9][a-z0-9._-]{1,61}[a-z0-9]$/;

--- a/tests/cli/migrate.test.ts
+++ b/tests/cli/migrate.test.ts
@@ -258,6 +258,22 @@ describe("runMigrate — annotating the retained set", () => {
     expect(annotateCalls()).toHaveLength(0);
   });
 
+  it("S13: rejects a poisoned infrastructure.json BEFORE any gcloud/kubectl call", async () => {
+    // destroy/describe/doctor/tail/rollback all ran assertSafeInfrastructure on this read;
+    // migrate was the gap — projectId/region below reach a `gcloud get-credentials` argv.
+    writeInfra({ ...PINNED_INFRA, projectId: "x&calc" });
+    await expect(
+      runMigrate({ projectDir: tmpDir, releaseName: RELEASE, yes: true }),
+    ).rejects.toThrow(/Invalid projectId/);
+    expect(vi.mocked(execCapture)).not.toHaveBeenCalled();
+    expect(vi.mocked(execOrThrow)).not.toHaveBeenCalled();
+    // And the region slot is covered by the same read-time battery.
+    writeInfra({ ...PINNED_INFRA, region: "us-central1;rm -rf /" });
+    await expect(
+      runMigrate({ projectDir: tmpDir, releaseName: RELEASE, yes: true }),
+    ).rejects.toThrow(/Invalid region/);
+  });
+
   it("FAILS CLOSED on an unreadable list — an unannotated set must never look migrated", async () => {
     // The N20 family: "could not list" is NOT "nothing to annotate". Exiting 0 here would
     // green-light enabling a pruning reconciler over an unprotected parked build.

--- a/tests/cli/rollback.test.ts
+++ b/tests/cli/rollback.test.ts
@@ -2093,6 +2093,117 @@ describe("revertRoutingServiceToBuild — env stays truthful", () => {
   });
 });
 
+// SECURITY (audit): the revert's image reference is assembled from ConfigMap-sourced values
+// (the emit-metadata CM's `registry`, the state CM's `routingImageDigests`) — mutable by any
+// namespace actor with configmaps/update. Unvalidated, that pair is an arbitrary-image
+// injection into the routing Deployment, whose pod starts with the release's dispatch secret.
+describe("revertRoutingServiceToBuild — ConfigMap-sourced image coordinates are validated", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // The deployment read the function always performs; the revert target's snapshot/secret
+  // lookups return "present" so the flow reaches the patch when it should.
+  function mockServingCluster() {
+    vi.mocked(execCapture).mockImplementation((async (_cmd: string, args: string[]) => {
+      if (args[0] === "patch") return { exitCode: 0, stdout: "", stderr: "" };
+      if (args[0] === "get" && args[1] === "deployment") {
+        return {
+          exitCode: 0,
+          stdout: JSON.stringify({
+            spec: {
+              template: {
+                spec: {
+                  containers: [
+                    {
+                      name: "routing-service",
+                      image: "gcr.io/p/routing-service:current",
+                      env: [{ name: "NEXT_BUILD_ID", value: "current" }],
+                    },
+                  ],
+                  volumes: [
+                    { name: "routing-manifest", configMap: { name: "rel-routing-manifest" } },
+                  ],
+                },
+              },
+            },
+          }),
+          stderr: "",
+        };
+      }
+      // snapshot configmap + secret lookups: present
+      return { exitCode: 0, stdout: "configmap/rel-rm-target", stderr: "" };
+    }) as never);
+  }
+
+  function patchBodies(): string[] {
+    return vi
+      .mocked(execCapture)
+      .mock.calls.filter(([, args]) => args[0] === "patch")
+      .map(([, args]) => {
+        const i = args.findIndex((a) => a === "-p" || a === "--patch");
+        return args[i + 1]!;
+      });
+  }
+
+  it("refuses a targetBuildId outside the build-id charset before touching the cluster", async () => {
+    await expect(
+      revertRoutingServiceToBuild({
+        releaseName: "rel",
+        targetBuildId: 'bad"\nbuild',
+        registry: "gcr.io/p",
+      }),
+    ).rejects.toThrow(/Invalid buildId/);
+    expect(execCapture).not.toHaveBeenCalled();
+  });
+
+  it("refuses a registry that is not a registry, and never patches", async () => {
+    mockServingCluster();
+    await expect(
+      revertRoutingServiceToBuild({
+        releaseName: "rel",
+        targetBuildId: "target-build",
+        registry: "attacker.io/x\ninjected: yes",
+      }),
+    ).rejects.toThrow(/Invalid image registry/);
+    expect(patchBodies()).toHaveLength(0);
+  });
+
+  it("IGNORES a malformed recorded digest — the edge reverts by TAG, not by injection", async () => {
+    mockServingCluster();
+    const warnings: string[] = [];
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation((...a: unknown[]) => {
+      warnings.push(a.map(String).join(" "));
+    });
+    try {
+      await revertRoutingServiceToBuild({
+        releaseName: "rel",
+        targetBuildId: "target-build",
+        registry: "gcr.io/p",
+        targetImageDigest: "attacker.io/pwn@latest",
+      });
+    } finally {
+      warnSpy.mockRestore();
+    }
+    const body = patchBodies().join("\n");
+    expect(body).toContain("routing-service:target-build");
+    expect(body).not.toContain("attacker.io/pwn");
+    expect(warnings.join("\n")).toMatch(/not sha256:<64 hex>/);
+  });
+
+  it("pins a WELL-FORMED recorded digest exactly as before", async () => {
+    mockServingCluster();
+    const digest = `sha256:${"c".repeat(64)}`;
+    await revertRoutingServiceToBuild({
+      releaseName: "rel",
+      targetBuildId: "target-build",
+      registry: "gcr.io/p",
+      targetImageDigest: digest,
+    });
+    expect(patchBodies().join("\n")).toContain(`routing-service@${digest}`);
+  });
+});
+
 // N87 (SECURITY). The internal dispatch secret is per BUILD, so the edge's secretKeyRef has to
 // move with the image for the same reason NEXT_BUILD_ID does: a reverted edge still presenting
 // the rolled-away-from build's secret is rejected by the rolled-back pools, which then re-resolve

--- a/tests/cli/state.test.ts
+++ b/tests/cli/state.test.ts
@@ -265,6 +265,42 @@ describe("readState — N20: unreadable cluster state is never 'no deploys yet'"
     await expect(readState(tmpDir)).rejects.toBeInstanceOf(StateUnavailableError);
   });
 
+  it("rejects a state whose routingImageDigests are not digests — the CM is operator-mutable", async () => {
+    // routingImageDigests flows into revertRoutingServiceToBuild's `kubectl patch` image
+    // reference. edge.ts validates at consumption; isAdapterState is the belt-and-braces
+    // read-side guard: a tampered blob is "unknown" (N20 fail-closed), never deployable truth.
+    vi.mocked(execCapture).mockResolvedValue(CLUSTER_ABSENT);
+    writeLocal(tmpDir, {
+      buildId: "buildn",
+      previousBuildId: "buildm",
+      routingImageDigests: { buildm: "attacker.io/x@latest" },
+    });
+    await expect(readState(tmpDir)).rejects.toBeInstanceOf(LocalStateReadError);
+    // A non-build-id key is rejected too (it would be spliced into log lines and patches).
+    writeLocal(tmpDir, {
+      buildId: "buildn",
+      previousBuildId: "buildm",
+      routingImageDigests: { 'bad"\nkey': `sha256:${"a".repeat(64)}` },
+    });
+    await expect(readState(tmpDir)).rejects.toBeInstanceOf(LocalStateReadError);
+    // A well-formed digest map reads fine.
+    writeLocal(tmpDir, {
+      buildId: "buildn",
+      previousBuildId: "buildm",
+      routingImageDigests: { buildm: `sha256:${"a".repeat(64)}` },
+    });
+    await expect(readState(tmpDir)).resolves.toMatchObject({ buildId: "buildn" });
+    // The cluster-CM read applies the same guard.
+    vi.mocked(execCapture).mockResolvedValue(
+      clusterGet({
+        buildId: "buildn",
+        previousBuildId: "buildm",
+        routingImageDigests: { buildm: "not-a-digest" },
+      }),
+    );
+    await expect(readState(tmpDir, "rel")).rejects.toThrow(/routingImageDigests/);
+  });
+
   it("falls back to the local file when the ConfigMap is genuinely absent", async () => {
     vi.mocked(execCapture).mockResolvedValue(CLUSTER_ABSENT);
     writeLocal(tmpDir, { buildId: "local-only", previousBuildId: null });

--- a/tests/cutover/from-cluster.test.ts
+++ b/tests/cutover/from-cluster.test.ts
@@ -194,6 +194,32 @@ describe("readJobEmitMetadata — the mounted emit-metadata ConfigMap", () => {
     );
     expect(readWithout("namespace")).toThrow(/Invalid namespace/);
   });
+
+  it("assertSafe*: registry, digests, pool names and projectId — the image-injection battery", () => {
+    // `registry` + a `digests` value combine into the routing image a `kubectl patch` puts
+    // on the routing Deployment (revertRoutingServiceToBuild): an unvalidated pair is an
+    // arbitrary-image injection into the pod that starts with the release's dispatch
+    // secret. The ConfigMap is operator-mutable, so the check runs HERE, on the read.
+    expect(() =>
+      readJobEmitMetadata(mount(metadataFixture({ registry: "Evil.Registry.io/x" }))),
+    ).toThrow(/Invalid image registry/);
+    expect(() =>
+      readJobEmitMetadata(mount(metadataFixture({ registry: "attacker.io/x\nfoo: bar" }))),
+    ).toThrow(/Invalid image registry/);
+    expect(() =>
+      readJobEmitMetadata(mount(metadataFixture({ digests: { routingService: "latest" } }))),
+    ).toThrow(/not sha256:<64 hex>/);
+    expect(() =>
+      readJobEmitMetadata(mount(metadataFixture({ poolTopology: ["ssr", "Bad Pool"] }))),
+    ).toThrow(/Invalid pool name/);
+    expect(() => readJobEmitMetadata(mount(metadataFixture({ defaultPool: "-ssr" })))).toThrow(
+      /Invalid pool name/,
+    );
+    // projectId reaches a gcloud argv in the CDN-invalidation step.
+    expect(() => readJobEmitMetadata(mount(metadataFixture({ projectId: "x&calc" })))).toThrow(
+      /Invalid projectId/,
+    );
+  });
 });
 
 describe("isAlreadyPromoted — the cheap-idempotent short-circuit (§4.3)", () => {

--- a/tests/cutover/from-cluster.test.ts
+++ b/tests/cutover/from-cluster.test.ts
@@ -158,6 +158,12 @@ describe("readJobEmitMetadata — the mounted emit-metadata ConfigMap", () => {
     expect(readWithout("defaultPool")).toThrow(/no defaultPool — refusing to promote/);
   });
 
+  it("fail-closed: defaultPool is not a member of poolTopology", () => {
+    expect(() =>
+      readJobEmitMetadata(mount(metadataFixture({ poolTopology: ["ssr"], defaultPool: "worker" }))),
+    ).toThrow(/defaultPool must name one of its poolTopology entries/);
+  });
+
   it("fail-closed: no registry — the edge revert could not run", () => {
     expect(readWithout("registry")).toThrow(/no registry — the edge revert could not run/);
   });


### PR DESCRIPTION
### What?

Validate every ConfigMap-sourced value used to reconstruct or patch a routing-service image during cutover and rollback.

- validate the target build ID and image registry at the final point of consumption
- accept only `sha256:<64 hex>` routing digests from persisted state
- validate job metadata for registries, digests, pool topology, default pools, and GCP project IDs
- apply the existing infrastructure validation to `migrate` before it invokes a subprocess

### Why?

The cutover path assembled a routing Deployment image from mutable ConfigMap values without validating them. A namespace actor with `configmaps/update` could combine a tampered registry or digest with an induced gate failure and make the rollback path run an arbitrary routing image. That pod receives the internal dispatch credential, turning the validation gap into release-wide middleware bypass and arbitrary code execution.

### How?

`revertRoutingServiceToBuild` now validates the build ID and registry before cluster access. A malformed stored digest is ignored with a warning and falls back to the existing tag-based rollback path, while the in-cluster cutover job rejects malformed emitted metadata. Persisted adapter state with invalid digest keys or values is treated as unknown, and `migrate` now uses the same infrastructure validator as the other cluster-facing commands.

### Testing

- regression coverage for malformed registries, digests, pool metadata, project IDs, build IDs, and poisoned migration infrastructure
- valid digests remain pinned byte-for-byte; malformed digests fall back to the build tag
- `npm test`
- `npm run typecheck`
- `npm run lint`
- `npm run fmt:check`
