### PR TITLE
Pool-server hardening: fall-through header strip, probe verbosity, log and containment hygiene

### DIFF
--- a/src/pool-server/dispatch.ts
+++ b/src/pool-server/dispatch.ts
@@ -2957,8 +2957,11 @@ export function createDispatcher(options: DispatcherOptions) {
           // If no handler exists for this output, fall through to 404
           if (!handlerLoader.has(handlerPathname)) {
             if (!handlerLoader.has("/_not-found") && !handlerLoader.has("/404")) {
+              // Pathname only, never req.url — the raw query string routinely carries
+              // tokens and signed parameters (server.ts's request log follows the same
+              // rule), and this line fires on attacker-inducible 404s.
               console.log(
-                `[dispatch] 404: no handler for matchedPathname="${handlerPathname}" url="${req.url}"`,
+                `[dispatch] 404: no handler for matchedPathname="${handlerPathname}" url="${requestTargetPathname(req.url ?? "/")}"`,
               );
             }
             const bufferedBody = bufferedActionBody(req);

--- a/src/pool-server/index.ts
+++ b/src/pool-server/index.ts
@@ -2740,13 +2740,17 @@ export async function startPoolServer(): Promise<ReturnType<typeof createPoolSer
     // Serve _next/static/* and _next/data/* directly from filesystem.
     // In production, CDN handles these. In standalone/emulate mode, the pool server must serve them.
     if (!middlewareMayCover && staticPathname.startsWith("/_next/static/")) {
-      const filePath = path.join(
-        process.cwd(),
-        ".next",
-        "static",
+      // S30, same containment as the public/data/image disk serves: the request path is
+      // percent-encoded (so `%2f` stays a literal character and the WHATWG parser has
+      // already folded dot segments — lexical traversal is not possible here), but a bare
+      // path.join FOLLOWS SYMLINKS, and an escaping symlink inside .next/static is
+      // reachable under emulate/local dev against a working tree (a malicious postinstall,
+      // a committed symlink). resolveWithinRoot's realpath re-check closes exactly that.
+      const filePath = resolveWithinRoot(
+        path.join(process.cwd(), ".next", "static"),
         staticPathname.slice("/_next/static/".length),
       );
-      if (existsSync(filePath)) {
+      if (filePath && existsSync(filePath)) {
         // N31: a build asset answers GET/HEAD only. `next start`'s router-server sets
         // `Allow: GET, HEAD` and 405s every other method BEFORE serveStatic (measured:
         // POST/PUT/DELETE on a chunk → 405; the adapter used to answer 200 with the full body
@@ -3657,6 +3661,21 @@ export async function startPoolServer(): Promise<ReturnType<typeof createPoolSer
         ...(extDeadlineAt ? { executionDeadlineAt: extDeadlineAt } : {}),
       });
       return;
+    }
+
+    // The fall-through path: a secret-gated `x-output-id` was present but the middleware
+    // verdict was absent or untrusted, so Phase 1 re-derives EVERYTHING itself — the
+    // dispatch vocabulary is unusable here by construction. S22 deleted it only inside the
+    // trusted branch above; left in place on this path, `x-output-id`, `x-upstream-pool`,
+    // `x-route-matches`, `x-invoke-path`, `x-invoke-query`, `x-nextjs-ppr` and the execution
+    // deadline rode into resolveRoutes, the middleware invocation, the loopback handler
+    // request (dispatch.ts's toNodeHeaders copy) and EXTERNAL-REWRITE targets as ordinary
+    // request headers — leaking the internal routing state (rewrite destination included)
+    // to app code and off-cluster third parties. Strip both the live request and the
+    // `headers` snapshot taken at :2894 (resolve reads the snapshot, dispatch reads req).
+    for (const h of INTERNAL_DISPATCH_HEADERS) {
+      delete req.headers[h];
+      headers.delete(h);
     }
 
     // Phase 1: resolve route locally

--- a/src/pool-server/server.ts
+++ b/src/pool-server/server.ts
@@ -219,6 +219,13 @@ export function createPoolServer(options: PoolServerOptions) {
     appOwnsProbePath,
   } = options;
 
+  // /readyz detail goes to the pod LOG, not the wire: the probe interception runs before any
+  // trust check and the Gateway catch-all HTTPRoute forwards every path to this port, so the
+  // body is internet-visible. The reason string names internal route-output keys ("route
+  // module loaded (/ssr)") and startup state — a free side-channel into the release for any
+  // client. Log it once per transition; the probe consumer (kubelet, HealthCheckPolicy,
+  // cutover gate) reads only the status code.
+  let lastLoggedNotReady: string | undefined;
   const server: Server = createServer(async (req, res) => {
     // Probes bypass all routing — unless the app itself owns the pathname (see appOwnsProbePath).
     // The pathname is parsed rather than compared to the raw target so `/healthz?x=1` is still a
@@ -234,12 +241,18 @@ export function createPoolServer(options: PoolServerOptions) {
         return;
       }
       const state = readiness?.() ?? { ready: false, reason: "readiness state not wired" };
+      if (!state.ready && state.reason !== lastLoggedNotReady) {
+        lastLoggedNotReady = state.reason;
+        console.warn(`[pool-server] /readyz unavailable: ${state.reason}`);
+      } else if (state.ready) {
+        lastLoggedNotReady = undefined;
+      }
       res.writeHead(state.ready ? 200 : 503, {
         "content-type": "application/json",
         // A 503 must never be cached by the LB/CDN or a proxy between it and the kubelet.
         "cache-control": "no-store",
       });
-      res.end(JSON.stringify({ status: state.ready ? "ok" : "unavailable", reason: state.reason }));
+      res.end(JSON.stringify({ status: state.ready ? "ok" : "unavailable" }));
       return;
     }
 

--- a/tests/pool-server/dispatch.test.ts
+++ b/tests/pool-server/dispatch.test.ts
@@ -80,6 +80,47 @@ describe("createDispatcher", () => {
     ).toEqual({ slug: ["company", "about-us"] });
   });
 
+  it("logs the 404-no-handler line with the PATHNAME only — never the raw query string", async () => {
+    // server.ts's request log is pathname-only because the raw query routinely carries
+    // tokens and signed parameters; dispatch's 404 line fired on attacker-inducible 404s
+    // and logged `req.url` verbatim. Reachable on builds whose loader has neither
+    // `/_not-found` nor `/404` (an app-wide getInitialProps exposes no standalone 404).
+    const localHandlerInvoker = vi.fn().mockResolvedValue(undefined);
+    const handlerLoader = {
+      load: vi.fn(),
+      has: vi.fn().mockReturnValue(false),
+      get: vi.fn().mockReturnValue(undefined),
+    };
+    const dispatcher = createDispatcher({
+      handlerLoader: handlerLoader as any,
+      poolName: "ssr",
+      buildId: "test123",
+      staticAssets: [],
+      localHandlerInvoker,
+      revalidate: vi.fn(),
+    });
+    const logs: string[] = [];
+    const spy = vi
+      .spyOn(console, "log")
+      .mockImplementation((...args: unknown[]) => logs.push(args.map(String).join(" ")));
+    try {
+      await dispatcher.dispatch(mockReq("/definitely-missing?token=secret-token"), mockRes(), {
+        kind: "route",
+        pool: "ssr",
+        matchedPathname: "/definitely-missing",
+        routeMatches: null,
+        resolvedHeaders: undefined,
+      });
+    } finally {
+      spy.mockRestore();
+    }
+    const line = logs.find((l) => l.includes("[dispatch] 404"));
+    expect(line, `expected a [dispatch] 404 line in: ${logs.join("\n")}`).toBeDefined();
+    expect(line).toContain("/definitely-missing");
+    expect(line).not.toContain("secret-token");
+    expect(line).not.toContain("?");
+  });
+
   it("dispatches route to handler", async () => {
     const handler = vi.fn();
     const revalidate = vi.fn().mockResolvedValue(undefined);

--- a/tests/pool-server/index.hardening.test.ts
+++ b/tests/pool-server/index.hardening.test.ts
@@ -12,7 +12,7 @@
 // The staged dirs live UNDER THE REPO ROOT so createRequire(<staged>/package.json) can resolve
 // the repo's `next` (the pool requires several next/dist modules at boot).
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, symlinkSync } from "node:fs";
 import net, { type AddressInfo } from "node:net";
 import path from "node:path";
 import { createServer } from "node:http";
@@ -146,7 +146,8 @@ function writeStagedDir(options: StageOptions = {}): Staged {
     `,
   );
   // Echoes exactly what the handler observes on req.headers — the only way to prove that
-  // middleware's final request-header set was installed as a REPLACEMENT (N40).
+  // middleware's final request-header set was installed as a REPLACEMENT (N40), and that the
+  // dispatch vocabulary never leaks into Phase 1 (the fall-through strip).
   writeFileSync(
     path.join(dir, "handlers", "echo-headers.mjs"),
     `export function handler(req, res) {
@@ -157,6 +158,9 @@ function writeStagedDir(options: StageOptions = {}): Staged {
          mwRequestHeaders: req.headers["x-mw-request-headers"] ?? null,
          resolvedHeaders: req.headers["x-resolved-headers"] ?? null,
          internalSecret: req.headers["x-internal-secret"] ?? null,
+         outputId: req.headers["x-output-id"] ?? null,
+         upstreamPool: req.headers["x-upstream-pool"] ?? null,
+         invokePath: req.headers["x-invoke-path"] ?? null,
        }));
      }
     `,
@@ -468,6 +472,18 @@ describe("pool-server request-boundary hardening", () => {
       const res = await fetch(url("/_next/static/chunks/nope.js"));
       expect(res.status).toBe(404);
     });
+
+    it("S30: never follows a symlink that escapes .next/static", async () => {
+      // The percent-encoded request path makes lexical traversal impossible, but a bare
+      // path.join follows SYMLINKS — and under emulate/local dev the server runs against a
+      // working tree where a malicious postinstall or a committed symlink can plant one.
+      // Target: the staged "compiled server bundle" carrying the planted secret.
+      const target = path.join(pool.staged.dir, ".next", "server", "pages", "_app.js");
+      symlinkSync(target, path.join(pool.staged.dir, ".next", "static", "leak.js"));
+      const res = await fetch(url("/_next/static/leak.js"));
+      expect(res.status).toBe(404);
+      expect(await res.text()).not.toContain(PLANTED_SECRET);
+    });
   });
 
   // ---- N35: one shared image byte cap ----
@@ -484,12 +500,17 @@ describe("pool-server request-boundary hardening", () => {
 
   // ---- N32: readiness ----
   describe("N32: /readyz on a healthy build", () => {
-    it("reports ready, and names what it verified", async () => {
+    it("reports ready — WITHOUT internal detail on the wire", async () => {
+      // The probe interception runs before any trust check and the Gateway catch-all
+      // forwards every path to this port, so the body is internet-visible. The reason
+      // string names internal route-output keys and startup state: it goes to the pod
+      // log, never the response body.
       const res = await fetch(url("/readyz"));
       expect(res.status).toBe(200);
-      const body = (await res.json()) as { status: string; reason: string };
+      const body = (await res.json()) as { status: string; reason?: string };
       expect(body.status).toBe("ok");
-      expect(body.reason).toContain("route module loaded");
+      expect(body.reason).toBeUndefined();
+      expect(Object.keys(body)).toEqual(["status"]);
       expect(res.headers.get("cache-control")).toBe("no-store");
     });
 
@@ -558,9 +579,9 @@ describe("N32: /readyz goes ready on a basePath build (manifest keys prefixed, N
     // gate timed every basePath rollout out — the full run's ~20-suite basePath cluster.
     const res = await fetch(`http://localhost:${pool.port}/readyz`);
     expect(res.status).toBe(200);
-    const body = (await res.json()) as { status: string; reason: string };
+    const body = (await res.json()) as { status: string; reason?: string };
     expect(body.status).toBe("ok");
-    expect(body.reason).toContain("route module loaded");
+    expect(body.reason).toBeUndefined();
   });
 });
 
