### PR TITLE
Track removed SSE content type during shutdown

### DIFF
--- a/src/pool-server/server.ts
+++ b/src/pool-server/server.ts
@@ -434,6 +434,12 @@ export function createPoolServer(options: PoolServerOptions) {
       }
       return originalSetHeader(name, value);
     }) as ServerResponse["setHeader"];
+    const originalRemoveHeader = res.removeHeader.bind(res);
+    res.removeHeader = ((name: string) => {
+      const result = originalRemoveHeader(name);
+      if (name.toLowerCase() === "content-type") responseState.eventStream = false;
+      return result;
+    }) as ServerResponse["removeHeader"];
     const originalTrackedWriteHead = res.writeHead.bind(res);
     (res as any).writeHead = function (statusCode: number, ...args: unknown[]) {
       const contentType = writeHeadHeaderValue(args, "content-type");

--- a/tests/pool-server/server-shutdown.test.ts
+++ b/tests/pool-server/server-shutdown.test.ts
@@ -255,6 +255,41 @@ describe("createPoolServer().stop()", () => {
     pool = null;
   });
 
+  it("resets a finite body when an earlier SSE content type was removed", async () => {
+    pool = createPoolServer({
+      onRequest: (_req: IncomingMessage, res: ServerResponse) => {
+        res.setHeader("content-type", "text/event-stream");
+        res.removeHeader("content-type");
+        res.write("partial-body");
+        // Never finishes. The final response is no longer SSE, so shutdown must reset it rather
+        // than turn the partial chunked body into a cleanly terminated representation.
+      },
+      port: 0,
+    });
+    const { port } = await pool.start();
+
+    let responseStarted!: () => void;
+    const started = new Promise<void>((resolve) => (responseStarted = resolve));
+    const aborted = new Promise<boolean>((resolve, reject) => {
+      httpGet({ host: "127.0.0.1", port, path: "/finite-after-sse" }, (res) => {
+        responseStarted();
+        res.on("data", () => undefined);
+        res.on("aborted", () => resolve(true));
+        res.on("end", () => resolve(false));
+        res.on("error", (error) => {
+          if ((error as NodeJS.ErrnoException).code === "ECONNRESET") resolve(true);
+          else reject(error);
+        });
+      }).on("error", reject);
+    });
+    await started;
+
+    const drain = pool.stop({ graceMs: 180 });
+    await expect(aborted).resolves.toBe(true);
+    await drain;
+    pool = null;
+  });
+
   it("rejects pipelined work that arrives on an existing connection after drain starts", async () => {
     let firstResponse!: ServerResponse;
     let firstStarted!: () => void;


### PR DESCRIPTION
## Summary

- clear shutdown's SSE classification when a handler removes the content-type header
- reset stalled finite responses instead of ending a partial chunked body cleanly
- cover the behavior with a real-socket regression test

## Testing

-  RUN  v4.1.10 /home/james/Code/nextjs/adapter-k8s

 Test Files  1 passed (1)
      Tests  12 passed (12)
   Start at  22:30:25
   Duration  2.31s (transform 134ms, setup 0ms, import 183ms, tests 2.07s, environment 0ms)\n- 
> @next-community/adapter-k8s@0.0.0 test
> vitest run


 RUN  v4.1.10 /home/james/Code/nextjs/adapter-k8s

hello
fast

 Test Files  138 passed | 8 skipped (146)
      Tests  2929 passed | 56 skipped (2985)
   Start at  22:30:27
   Duration  11.21s (transform 31.41s, setup 0ms, import 51.32s, tests 32.67s, environment 10ms)\n- 