@@ -580,12 +601,16 @@ describe("N32: /readyz withholds traffic from a build whose route module cannot 
     expect(await res.json()).toEqual({ status: "ok" });
   });
 
-  it("answers /readyz 503 with the reason", async () => {
+  it("answers /readyz 503 — the reason is logged, not served to the internet", async () => {
     const res = await fetch(`http://localhost:${pool.port}/readyz`);
     expect(res.status).toBe(503);
-    const body = (await res.json()) as { status: string; reason: string };
+    const body = (await res.json()) as { status: string; reason?: string };
     expect(body.status).toBe("unavailable");
-    expect(body.reason).toContain("failed to load");
+    // The failure detail ("route module X failed to load") names internal route-output
+    // keys: pod logs carry it (boot logs it at error level, and server.ts logs the /readyz
+    // transition), the internet-visible body must not.
+    expect(body.reason).toBeUndefined();
+    expect(Object.keys(body)).toEqual(["status"]);
   });
 
   it("and the app route it could not load does 500 — which is what the gate must catch", async () => {
@@ -700,6 +725,9 @@ describe("N40: Phase 2 installs the middleware's final request-header set", () =
       mwRequestHeaders: string | null;
       resolvedHeaders: string | null;
       internalSecret: string | null;
+      outputId: string | null;
+      upstreamPool: string | null;
+      invokePath: string | null;
     };
   }
 
@@ -726,6 +754,42 @@ describe("N40: Phase 2 installs the middleware's final request-header set", () =
     });
     expect(body.mwRequestHeaders).toBeNull();
     expect(body.resolvedHeaders).toBeNull();
+    expect(body.internalSecret).toBeNull();
+  });
+
+  it("RED TEAM: valid secret + ABSENT mw verdict fails safe to Phase 1 — and leaks NO dispatch vocabulary", async () => {
+    // The fall-through case: `x-output-id` proved trust but nothing asserts the middleware
+    // stage ran (a broken/custom extension), so the pool re-resolves locally. The dispatch
+    // headers are transport, not request data — before the strip, they reached the handler
+    // (and middleware, and external-rewrite targets) as ordinary request headers.
+    const body = await echo(
+      {
+        "x-internal-secret": SECRET,
+        "x-output-id": "/echo-headers",
+        "x-upstream-pool": "main",
+        "x-invoke-path": "/echo-headers",
+        "x-route-matches": "{}",
+      },
+      "/echo-headers",
+    );
+    expect(body.outputId).toBeNull();
+    expect(body.upstreamPool).toBeNull();
+    expect(body.invokePath).toBeNull();
+    expect(body.internalSecret).toBeNull();
+  });
+
+  it("RED TEAM: an UNRECOGNIZED mw verdict gets the same treatment", async () => {
+    const body = await echo(
+      {
+        "x-internal-secret": SECRET,
+        "x-output-id": "/echo-headers",
+        "x-mw-evaluated": "trust-me-bro",
+        "x-upstream-pool": "main",
+      },
+      "/echo-headers",
+    );
+    expect(body.outputId).toBeNull();
+    expect(body.upstreamPool).toBeNull();
     expect(body.internalSecret).toBeNull();
   });
 


### PR DESCRIPTION
### What?

Harden four pool-server boundaries found during the security audit:

- strip the complete internal dispatch vocabulary before fail-safe local resolution
- remove internal readiness reasons from the public `/readyz` response
- log only the pathname for dispatch 404s
- serve `/_next/static` files through the same realpath containment check as other disk-backed assets

### Why?

A request with a valid secret but an absent or untrusted middleware verdict correctly falls back to local resolution, but its internal routing headers previously remained visible to middleware, application code, and external rewrite targets. Separately, `/readyz` exposed release-state details, 404 logs retained query strings, and the static fast path could follow a symlink outside `.next/static` in local or emulated deployments.

### How?

Both the live Node headers and the `Headers` snapshot used by local resolution are sanitized before the fallback path runs. Readiness reasons move to transition logs while the wire response keeps only `{ status }`. Dispatch logging parses the URL and records the pathname, and the static fast path now uses `resolveWithinRoot`.

The production routing service and cross-pool proxy always provide a trusted middleware verdict, so the dispatch-header change affects broken, custom, or forged phase-two metadata rather than the normal request path.

### Testing

- regression coverage for absent and unrecognized middleware verdicts at the real handler boundary
- `/readyz` response coverage for both 200 and 503 states
- query-string redaction and escaping-symlink coverage
- `npm test`
- `npm run typecheck`
- `npm run lint`
- `npm run fmt:check`
