### PR TITLE
Fix WebSocket handshake rejection, tunnel close-frame splicing, and x-forwarded-proto parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,9 +288,12 @@ Current boundaries are deliberate:
   ingress/load-balancer timeout. State continuity needs an application cursor/session token and
   shared replay/pub-sub; a live connection cannot be transferred between pods.
 - During shutdown the pod stops accepting upgrades, gives established sockets the configured
-  bounded shutdown window, sends close code `1001` (going away) on the sockets it owns, and then
-  force-closes survivors. A socket tunnelled to another pool gets no injected frame — that pipe is
-  frame-blind, so the owning pool's own close frame is relayed instead.
+  bounded shutdown window, sends close code `1001` (going away), and then force-closes survivors. A
+  socket tunnelled to another pool is relayed byte-for-byte, so it gets the `1001` only when its
+  relayed frame stream is provably between frames at that instant; a socket caught mid-frame gets
+  no injected close frame (splicing one into a frame's payload would corrupt it) and ends in an
+  abnormal closure unless the peer pool happens to be draining too. The drain log's `tunnelled=`
+  counter is exactly that population.
 
 The same rollout contract covers finite response streams and SSE, including clean SSE EOF and
 `Last-Event-ID` replay guidance. See [deploy lifecycle](./docs/lifecycle.md#long-lived-requests-during-cutover).

--- a/README.md
+++ b/README.md
@@ -288,7 +288,9 @@ Current boundaries are deliberate:
   ingress/load-balancer timeout. State continuity needs an application cursor/session token and
   shared replay/pub-sub; a live connection cannot be transferred between pods.
 - During shutdown the pod stops accepting upgrades, gives established sockets the configured
-  bounded shutdown window, sends close code `1001` (going away), and then force-closes survivors.
+  bounded shutdown window, sends close code `1001` (going away) on the sockets it owns, and then
+  force-closes survivors. A socket tunnelled to another pool gets no injected frame — that pipe is
+  frame-blind, so the owning pool's own close frame is relayed instead.
 
 The same rollout contract covers finite response streams and SSE, including clean SSE EOF and
 `Last-Event-ID` replay guidance. See [deploy lifecycle](./docs/lifecycle.md#long-lived-requests-during-cutover).

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -44,6 +44,13 @@ The terminal behavior is protocol-specific:
   before bounded forced teardown. Clients should reconnect with jittered backoff and send an
   application cursor/session token when missed state matters. Cross-pod topics and replay require
   shared pub/sub or storage; socket state itself is not transferable.
+- A WebSocket **tunnelled to another pool** of the same build is the one exception: the pod
+  relaying it does not own its framing, so it injects no close frame — a relayed frame can be only
+  partly written at that instant, and a `1001` written there would land inside that frame's
+  payload. It relays the owning pool's own `1001` if that pool is draining too (a rollout drains
+  every pool of the build), then tears the tunnel down within the same bounded window. A client
+  whose tunnel is dropped without a close frame sees an abnormal closure and must reconnect, which
+  is what the reconnect guidance above already requires.
 
 For the generic Envoy target, generated application rules disable Envoy's 15-second total route
 deadline with `timeouts.request: 0s`; the gateway's stream-idle timeout still detects a connection

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -44,13 +44,17 @@ The terminal behavior is protocol-specific:
   before bounded forced teardown. Clients should reconnect with jittered backoff and send an
   application cursor/session token when missed state matters. Cross-pod topics and replay require
   shared pub/sub or storage; socket state itself is not transferable.
-- A WebSocket **tunnelled to another pool** of the same build is the one exception: the pod
-  relaying it does not own its framing, so it injects no close frame — a relayed frame can be only
-  partly written at that instant, and a `1001` written there would land inside that frame's
-  payload. It relays the owning pool's own `1001` if that pool is draining too (a rollout drains
-  every pool of the build), then tears the tunnel down within the same bounded window. A client
-  whose tunnel is dropped without a close frame sees an abnormal closure and must reconnect, which
-  is what the reconnect guidance above already requires.
+- A WebSocket **tunnelled to another pool** of the same build is the one qualified case: the pod
+  relaying it does not own its framing, so it may only write a close frame where the relayed byte
+  stream sits between frames. It checks: an idle tunnel — the ordinary case, and the only one for a
+  tunnel that never carried a frame — gets the same clean `1001`. A tunnel caught mid-frame gets
+  nothing injected, because a `1001` written there would land inside the payload the frame's header
+  already promised. Such a client sees the owning pool's own `1001` relayed only if that pool is
+  draining at the same moment (a full-build rollout drains every pool, but a per-pool HPA
+  scale-down or single-pod eviction does not), and otherwise an abnormal closure — which is what
+  the reconnect guidance above already requires. `tunnelled=` on the drain-complete line counts the
+  tunnels that could not be given a `1001`; a persistent non-zero value under scale-down is the
+  signal that clients are ending on close code 1006.
 
 For the generic Envoy target, generated application rules disable Envoy's 15-second total route
 deadline with `timeouts.request: 0s`; the gateway's stream-idle timeout still detects a connection

--- a/docs/targets.md
+++ b/docs/targets.md
@@ -58,12 +58,20 @@ Use `gatewayApiExposure` instead for any conformant GatewayClass.
 **One requirement on whatever terminates TLS.** The pool's own socket is always plaintext, so
 `x-forwarded-proto` is its only witness of the client-facing scheme: it decides middleware's
 request URL, whether a middleware redirect `Location` is same-origin, and the origin a WebSocket
-handshake's `Origin` header is compared against. The adapter reads the **rightmost** element of
-that header's comma-joined chain, so the requirement is only that your ingress be the last hop to
-write it — overwriting (Envoy, and Envoy Gateway with the default zero trusted hops) and appending
-(the `X-Forwarded-For` convention) both satisfy it. An ingress that forwards a client-supplied
-`x-forwarded-proto` unchanged does not, and an https app behind it would evaluate its own routing
-against a scheme the client chose.
+handshake's `Origin` header is compared against. **It must reach the pool single-valued, written by
+the hop that terminated TLS.** Envoy — and Envoy Gateway, with the default zero trusted hops —
+overwrites it from the downstream connection's TLS state, so both emitted topologies satisfy this
+with no configuration. Two ways operator-supplied ingress can break it:
+
+- **Forwarding a client-supplied value unchanged.** Then an https app evaluates its own routing
+  against a scheme the client chose. Overwrite it at the edge.
+- **An appending intermediary between the TLS terminator and the pool.** Append conventions are
+  client-first (the `X-Forwarded-For` ordering, standardized in RFC 7239), so a second hop turns
+  the header into `https,http` — its own plaintext observation on the right. The adapter reads the
+  **leftmost** element, so it still derives `https`, but Next's own `x-forwarded-proto` handling
+  treats only the exact single value `https` as secure and will read `http` from that chain
+  regardless. Anything the app derives itself (absolute URLs, its own redirects) is then wrong even
+  though adapter-level routing is right. Configure the inner hop to overwrite, not append.
 
 ### TLS for dedicated exposures (cert-manager)
 

--- a/docs/targets.md
+++ b/docs/targets.md
@@ -55,6 +55,16 @@ export default createK8sAdapter({
 
 Use `gatewayApiExposure` instead for any conformant GatewayClass.
 
+**One requirement on whatever terminates TLS.** The pool's own socket is always plaintext, so
+`x-forwarded-proto` is its only witness of the client-facing scheme: it decides middleware's
+request URL, whether a middleware redirect `Location` is same-origin, and the origin a WebSocket
+handshake's `Origin` header is compared against. The adapter reads the **rightmost** element of
+that header's comma-joined chain, so the requirement is only that your ingress be the last hop to
+write it — overwriting (Envoy, and Envoy Gateway with the default zero trusted hops) and appending
+(the `X-Forwarded-For` convention) both satisfy it. An ingress that forwards a client-supplied
+`x-forwarded-proto` unchanged does not, and an https app behind it would evaluate its own routing
+against a scheme the client chose.
+
 ### TLS for dedicated exposures (cert-manager)
 
 A dedicated Gateway or Ingress terminates TLS from a Secret **in the app's namespace** — Gateway `certificateRefs` and Ingress `spec.tls` are namespace-local. Wildcard-cert fleets typically keep their certificate in the gateway owner's namespace (e.g. `network`), so no such Secret exists per app namespace. Both dedicated exposures accept `certManager` to emit a `cert-manager.io/v1` Certificate that issues it in place:

--- a/src/pool-server/dispatch.ts
+++ b/src/pool-server/dispatch.ts
@@ -96,45 +96,71 @@ const FORWARDED_HOST_RE = /^[a-zA-Z0-9.-]+(:[0-9]{1,5})?$/;
 // must compare a browser's `Origin: https://…` against `https://…`, not against the plain-http
 // scheme of the pool's own socket.
 //
-// S25. The RIGHTMOST value wins, and this is the whole reason the parse is centralized here.
-// X-Forwarded-* chains grow to the RIGHT: under append semantics the leftmost element is the one
-// the CLIENT supplied and the rightmost is the one added by the hop closest to this pool, i.e. the
-// trusted edge. Reading the leftmost element (as this did) means that in any topology whose edge
-// appends instead of overwriting, the pool derives its public scheme — and therefore the
-// WebSocket handshake's same-origin authority, middleware's request URL, and the
-// relative-vs-absolute middleware redirect decision — from a value the client chose.
+// S25. The LEFTMOST value wins, and pinning that down is the whole reason the parse is
+// centralized here. Both supported topologies OVERWRITE, so a single element is what actually
+// arrives and every reading of it is byte-identical; element order only decides what happens in a
+// topology that APPENDS, and there the leftmost element is the client-facing one:
+//   • RFC 7239 §4 — the standardized form of this field, and the equivalent MDN points at —
+//     orders its element list client-first, so the `proto` of the connection the client actually
+//     made is the FIRST element. De-facto `x-forwarded-proto` follows the `X-Forwarded-For`
+//     convention it was cloned from, which is client-first for the same reason: each proxy
+//     appends what it saw on the connection IT received. The hop that terminates TLS is the
+//     OUTERMOST one, so it contributes the LEFTMOST element, while an appending intermediary
+//     between it and this pool saw the already-decrypted plaintext leg and contributes the
+//     rightmost. "The last hop to write it" and "the trusted edge" are therefore opposite ends of
+//     an appended chain — reading the rightmost element derives `http` for an https site behind a
+//     TLS-terminating outer LB, which is a 403 on every browser `wss://` handshake against the
+//     app's own origin (webSocketRequestAuthority), an `http://` initURL, and a same-origin
+//     middleware redirect emitted absolute with the wrong scheme.
+//   • Leftmost is also what the ecosystem reads and what operators configure against: Express's
+//     `req.protocol` takes the substring before the first comma.
 //
-// Both supported topologies are believed to OVERWRITE, so a single value is what actually
-// arrives, and rightmost then reads identically to leftmost:
-//   • Generic provider (Envoy Gateway / the emitted Envoy in front of the pool): Envoy treats
-//     x-forwarded-proto as SINGLE-valued and sets it from the downstream connection's TLS state,
-//     honoring a downstream value only when `xff_num_trusted_hops` is non-zero — which nothing
-//     the adapter emits configures (see client-traffic-policy.ts: the only ClientTrafficPolicy
-//     knob emitted is escapedSlashesAction), so the default of zero trusted hops applies and
-//     Envoy never appends.
+// What a leftmost read gives up is a client PREPENDING an element of its own in an appending
+// topology (client sends `https`, a hop appends `http`, leftmost → https). That buys an attacker
+// nothing reachable. The value is load-bearing only for this request's own derived scheme, and
+// the single security decision it feeds — websocket-upgrade.ts's same-origin `Origin` check —
+// exists to stop a hostile WEB PAGE, which cannot put a request header on a WebSocket handshake
+// at all (the browser WebSocket API admits no custom headers) and cannot get one past CORS
+// preflight elsewhere. A non-browser client is not constrained by `Origin` in the first place, so
+// moving the scheme gains it nothing either. An unreachable spoof does not justify a permanent
+// 403 for a legitimate topology, so the fail-safe direction here is the ecosystem's ordering.
+//
+// Both EMITTED topologies overwrite, which is why any of this is only a requirement on
+// operator-supplied ingress (docs/targets.md):
+//   • Generic provider (Envoy Gateway / the emitted Envoy in front of the pool): Envoy's HCM
+//     documents that downstream `x-forwarded-proto` headers are trusted only when
+//     `xff_num_trusted_hops` is non-zero, and that when it is zero the downstream
+//     `x-forwarded-proto` and `:scheme` are SET from whether the downstream connection is TLS.
+//     Nothing the adapter emits configures that knob (see client-traffic-policy.ts: the only
+//     ClientTrafficPolicy knob emitted is escapedSlashesAction) and integration/envoy.yaml sets
+//     no XFF knob either, so the zero default applies and Envoy overwrites with a single value.
 //   • GKE / GXLB: the load-balancer header documentation is explicit that X-Forwarded-For is
 //     appended to and specifies X-Forwarded-Proto as a single `[http | https]` value, but it does
 //     NOT state overwrite-vs-append for it. That is the same gap routing-common.ts's
 //     PROOF_COVERED_CONTEXT_HEADERS operational note already records for this header.
-// Rightmost is therefore the fail-safe reading: identical under overwrite, correct under append,
-// and it cannot be turned into a downgrade by a client prepending values of its own.
 //
-// A garbage rightmost element yields undefined rather than falling further left, so a client
-// cannot promote its own value past a trusted one by appending junk. Empty elements are skipped
-// (a trusted edge never writes an empty scheme). Comparison is case-insensitive because URI
-// schemes are (RFC 3986 §3.1) and treating `HTTPS` as unknown silently downgrades the derived
-// scheme to http; it grants nothing extra, since a client that can write `HTTPS` can write
-// `https`. The proof binds the RAW wire bytes (routing-common.ts), so none of this parsing is
-// part of the covered value.
+// A garbage leftmost element yields undefined rather than falling further right: junk in the
+// client-facing position means there is no witness, and an https site must not be derived from a
+// hop that only ever saw the plaintext leg. Empty elements are skipped (no hop writes an empty
+// scheme). Comparison is case-insensitive because URI schemes are (RFC 3986 §3.1) and treating
+// `HTTPS` as unknown silently downgrades the derived scheme; it grants nothing extra, since a
+// client that can write `HTTPS` can write `https`. The proof binds the RAW wire bytes
+// (routing-common.ts), so none of this parsing is part of the covered value.
+//
+// One asymmetry no reading here can fix, which docs/targets.md states as the operator
+// requirement instead: Next's own base-server derives `isHttps` from
+// `xForwardedProto === "https"` — an EXACT single value (node_modules/next/dist/server/
+// base-server.js) — so on ANY comma-joined chain Next itself reads http regardless of which
+// element this picks. A multi-valued chain is a misconfigured ingress for the whole app, not
+// just for this witness.
 export function validatedForwardedProtocol(req: IncomingMessage): "http" | "https" | undefined {
   const forwardedProto = req.headers["x-forwarded-proto"];
   // Repeated header instances are semantically one comma-joined list (RFC 9110 §5.3). Node
   // already joins them for this field; joining an array shape too keeps both identical.
   const chain = Array.isArray(forwardedProto) ? forwardedProto.join(",") : forwardedProto;
   if (!chain) return undefined;
-  const elements = chain.split(",");
-  for (let index = elements.length - 1; index >= 0; index--) {
-    const value = elements[index]!.trim().toLowerCase();
+  for (const element of chain.split(",")) {
+    const value = element.trim().toLowerCase();
     if (!value) continue;
     return value === "https" || value === "http" ? value : undefined;
   }

--- a/src/pool-server/dispatch.ts
+++ b/src/pool-server/dispatch.ts
@@ -95,14 +95,50 @@ const FORWARDED_HOST_RE = /^[a-zA-Z0-9.-]+(:[0-9]{1,5})?$/;
 // from the same witness this file uses — an https site behind the TLS-terminating load balancer
 // must compare a browser's `Origin: https://…` against `https://…`, not against the plain-http
 // scheme of the pool's own socket.
+//
+// S25. The RIGHTMOST value wins, and this is the whole reason the parse is centralized here.
+// X-Forwarded-* chains grow to the RIGHT: under append semantics the leftmost element is the one
+// the CLIENT supplied and the rightmost is the one added by the hop closest to this pool, i.e. the
+// trusted edge. Reading the leftmost element (as this did) means that in any topology whose edge
+// appends instead of overwriting, the pool derives its public scheme — and therefore the
+// WebSocket handshake's same-origin authority, middleware's request URL, and the
+// relative-vs-absolute middleware redirect decision — from a value the client chose.
+//
+// Both supported topologies are believed to OVERWRITE, so a single value is what actually
+// arrives, and rightmost then reads identically to leftmost:
+//   • Generic provider (Envoy Gateway / the emitted Envoy in front of the pool): Envoy treats
+//     x-forwarded-proto as SINGLE-valued and sets it from the downstream connection's TLS state,
+//     honoring a downstream value only when `xff_num_trusted_hops` is non-zero — which nothing
+//     the adapter emits configures (see client-traffic-policy.ts: the only ClientTrafficPolicy
+//     knob emitted is escapedSlashesAction), so the default of zero trusted hops applies and
+//     Envoy never appends.
+//   • GKE / GXLB: the load-balancer header documentation is explicit that X-Forwarded-For is
+//     appended to and specifies X-Forwarded-Proto as a single `[http | https]` value, but it does
+//     NOT state overwrite-vs-append for it. That is the same gap routing-common.ts's
+//     PROOF_COVERED_CONTEXT_HEADERS operational note already records for this header.
+// Rightmost is therefore the fail-safe reading: identical under overwrite, correct under append,
+// and it cannot be turned into a downgrade by a client prepending values of its own.
+//
+// A garbage rightmost element yields undefined rather than falling further left, so a client
+// cannot promote its own value past a trusted one by appending junk. Empty elements are skipped
+// (a trusted edge never writes an empty scheme). Comparison is case-insensitive because URI
+// schemes are (RFC 3986 §3.1) and treating `HTTPS` as unknown silently downgrades the derived
+// scheme to http; it grants nothing extra, since a client that can write `HTTPS` can write
+// `https`. The proof binds the RAW wire bytes (routing-common.ts), so none of this parsing is
+// part of the covered value.
 export function validatedForwardedProtocol(req: IncomingMessage): "http" | "https" | undefined {
   const forwardedProto = req.headers["x-forwarded-proto"];
-  const forwardedProtoValue = (Array.isArray(forwardedProto) ? forwardedProto[0] : forwardedProto)
-    ?.split(",")[0]
-    ?.trim();
-  return forwardedProtoValue === "https" || forwardedProtoValue === "http"
-    ? forwardedProtoValue
-    : undefined;
+  // Repeated header instances are semantically one comma-joined list (RFC 9110 §5.3). Node
+  // already joins them for this field; joining an array shape too keeps both identical.
+  const chain = Array.isArray(forwardedProto) ? forwardedProto.join(",") : forwardedProto;
+  if (!chain) return undefined;
+  const elements = chain.split(",");
+  for (let index = elements.length - 1; index >= 0; index--) {
+    const value = elements[index]!.trim().toLowerCase();
+    if (!value) continue;
+    return value === "https" || value === "http" ? value : undefined;
+  }
+  return undefined;
 }
 
 // Effective public scheme of a request that reached this pool. TLS terminates at the load

--- a/src/pool-server/index.ts
+++ b/src/pool-server/index.ts
@@ -2349,7 +2349,17 @@ export async function startPoolServer(): Promise<ReturnType<typeof createPoolSer
   const pinnedWebSocket = appRequire("next/dist/compiled/ws") as {
     extension?: { parse?: (value: string) => unknown };
   };
-  const parseWebSocketExtensions = pinnedWebSocket.extension?.parse;
+  // N89. Optional on purpose, and absent in practice: the compiled bundle exports only the ws
+  // transport classes, so `extension` is undefined for every Next release the adapter has seen
+  // (16.3.0 included). The handshake validator skips adapter-side Sec-WebSocket-Extensions
+  // validation when this is undefined instead of failing the handshake — Next's generated ws
+  // stack is what negotiates extensions, and it parses the header itself. The lookup stays so a
+  // future Next that does export the parser is used immediately, and the shape is checked because
+  // a non-callable `extension.parse` would otherwise throw inside the handshake path.
+  const parseWebSocketExtensions =
+    typeof pinnedWebSocket.extension?.parse === "function"
+      ? pinnedWebSocket.extension.parse
+      : undefined;
   const { createRequestResponseMocks } = appRequire("next/dist/server/lib/mock-request") as {
     createRequestResponseMocks(options: {
       url: string;

--- a/src/pool-server/server.ts
+++ b/src/pool-server/server.ts
@@ -10,6 +10,9 @@ import {
   verifyDispatchProof,
 } from "../routing-common.js";
 import { guardStreamErrors } from "./dispatch.js";
+// A leaf: it knows about byte positions in a relayed frame stream and nothing about dispatch, so
+// importing it keeps the "no dependency on the dispatcher" property `onUpgrade` is spelled out for.
+import { injectTunnelCloseFrame } from "./websocket-frame-cursor.js";
 import {
   metricHttpMethod,
   recordPoolRequest,
@@ -232,7 +235,8 @@ export interface PoolServerOptions {
    * disposition marks the still-open socket as an established WebSocket for graceful shutdown,
    * and says who owns its FRAMING — `accepted-local` for a socket Next's ws stack writes frames
    * into (shutdown may stamp RFC 6455 code 1001 itself), `accepted-tunnel` for one end of a
-   * frame-blind cross-pool byte pipe (shutdown must inject nothing). N90 in
+   * cross-pool byte pipe whose framing nothing here owns (shutdown may stamp 1001 only where the
+   * N91 cursor proves the relayed stream sits between frames). N90 in
    * websocket-upgrade.ts `UpgradeDisposition` carries the full derivation; the union is spelled
    * out here rather than imported so this transport keeps no dependency on the dispatcher.
    */
@@ -306,7 +310,12 @@ interface ActiveResponseState {
  * flight, while wsForced counts the SEPARATE later act of destroying a socket that outlived the
  * terminal flush window. A socket signalled with 1001 and then destroyed appears in both
  * (signalled=1 wsForced=1) — the 1001 says what the peer was told, wsForced says how the socket
- * ended. tunnelled is the N90 split: a cross-pool tunnel that gets no injected frame at all.
+ * ended. tunnelled is the N90/N91 split: a cross-pool tunnel that could NOT be given a 1001,
+ * because its client-bound relay was mid-frame at that instant or had already relayed the peer
+ * pool's own close frame. A tunnel that was between frames is counted in signalled with every
+ * other socket the client heard 1001 from — the counter is about what the peer was told, not about
+ * which code path told it — so a rising tunnelled is the population that ends abnormally (ws 1006)
+ * and is worth an operator's attention on its own.
  */
 interface DrainMetrics {
   httpAtStart: number;
@@ -656,8 +665,9 @@ export function createPoolServer(options: PoolServerOptions) {
      * active responses use the COMPLETE grace window, then close each surviving protocol
      * honestly. SSE receives a normal EOF (EventSource can reconnect); an incomplete finite body
      * is reset rather than pretending truncated bytes are complete; an established WebSocket this
-     * pod OWNS gets RFC 6455 code 1001 before forced teardown, while a cross-pool tunnel is left
-     * un-injected and only relays the back pool's own close frame (N90). Errors are swallowed — "already closing" and
+     * pod OWNS gets RFC 6455 code 1001 before forced teardown, and a cross-pool tunnel gets one
+     * only where its relayed frame stream is provably between frames (N90/N91). Errors are
+     * swallowed — "already closing" and
      * "never started" are the only outcomes, and neither should stop a caller from exiting.
      */
     async stop(options: { graceMs?: number } = {}): Promise<void> {
@@ -736,18 +746,27 @@ export function createPoolServer(options: PoolServerOptions) {
                   drainMetrics.webSocketsSignalled += 1;
                   socket.write(goingAway);
                 } else if (state.ownership === "tunnel") {
-                  // N90. A cross-pool tunnel is a frame-blind byte pipe
-                  // (websocket-upgrade.ts proxyUpgradeToPool), so a frame relayed from the back
-                  // pool may be only partly written into this socket right now — its header has
-                  // already promised N more payload bytes. Writing 1001 here puts close-frame
-                  // bytes INSIDE that payload and corrupts the stream, which is strictly worse
-                  // than no close frame at all. Inject nothing: the pipe stays open through the
-                  // terminal flush window below, so the sibling pool's own drain (a rollout
-                  // SIGTERMs every pool of the build) can emit its 1001 to its client — this
-                  // socket — at a real frame boundary and have it relayed intact. The forced
-                  // destroy that follows takes the upstream connection with it through the
-                  // tunnel's teardown pair, which is how the back pool learns the peer is gone.
-                  drainMetrics.webSocketsTunnelled += 1;
+                  // N90. A cross-pool tunnel (websocket-upgrade.ts proxyUpgradeToPool) is a byte
+                  // pipe whose framing nothing here owns: a frame relayed from the peer pool may
+                  // be only partly written into this socket right now, its header already having
+                  // promised N more payload bytes. Writing 1001 blindly puts close-frame bytes
+                  // INSIDE that payload and corrupts the stream — strictly worse than no close
+                  // frame at all.
+                  //
+                  // N91 (websocket-frame-cursor.ts) makes the position knowable, so ask instead of
+                  // assume. Between frames — the ordinary case for an idle tunnel, and the only
+                  // case for one that never carried a frame — the client gets a real 1001. Mid
+                  // frame, or once the peer's own close frame has already been relayed, nothing is
+                  // injected: the pipe stays open through the terminal flush window so a peer pool
+                  // that is draining too can emit its 1001 at a real boundary and have it relayed
+                  // intact. Either way the forced destroy that follows takes the upstream
+                  // connection with it through the tunnel's teardown pair, which is how the peer
+                  // pool learns the client is gone.
+                  if (injectTunnelCloseFrame(socket, goingAway)) {
+                    drainMetrics.webSocketsSignalled += 1;
+                  } else {
+                    drainMetrics.webSocketsTunnelled += 1;
+                  }
                 } else {
                   socket.end();
                 }

--- a/src/pool-server/server.ts
+++ b/src/pool-server/server.ts
@@ -228,14 +228,23 @@ export function filterWriteHeadHeadersArg(
 export interface PoolServerOptions {
   onRequest: (req: IncomingMessage, res: ServerResponse) => void | Promise<void>;
   /**
-   * Node upgrade transport used by Next's generated App Route `upgradeHandler`. Returning
-   * `accepted` marks the still-open socket as an established WebSocket for graceful shutdown.
+   * Node upgrade transport used by Next's generated App Route `upgradeHandler`. An accepting
+   * disposition marks the still-open socket as an established WebSocket for graceful shutdown,
+   * and says who owns its FRAMING — `accepted-local` for a socket Next's ws stack writes frames
+   * into (shutdown may stamp RFC 6455 code 1001 itself), `accepted-tunnel` for one end of a
+   * frame-blind cross-pool byte pipe (shutdown must inject nothing). N90 in
+   * websocket-upgrade.ts `UpgradeDisposition` carries the full derivation; the union is spelled
+   * out here rather than imported so this transport keeps no dependency on the dispatcher.
    */
   onUpgrade?: (
     req: IncomingMessage,
     socket: Duplex,
     head: Buffer,
-  ) => "accepted" | "rejected" | Promise<"accepted" | "rejected">;
+  ) =>
+    | "accepted-local"
+    | "accepted-tunnel"
+    | "rejected"
+    | Promise<"accepted-local" | "accepted-tunnel" | "rejected">;
   port: number;
   /**
    * When true, trust x-output-id etc. from the request WITHOUT a secret. Legacy fallback used
@@ -286,11 +295,18 @@ interface ActiveResponseState {
 }
 
 /**
- * One drain outcome per tracked response, and one per tracked socket. The HTTP categories
- * (completed, clientClosed, sseEnded, sseForced, httpForceClosed) are mutually exclusive and never
- * sum past httpAtStart — an operator reading the single "drain complete" line after an incident has
- * to be able to add them up, so a response that receives an SSE EOF and is then destroyed because
- * the EOF never flushed must land in exactly one of them (sseForced), not in two.
+ * One drain outcome per tracked response, and one terminal SIGNAL per tracked socket. The HTTP
+ * categories (completed, clientClosed, sseEnded, sseForced, httpForceClosed) are mutually exclusive
+ * and never sum past httpAtStart — an operator reading the single "drain complete" line after an
+ * incident has to be able to add them up, so a response that receives an SSE EOF and is then
+ * destroyed because the EOF never flushed must land in exactly one of them (sseForced), not in two.
+ *
+ * The WebSocket counters partition differently, and deliberately: peerClosed, signalled and
+ * tunnelled are mutually exclusive and sum to webSocketsAtStart minus the handshakes still in
+ * flight, while wsForced counts the SEPARATE later act of destroying a socket that outlived the
+ * terminal flush window. A socket signalled with 1001 and then destroyed appears in both
+ * (signalled=1 wsForced=1) — the 1001 says what the peer was told, wsForced says how the socket
+ * ended. tunnelled is the N90 split: a cross-pool tunnel that gets no injected frame at all.
  */
 interface DrainMetrics {
   httpAtStart: number;
@@ -302,6 +318,7 @@ interface DrainMetrics {
   webSocketsAtStart: number;
   webSocketsPeerClosed: number;
   webSocketsSignalled: number;
+  webSocketsTunnelled: number;
   webSocketsForceClosed: number;
 }
 
@@ -365,7 +382,13 @@ export function createPoolServer(options: PoolServerOptions) {
   // shutdown can let finite responses complete, end SSE with a reconnectable EOF, and close a
   // WebSocket with RFC 6455 code 1001 instead of applying one blunt socket operation to all three.
   const activeResponses = new Map<ServerResponse, ActiveResponseState>();
-  const upgradedSockets = new Map<Duplex, { accepted: boolean; serverSignalled: boolean }>();
+  // `ownership` starts as "handshake" — still an HTTP exchange, so it gets an HTTP close rather
+  // than a WebSocket frame — and becomes "local" or "tunnel" from the upgrade disposition. N90:
+  // only "local" sockets may be written into during drain.
+  const upgradedSockets = new Map<
+    Duplex,
+    { ownership: "handshake" | "local" | "tunnel"; serverSignalled: boolean }
+  >();
   let draining = false;
   let drainMetrics: DrainMetrics | undefined;
   let stopPromise: Promise<void> | undefined;
@@ -541,7 +564,8 @@ export function createPoolServer(options: PoolServerOptions) {
         trustInternalHeaders,
         proofHeaderNames,
       });
-      const socketState = { accepted: false, serverSignalled: false };
+      const socketState: { ownership: "handshake" | "local" | "tunnel"; serverSignalled: boolean } =
+        { ownership: "handshake", serverSignalled: false };
       upgradedSockets.set(socket, socketState);
       socket.once("close", () => {
         upgradedSockets.delete(socket);
@@ -556,7 +580,9 @@ export function createPoolServer(options: PoolServerOptions) {
       Promise.resolve(onUpgrade(req, socket, head))
         .then((disposition) => {
           const state = upgradedSockets.get(socket);
-          if (state && disposition === "accepted") state.accepted = true;
+          if (state && disposition !== "rejected") {
+            state.ownership = disposition === "accepted-tunnel" ? "tunnel" : "local";
+          }
           if (disposition === "rejected" && !socket.destroyed && !socket.writableEnded) {
             // The SERVER is ending this handshake. Without the flag a rejection that lands after
             // drain begins is reported as webSocketsPeerClosed — a voluntary peer departure the
@@ -629,8 +655,9 @@ export function createPoolServer(options: PoolServerOptions) {
      * This form always settles: stop accepting, drop idle keep-alive sockets immediately, let
      * active responses use the COMPLETE grace window, then close each surviving protocol
      * honestly. SSE receives a normal EOF (EventSource can reconnect); an incomplete finite body
-     * is reset rather than pretending truncated bytes are complete; established WebSockets get
-     * RFC 6455 code 1001 before forced teardown. Errors are swallowed — "already closing" and
+     * is reset rather than pretending truncated bytes are complete; an established WebSocket this
+     * pod OWNS gets RFC 6455 code 1001 before forced teardown, while a cross-pool tunnel is left
+     * un-injected and only relays the back pool's own close frame (N90). Errors are swallowed — "already closing" and
      * "never started" are the only outcomes, and neither should stop a caller from exiting.
      */
     async stop(options: { graceMs?: number } = {}): Promise<void> {
@@ -651,6 +678,7 @@ export function createPoolServer(options: PoolServerOptions) {
           webSocketsAtStart: upgradedSockets.size,
           webSocketsPeerClosed: 0,
           webSocketsSignalled: 0,
+          webSocketsTunnelled: 0,
           webSocketsForceClosed: 0,
         };
 
@@ -704,9 +732,22 @@ export function createPoolServer(options: PoolServerOptions) {
             try {
               if (!socket.destroyed) {
                 state.serverSignalled = true;
-                if (state.accepted) {
+                if (state.ownership === "local") {
                   drainMetrics.webSocketsSignalled += 1;
                   socket.write(goingAway);
+                } else if (state.ownership === "tunnel") {
+                  // N90. A cross-pool tunnel is a frame-blind byte pipe
+                  // (websocket-upgrade.ts proxyUpgradeToPool), so a frame relayed from the back
+                  // pool may be only partly written into this socket right now — its header has
+                  // already promised N more payload bytes. Writing 1001 here puts close-frame
+                  // bytes INSIDE that payload and corrupts the stream, which is strictly worse
+                  // than no close frame at all. Inject nothing: the pipe stays open through the
+                  // terminal flush window below, so the sibling pool's own drain (a rollout
+                  // SIGTERMs every pool of the build) can emit its 1001 to its client — this
+                  // socket — at a real frame boundary and have it relayed intact. The forced
+                  // destroy that follows takes the upstream connection with it through the
+                  // tunnel's teardown pair, which is how the back pool learns the peer is gone.
+                  drainMetrics.webSocketsTunnelled += 1;
                 } else {
                   socket.end();
                 }
@@ -759,6 +800,7 @@ export function createPoolServer(options: PoolServerOptions) {
             `webSockets=${drainMetrics.webSocketsAtStart} ` +
             `peerClosed=${drainMetrics.webSocketsPeerClosed} ` +
             `signalled=${drainMetrics.webSocketsSignalled} ` +
+            `tunnelled=${drainMetrics.webSocketsTunnelled} ` +
             `wsForced=${drainMetrics.webSocketsForceClosed}`,
         );
       })();

--- a/src/pool-server/websocket-frame-cursor.ts
+++ b/src/pool-server/websocket-frame-cursor.ts
@@ -1,0 +1,155 @@
+// src/pool-server/websocket-frame-cursor.ts
+import type { Duplex } from "node:stream";
+
+/**
+ * N91. Where a cross-pool WebSocket tunnel's CLIENT-BOUND byte stream currently sits, so shutdown
+ * can tell "between frames" from "halfway through a relayed frame".
+ *
+ * N90 (websocket-upgrade.ts `UpgradeDisposition`) established that a tunnel must never be written
+ * into blindly: `proxySocket.pipe(socket)` relays the sibling pool's frames as raw bytes, a frame
+ * routinely spans several TCP chunks, and a `1001` written while one is half-relayed lands INSIDE
+ * that frame's declared payload. Refusing to write at all is the safe answer to that, but it is
+ * the wrong DEFAULT: the relay only carries the sibling's own close frame when the sibling pool is
+ * draining at the same moment, and pools are separate Deployments with per-pool HPAs
+ * (emit/templates/hpa.ts). A front pool scaling 3→2, a single-pod eviction, or a rollout touching
+ * only one pool's Deployment leaves the peer pool healthy and silent, so those tunnelled clients
+ * would get no close frame at all — partial bytes then a TCP destroy, i.e. ws code 1006 — where a
+ * blind injection at least gave the common (idle, frame-aligned) tunnel a clean 1001.
+ *
+ * So track the one thing that decides between the two: the client-bound relay's frame position.
+ * Only the payload LENGTH matters, so this reads headers and skips payloads — it does not decode,
+ * validate or reassemble anything, and permessage-deflate is transparent to it (compression
+ * changes payload bytes, not framing). The direction it tracks is server→client, which RFC 6455
+ * §5.1 requires to be unmasked, so a header is 2 bytes plus at most an 8-byte extended length.
+ *
+ * Every uncertainty is fail-closed to "not a boundary", which is exactly the N90 behavior of
+ * injecting nothing: an untracked socket, a masked or over-long header (a stream this cannot be
+ * reasoning about correctly), a partly received header, a partly relayed payload, or a close frame
+ * the sibling already sent. The worst case of this cursor is therefore the branch's un-injected
+ * behavior; it can only ADD close frames in provably safe positions.
+ */
+class ClientBoundFrameCursor {
+  /** Cleared for good once the stream stops looking like unmasked server framing. */
+  #trackable = true;
+  #payloadRemaining = 0;
+  /** Header bytes seen for the frame currently being parsed; empty means "expecting a header". */
+  #header: number[] = [];
+  #closeRelayed = false;
+  /** Set when shutdown has taken the relay over, so nothing further is credited to the client. */
+  #relayStopped = false;
+  readonly #detachRelay: () => void;
+
+  constructor(detachRelay: () => void) {
+    this.#detachRelay = detachRelay;
+  }
+
+  observe(chunk: Buffer): void {
+    if (!this.#trackable) return;
+    let offset = 0;
+    while (offset < chunk.length) {
+      if (this.#payloadRemaining > 0) {
+        // Bulk skip: payload bytes carry no framing, so the loop is O(frames), not O(bytes).
+        const consumed = Math.min(this.#payloadRemaining, chunk.length - offset);
+        this.#payloadRemaining -= consumed;
+        offset += consumed;
+        continue;
+      }
+      this.#header.push(chunk[offset]!);
+      offset += 1;
+      const parsed = parseFrameHeader(this.#header);
+      if (parsed === "incomplete") continue;
+      if (parsed === "untrackable") {
+        this.#trackable = false;
+        return;
+      }
+      this.#payloadRemaining = parsed.payloadLength;
+      if (parsed.close) this.#closeRelayed = true;
+      this.#header = [];
+    }
+  }
+
+  atFrameBoundary(): boolean {
+    return (
+      this.#trackable &&
+      !this.#relayStopped &&
+      !this.#closeRelayed &&
+      this.#payloadRemaining === 0 &&
+      this.#header.length === 0
+    );
+  }
+
+  stopRelay(): void {
+    this.#relayStopped = true;
+    this.#detachRelay();
+  }
+}
+
+type ParsedFrameHeader = { payloadLength: number; close: boolean };
+
+/**
+ * Length (and closeness) of the frame whose header these bytes begin, or why that is not knowable
+ * yet — or at all. `masked` is the "not at all" case: RFC 6455 §5.1 forbids a server from masking,
+ * so a mask bit in this direction means the bytes are not the frame stream this thinks they are
+ * (a sibling that is not a WebSocket endpoint, a stream already desynchronized) and no position in
+ * it can be trusted again.
+ */
+function parseFrameHeader(
+  header: readonly number[],
+): ParsedFrameHeader | "incomplete" | "untrackable" {
+  if (header.length < 2) return "incomplete";
+  const close = (header[0]! & 0x0f) === 0x8;
+  if ((header[1]! & 0x80) !== 0) return "untrackable";
+  const length7 = header[1]! & 0x7f;
+  if (length7 < 126) return { payloadLength: length7, close };
+  if (length7 === 126) {
+    if (header.length < 4) return "incomplete";
+    return { payloadLength: (header[2]! << 8) | header[3]!, close };
+  }
+  if (header.length < 10) return "incomplete";
+  // 64-bit length. Anything past Number.MAX_SAFE_INTEGER cannot be counted down in a JS number,
+  // and no real peer sends it, so stop tracking rather than mis-track.
+  let payloadLength = 0;
+  for (let index = 2; index < 10; index++) {
+    payloadLength = payloadLength * 256 + header[index]!;
+    if (!Number.isSafeInteger(payloadLength)) return "untrackable";
+  }
+  return { payloadLength, close };
+}
+
+/**
+ * Keyed by the CLIENT socket, which is the socket createPoolServer's drain iterates and the only
+ * handle it has. Weak so a closed tunnel's cursor is collected with its socket.
+ */
+const cursors = new WeakMap<Duplex, ClientBoundFrameCursor>();
+
+/**
+ * Start tracking the client-bound direction of a tunnel. `relayedHead` is the frame bytes the
+ * upgrade response already carried (`proxyHead`), which are written to the client before the pipe
+ * exists and are therefore part of the same stream.
+ */
+export function trackTunnelFraming(clientSocket: Duplex, poolSocket: Duplex, relayedHead: Buffer) {
+  const cursor = new ClientBoundFrameCursor(() => poolSocket.unpipe(clientSocket));
+  cursors.set(clientSocket, cursor);
+  if (relayedHead.length > 0) cursor.observe(relayedHead);
+  // Attached after `pipe()` deliberately: `pipe()` already resumed the source, and resumption is
+  // scheduled (process.nextTick), so no chunk can be emitted between the two calls — while
+  // attaching a `data` listener FIRST would resume the source before the destination exists.
+  poolSocket.on("data", (chunk: Buffer) => cursor.observe(chunk));
+}
+
+/**
+ * Write a close frame into a tunnel if — and only if — the client-bound relay is provably between
+ * frames (N91). Returns whether it was written; `false` means the N90 outcome, no injected frame.
+ *
+ * The relay is detached on success so the injected frame is the last thing the client sees: once
+ * this pod has told the client "going away" on the peer's behalf, forwarding further frames from a
+ * peer that has not closed is a different kind of lie, and the pipe is destroyed within the
+ * terminal flush window regardless.
+ */
+export function injectTunnelCloseFrame(clientSocket: Duplex, closeFrame: Buffer): boolean {
+  const cursor = cursors.get(clientSocket);
+  if (!cursor?.atFrameBoundary()) return false;
+  cursor.stopRelay();
+  clientSocket.write(closeFrame);
+  return true;
+}

--- a/src/pool-server/websocket-upgrade.ts
+++ b/src/pool-server/websocket-upgrade.ts
@@ -31,6 +31,7 @@ import {
 } from "./dispatch.js";
 import type { HandlerLoader } from "./handler-loader.js";
 import type { ResolveResult } from "./resolve.js";
+import { trackTunnelFraming } from "./websocket-frame-cursor.js";
 
 /**
  * N90. Who owns FRAMING on an accepted socket, which is what shutdown needs to know before it
@@ -39,12 +40,13 @@ import type { ResolveResult } from "./resolve.js";
  * - `accepted-local`: Next's generated ws stack owns this socket. It writes each frame
  *   synchronously under cork, so a close frame injected between frames cannot interleave with a
  *   partially written one — the drain path may stamp RFC 6455 code 1001 itself.
- * - `accepted-tunnel`: the socket is one end of `proxyUpgradeToPool`'s frame-blind byte pipe. A
- *   frame relayed from the sibling pool routinely spans several TCP chunks, so at any instant the
- *   client may hold a partially relayed frame whose header already promised N more payload bytes.
- *   Injecting a close frame there lands close-frame bytes INSIDE that payload and corrupts the
- *   stream. The drain path relays whatever close frame the back pool's own drain emits (correctly
- *   framed, at a frame boundary) and then tears the tunnel down, injecting nothing.
+ * - `accepted-tunnel`: the socket is one end of `proxyUpgradeToPool`'s byte pipe. Nothing here
+ *   owns its framing: a frame relayed from the sibling pool routinely spans several TCP chunks, so
+ *   at any instant the client may hold a partially relayed frame whose header already promised N
+ *   more payload bytes, and a close frame written there lands INSIDE that payload and corrupts the
+ *   stream. The drain path therefore asks websocket-frame-cursor.ts whether the client-bound relay
+ *   is provably between frames (N91) and injects only then; otherwise it injects nothing and
+ *   relays whatever close frame the peer pool's own drain emits.
  *
  * Deliberately not a boolean `accepted`: conflating the two ownership models is exactly what put
  * a close frame into the middle of a relayed frame, so every accepting path must now say which.
@@ -846,8 +848,8 @@ async function proxyUpgradeToPool(
       // Either end closing takes the other with it, so shutdown needs no separate handle on the
       // upstream socket: when the drain path destroys the client socket after its bounded flush
       // window, this teardown closes the sibling-pool connection in the same tick and the back
-      // pool's generated stack sees its peer leave. N90: the drain path must NOT write into
-      // either end of this pipe — see UpgradeDisposition.
+      // pool's generated stack sees its peer leave. N90: the drain path may write into the client
+      // end ONLY at a frame boundary, which is what the N91 cursor below exists to establish.
       const teardown = () => {
         if (!socket.destroyed) socket.destroy();
         if (!proxySocket.destroyed) proxySocket.destroy();
@@ -858,6 +860,9 @@ async function proxyUpgradeToPool(
       proxySocket.on("close", teardown);
       socket.pipe(proxySocket);
       proxySocket.pipe(socket);
+      // N91. Track only the CLIENT-BOUND direction: it is the one shutdown may write into, and
+      // `proxyHead` is already part of that stream (it was written above, before the pipe existed).
+      trackTunnelFraming(socket, proxySocket, proxyHead);
       finish("accepted-tunnel");
     });
 

--- a/src/pool-server/websocket-upgrade.ts
+++ b/src/pool-server/websocket-upgrade.ts
@@ -255,13 +255,29 @@ function validateWebSocketHandshake(
       seen.add(protocol);
     }
   }
+  // Sec-WebSocket-Extensions is validated ONLY when the app's pinned ws transport actually
+  // exports its parser — RFC 6455's extension grammar has enough edge cases that a hand-rolled
+  // approximation would drift from what the ws stack downstream accepts, and two disagreeing
+  // parsers on one handshake is worse than one.
+  //
+  // N89. The adapter must DEGRADE, not fail, when that parser is absent. `next/dist/compiled/ws`
+  // is an nccc bundle whose only public exports are the transport classes (CONNECTING…CLOSED,
+  // createWebSocketStream, Server, Receiver, Sender, WebSocket, WebSocketServer) — `extension` is
+  // internal to the bundle and is NOT exported as of Next 16.3.0. Throwing here therefore fired
+  // on every handshake carrying this header, i.e. every real browser (all of them offer
+  // permessage-deflate): the rejected promise landed in createPoolServer's upgrade `.catch`,
+  // which destroyed the socket after writing ZERO bytes, so the client saw a bare TCP close
+  // rather than any HTTP status and the pod logged one "Unhandled WebSocket upgrade error" per
+  // attempt. Skipping the check keeps browser WebSockets working and costs no trust boundary:
+  // nothing in this file reads the extensions header (unlike host/origin/key/version, which
+  // decide same-origin and handshake validity), it is relayed verbatim on a cross-pool hop, and
+  // the party that negotiates extensions is Next's generated ws stack — `WebSocketServer`
+  // parses this header itself and answers 400 when perMessageDeflate is enabled, and ignores it
+  // (negotiating nothing, so framing stays plain RFC 6455) when it is not. An unparseable value
+  // can therefore never reach frame decoding as an active extension.
   const extensions = rawHeaderValues(req, "sec-websocket-extensions");
-  if (extensions.length > 0) {
-    if (!parseWebSocketExtensions) {
-      throw new Error("The vendored WebSocket extension parser is unavailable.");
-    }
+  if (extensions.length > 0 && parseWebSocketExtensions) {
     try {
-      // RFC 6455 grammar has enough edge cases that a hand-rolled approximation will drift.
       // Use the exact parser pinned by the application's Next transport, as Next itself does.
       parseWebSocketExtensions(extensions.join(","));
     } catch {

--- a/src/pool-server/websocket-upgrade.ts
+++ b/src/pool-server/websocket-upgrade.ts
@@ -32,7 +32,24 @@ import {
 import type { HandlerLoader } from "./handler-loader.js";
 import type { ResolveResult } from "./resolve.js";
 
-export type UpgradeDisposition = "accepted" | "rejected";
+/**
+ * N90. Who owns FRAMING on an accepted socket, which is what shutdown needs to know before it
+ * writes anything into one (createPoolServer's drain, and the same union on its `onUpgrade`).
+ *
+ * - `accepted-local`: Next's generated ws stack owns this socket. It writes each frame
+ *   synchronously under cork, so a close frame injected between frames cannot interleave with a
+ *   partially written one — the drain path may stamp RFC 6455 code 1001 itself.
+ * - `accepted-tunnel`: the socket is one end of `proxyUpgradeToPool`'s frame-blind byte pipe. A
+ *   frame relayed from the sibling pool routinely spans several TCP chunks, so at any instant the
+ *   client may hold a partially relayed frame whose header already promised N more payload bytes.
+ *   Injecting a close frame there lands close-frame bytes INSIDE that payload and corrupts the
+ *   stream. The drain path relays whatever close frame the back pool's own drain emits (correctly
+ *   framed, at a frame boundary) and then tears the tunnel down, injecting nothing.
+ *
+ * Deliberately not a boolean `accepted`: conflating the two ownership models is exactly what put
+ * a close frame into the middle of a relayed frame, so every accepting path must now say which.
+ */
+export type UpgradeDisposition = "accepted-local" | "accepted-tunnel" | "rejected";
 
 export interface WebSocketUpgradeDispatcher {
   resolve(
@@ -442,7 +459,8 @@ function generatedUpgradeDisposition(outcome: unknown): UpgradeDisposition {
   ) {
     throw new TypeError("Next generated upgradeHandler returned an inconsistent upgrade outcome");
   }
-  return upgraded ? "accepted" : "rejected";
+  // Accepted here means the GENERATED entrypoint took the socket, so ws owns its framing.
+  return upgraded ? "accepted-local" : "rejected";
 }
 
 /** Read the proof-gated phase-two routing verdict, then erase the transport vocabulary. */
@@ -825,6 +843,11 @@ async function proxyUpgradeToPool(
         return;
       }
 
+      // Either end closing takes the other with it, so shutdown needs no separate handle on the
+      // upstream socket: when the drain path destroys the client socket after its bounded flush
+      // window, this teardown closes the sibling-pool connection in the same tick and the back
+      // pool's generated stack sees its peer leave. N90: the drain path must NOT write into
+      // either end of this pipe — see UpgradeDisposition.
       const teardown = () => {
         if (!socket.destroyed) socket.destroy();
         if (!proxySocket.destroyed) proxySocket.destroy();
@@ -835,7 +858,7 @@ async function proxyUpgradeToPool(
       proxySocket.on("close", teardown);
       socket.pipe(proxySocket);
       proxySocket.pipe(socket);
-      finish("accepted");
+      finish("accepted-tunnel");
     });
 
     proxyReq.once("response", (proxyRes) => {

--- a/tests/pool-server/forwarded-proto.test.ts
+++ b/tests/pool-server/forwarded-proto.test.ts
@@ -4,6 +4,11 @@
 // request URL, the relative-vs-absolute middleware redirect comparison, and — since WebSocket
 // support landed — the same-origin authority a browser's `Origin` is compared against. The parse
 // had no test of its own, so nothing pinned which element of a multi-hop chain wins.
+//
+// The pinned answer is the LEFTMOST element: append conventions are client-first (RFC 7239 §4
+// orders elements client-first; `X-Forwarded-For` does the same), so the TLS-terminating outer hop
+// contributes the leftmost element and an appending inner hop — which only ever saw the plaintext
+// leg — contributes the rightmost. See S25 in src/pool-server/dispatch.ts.
 import { describe, expect, it } from "vitest";
 import type { IncomingMessage } from "node:http";
 import { validatedForwardedProtocol } from "../../src/pool-server/dispatch.js";
@@ -22,12 +27,13 @@ describe("validatedForwardedProtocol", () => {
     ["http", "http", "single plaintext value"],
     ["HTTPS", "https", "URI schemes are case-insensitive (RFC 3986 §3.1)"],
     ["  Https  ", "https", "optional whitespace around a list element"],
-    ["http,https", "https", "rightmost hop wins: the edge appended https"],
-    // The spoof case. Leftmost parsing returned "https" here — a client-supplied value overriding
-    // the trusted edge's own witness.
-    ["https,http", "http", "rightmost hop wins: the client prepended https, the edge said http"],
-    ["https, http", "http", "Node joins repeated header instances into one comma list"],
-    [["https", "http"], "http", "array shape (repeated instances) is joined, not indexed"],
+    // The topology this ordering exists for: a TLS-terminating outer LB writes https, an appending
+    // inner hop adds its own plaintext observation. Reading the rightmost element here derives
+    // http and 403s every browser wss:// handshake against the app's own origin.
+    ["https,http", "https", "leftmost hop wins: the TLS terminator is the outermost hop"],
+    ["https, http", "https", "Node joins repeated header instances into one comma list"],
+    ["http,https", "http", "leftmost hop wins: the client-facing leg was plaintext"],
+    [["https", "http"], "https", "array shape (repeated instances) is joined, not indexed"],
     [["http"], "http", "single-element array shape"],
     ["https,", "https", "trailing empty element is skipped, not treated as garbage"],
     [",https", "https", "leading empty element"],
@@ -36,10 +42,12 @@ describe("validatedForwardedProtocol", () => {
     ["javascript", undefined, "not one of the two real schemes"],
     ["wss", undefined, "the handshake's URL scheme is not a forwarding witness"],
     ["httpsx", undefined, "no prefix matching"],
-    // Garbage on the right must NOT fall back to the element on its left: that would let a client
-    // promote its own value past the trusted edge's by appending junk.
-    ["https,javascript", undefined, "garbage rightmost element does not fall further left"],
-    ["https,http;q=1", undefined, "parameters are not part of this field's grammar"],
+    // Garbage in the client-facing position must NOT fall through to the element on its right:
+    // that element belongs to a hop which only ever saw the plaintext leg, so it cannot stand in
+    // as a witness of the client's scheme.
+    ["javascript,https", undefined, "garbage leftmost element does not fall further right"],
+    ["https;q=1,https", undefined, "parameters are not part of this field's grammar"],
+    ["https,javascript", "https", "junk appended by an inner hop cannot demote the outer hop"],
   ] as const)("%j → %s (%s)", (value, expected) => {
     expect(validatedForwardedProtocol(withHeader(value as string | string[] | undefined))).toBe(
       expected,

--- a/tests/pool-server/forwarded-proto.test.ts
+++ b/tests/pool-server/forwarded-proto.test.ts
@@ -1,0 +1,48 @@
+// tests/pool-server/forwarded-proto.test.ts
+// S25: x-forwarded-proto is the pool's ONLY witness of the client-facing scheme (TLS terminates at
+// the load balancer, so the pool's own socket is always plain http). It decides middleware's
+// request URL, the relative-vs-absolute middleware redirect comparison, and — since WebSocket
+// support landed — the same-origin authority a browser's `Origin` is compared against. The parse
+// had no test of its own, so nothing pinned which element of a multi-hop chain wins.
+import { describe, expect, it } from "vitest";
+import type { IncomingMessage } from "node:http";
+import { validatedForwardedProtocol } from "../../src/pool-server/dispatch.js";
+
+function withHeader(value: string | string[] | undefined): IncomingMessage {
+  return {
+    headers: value === undefined ? {} : { "x-forwarded-proto": value },
+  } as IncomingMessage;
+}
+
+describe("validatedForwardedProtocol", () => {
+  it.each([
+    // [x-forwarded-proto, expected, why]
+    [undefined, undefined, "absent: the caller falls back to http (or socket.encrypted)"],
+    ["https", "https", "single value stamped by the trusted edge"],
+    ["http", "http", "single plaintext value"],
+    ["HTTPS", "https", "URI schemes are case-insensitive (RFC 3986 §3.1)"],
+    ["  Https  ", "https", "optional whitespace around a list element"],
+    ["http,https", "https", "rightmost hop wins: the edge appended https"],
+    // The spoof case. Leftmost parsing returned "https" here — a client-supplied value overriding
+    // the trusted edge's own witness.
+    ["https,http", "http", "rightmost hop wins: the client prepended https, the edge said http"],
+    ["https, http", "http", "Node joins repeated header instances into one comma list"],
+    [["https", "http"], "http", "array shape (repeated instances) is joined, not indexed"],
+    [["http"], "http", "single-element array shape"],
+    ["https,", "https", "trailing empty element is skipped, not treated as garbage"],
+    [",https", "https", "leading empty element"],
+    ["", undefined, "empty header value carries no witness"],
+    ["   ", undefined, "whitespace-only header value carries no witness"],
+    ["javascript", undefined, "not one of the two real schemes"],
+    ["wss", undefined, "the handshake's URL scheme is not a forwarding witness"],
+    ["httpsx", undefined, "no prefix matching"],
+    // Garbage on the right must NOT fall back to the element on its left: that would let a client
+    // promote its own value past the trusted edge's by appending junk.
+    ["https,javascript", undefined, "garbage rightmost element does not fall further left"],
+    ["https,http;q=1", undefined, "parameters are not part of this field's grammar"],
+  ] as const)("%j → %s (%s)", (value, expected) => {
+    expect(validatedForwardedProtocol(withHeader(value as string | string[] | undefined))).toBe(
+      expected,
+    );
+  });
+});

--- a/tests/pool-server/portable-rollout.integration.test.ts
+++ b/tests/pool-server/portable-rollout.integration.test.ts
@@ -56,7 +56,7 @@ function websocketHandler(build: string) {
         `Sec-WebSocket-Accept: ${accept}\r\n\r\n`,
     );
     socket.write(websocketFrame(build));
-    return "accepted" as const;
+    return "accepted-local" as const;
   };
 }
 

--- a/tests/pool-server/server-shutdown.test.ts
+++ b/tests/pool-server/server-shutdown.test.ts
@@ -384,17 +384,21 @@ describe("createPoolServer().stop()", () => {
     pool = null;
   });
 
-  it("relays a tunnelled WebSocket's own close frame instead of injecting one mid-frame", async () => {
-    // N90. A cross-pool tunnel (websocket-upgrade.ts proxyUpgradeToPool) is a frame-BLIND byte
-    // pipe: a frame relayed from the sibling pool routinely spans several TCP chunks, so at drain
-    // time this pool's client can hold a partially relayed frame whose header already promised
-    // more payload. Writing the 1001 frame that a locally owned socket gets would put close-frame
-    // bytes inside that payload — the client reads a header promising N bytes and gets 0x88 …
-    // instead. Real sockets and a real sibling server throughout: the corruption only exists at
-    // the byte level, and a mock pipe could not have shown it.
-    const partialFrame = Buffer.from([0x81, 0x08, 0x61, 0x62]); // header claims 8 bytes, 2 sent
-    const restOfFrame = Buffer.from("cdefgh");
-    const siblingGoingAway = Buffer.from([0x88, 0x02, 0x03, 0xe9]);
+  // N90/N91. A cross-pool tunnel (websocket-upgrade.ts proxyUpgradeToPool) is a byte pipe whose
+  // framing nothing in this pod owns: a frame relayed from the sibling pool routinely spans several
+  // TCP chunks, so at drain time this pool's client can hold a partially relayed frame whose header
+  // already promised more payload. Writing the 1001 frame a locally owned socket gets would put
+  // close-frame bytes inside that payload — the client reads a header promising N bytes and gets
+  // 0x88 … instead. Real sockets and a real sibling server throughout: the corruption only exists
+  // at the byte level, and a mock pipe could not have shown it.
+  //
+  // GRACE/TIMING NOTE, because it is what makes these tests able to fail: `stop()`'s poll loop
+  // cannot break early while a socket is still tracked, so with graceMs=200 it signals at ~200ms
+  // and then holds the terminal flush window (min(250, graceMs) = 200ms) until ~400ms. A sibling
+  // write BEFORE 200ms therefore tests "the frame was already complete when we signalled"; a write
+  // between 200ms and 400ms tests the actual mid-frame instant, where a regression splices its
+  // 1001 between the two halves rather than merely appending bytes at the end.
+  async function tunnelledPool(onSiblingUpgrade: (socket: Duplex) => void) {
     let siblingSocket: Duplex | undefined;
     const sibling = createServer();
     sibling.on("upgrade", (_req, socket) => {
@@ -403,7 +407,7 @@ describe("createPoolServer().stop()", () => {
       socket.write(
         "HTTP/1.1 101 Switching Protocols\r\nConnection: Upgrade\r\nUpgrade: websocket\r\n\r\n",
       );
-      socket.write(partialFrame);
+      onSiblingUpgrade(socket);
     });
     await new Promise<void>((resolve) => sibling.listen(0, "127.0.0.1", () => resolve()));
     const siblingAddress = sibling.address();
@@ -411,7 +415,7 @@ describe("createPoolServer().stop()", () => {
       throw new Error("missing sibling pool address");
     }
 
-    pool = createPoolServer({
+    const poolServer = createPoolServer({
       onRequest: () => undefined,
       onUpgrade: (req, socket, head) =>
         handleWebSocketUpgrade(
@@ -438,7 +442,8 @@ describe("createPoolServer().stop()", () => {
         ),
       port: 0,
     });
-    const { port } = await pool.start();
+    pool = poolServer;
+    const { port } = await poolServer.start();
     const socket = net.createConnection({ host: "127.0.0.1", port });
     const chunks: Buffer[] = [];
     socket.on("data", (chunk) => chunks.push(Buffer.from(chunk)));
@@ -451,33 +456,102 @@ describe("createPoolServer().stop()", () => {
     );
     await new Promise<void>((resolve) => socket.once("data", () => resolve()));
 
+    return {
+      stop: poolServer.stop,
+      /** The relayed WebSocket byte stream, with the 101 head asserted and stripped. */
+      relayedBytes() {
+        const received = Buffer.concat(chunks);
+        const bodyAt = received.indexOf("\r\n\r\n") + 4;
+        expect(received.subarray(0, bodyAt).toString("latin1")).toContain(
+          "101 Switching Protocols",
+        );
+        return received.subarray(bodyAt);
+      },
+      sibling: () => siblingSocket,
+      async close() {
+        socket.destroy();
+        siblingSocket?.destroy();
+        await new Promise<void>((resolve) => sibling.close(() => resolve()));
+        pool = null;
+      },
+    };
+  }
+
+  it.each<[string, number, string]>([
+    // [name, sibling-write delay relative to a 200ms grace, why this timing matters]
+    [
+      "already complete when the drain signals",
+      40,
+      "the accounting case: the frame finished before the signalling loop ran",
+    ],
+    [
+      "still incomplete when the drain signals",
+      260,
+      "the corruption case: the signalling loop runs at ~200ms with two payload bytes owed",
+    ],
+  ])(
+    "relays a tunnelled WebSocket's own close frame, never splicing one into a frame %s",
+    async (_name, siblingWriteMs) => {
+      const partialFrame = Buffer.from([0x81, 0x08, 0x61, 0x62]); // header claims 8 bytes, 2 sent
+      const restOfFrame = Buffer.from("cdefgh");
+      const siblingGoingAway = Buffer.from([0x88, 0x02, 0x03, 0xe9]);
+      const tunnel = await tunnelledPool((socket) => socket.write(partialFrame));
+
+      const readDrainLog = captureDrainLog();
+      const drain = tunnel.stop({ graceMs: 200 });
+      // The sibling pool drains too (a rollout SIGTERMs every pool of the build) and emits its own
+      // 1001 at a real frame boundary. The tunnel must still be open to relay it.
+      await new Promise<void>((resolve) => setTimeout(resolve, siblingWriteMs));
+      tunnel.sibling()?.write(Buffer.concat([restOfFrame, siblingGoingAway]));
+      await drain;
+
+      // Exactly the relayed byte stream: the completed frame, then the sibling's close frame. An
+      // injected 1001 appears appended after it (40ms) or spliced between `ab` and `cdefgh`
+      // (260ms) instead.
+      expect(tunnel.relayedBytes()).toEqual(
+        Buffer.concat([partialFrame, restOfFrame, siblingGoingAway]),
+      );
+
+      const counts = readDrainLog();
+      expect(counts.webSockets).toBe(1);
+      expect(counts.tunnelled).toBe(1);
+      expect(counts.signalled).toBe(0);
+      expect(counts.peerClosed).toBe(0);
+      expect(counts.wsForced).toBe(1);
+      await tunnel.close();
+    },
+  );
+
+  it.each<[string, Buffer | undefined]>([
+    // [name, bytes the sibling relays before the drain]
+    ["that never carried a frame", undefined],
+    ["sitting between frames", Buffer.from([0x81, 0x02, 0x68, 0x69])],
+  ])("injects 1001 into a tunnel %s when the peer pool is not draining", async (_name, relayed) => {
+    // N91. The peer pool is a separate Deployment with its own HPA, so the ORDINARY case (a
+    // front pool scaling down, one pod evicted, a rollout touching one Deployment) leaves it
+    // healthy and silent — no close frame ever arrives to relay. Refusing to inject at all
+    // would end these clients on ws 1006. The cursor makes the frame position knowable, so a
+    // tunnel that is provably between frames gets the same clean 1001 as a local socket.
+    const goingAway = Buffer.from([0x88, 0x02, 0x03, 0xe9]);
+    const tunnel = await tunnelledPool((socket) => {
+      if (relayed) socket.write(relayed);
+    });
+    // Let the relayed frame arrive and be counted before the drain reads the cursor.
+    if (relayed) await new Promise<void>((resolve) => setTimeout(resolve, 50));
+
     const readDrainLog = captureDrainLog();
-    const drain = pool.stop({ graceMs: 200 });
-    // The sibling pool drains too (a rollout SIGTERMs every pool of the build) and emits its own
-    // 1001 at a real frame boundary. The tunnel must still be open to relay it.
-    await new Promise<void>((resolve) => setTimeout(resolve, 40));
-    siblingSocket?.write(Buffer.concat([restOfFrame, siblingGoingAway]));
-    await drain;
+    await tunnel.stop({ graceMs: 100 });
 
-    const received = Buffer.concat(chunks);
-    const bodyAt = received.indexOf("\r\n\r\n") + 4;
-    expect(received.subarray(0, bodyAt).toString("latin1")).toContain("101 Switching Protocols");
-    // Exactly the relayed byte stream: the completed frame, then the sibling's close frame. An
-    // injected 1001 would appear between `ab` and `cdefgh` instead.
-    expect(received.subarray(bodyAt)).toEqual(
-      Buffer.concat([partialFrame, restOfFrame, siblingGoingAway]),
+    expect(tunnel.relayedBytes()).toEqual(
+      relayed ? Buffer.concat([relayed, goingAway]) : goingAway,
     );
-
     const counts = readDrainLog();
     expect(counts.webSockets).toBe(1);
-    expect(counts.tunnelled).toBe(1);
-    expect(counts.signalled).toBe(0);
+    expect(counts.signalled).toBe(1);
+    expect(counts.tunnelled).toBe(0);
     expect(counts.peerClosed).toBe(0);
     expect(counts.wsForced).toBe(1);
-    socket.destroy();
-    siblingSocket?.destroy();
-    await new Promise<void>((resolve) => sibling.close(() => resolve()));
-    pool = null;
+    await tunnel.close();
   });
 
   it("does not report a server-rejected upgrade as a voluntary peer close", async () => {

--- a/tests/pool-server/server-shutdown.test.ts
+++ b/tests/pool-server/server-shutdown.test.ts
@@ -12,8 +12,10 @@
 // bug only exists at the socket layer, so a mock could not have caught it.
 import { describe, it, expect, afterEach, vi } from "vitest";
 import net from "node:net";
-import { get as httpGet, type IncomingMessage, type ServerResponse } from "node:http";
+import { createServer, get as httpGet, type IncomingMessage, type ServerResponse } from "node:http";
+import type { Duplex } from "node:stream";
 import { createPoolServer } from "../../src/pool-server/server.js";
+import { handleWebSocketUpgrade } from "../../src/pool-server/websocket-upgrade.js";
 import { INTERNAL_DISPATCH_PROOF_HEADER } from "../../src/routing-common.js";
 import { signDispatch } from "../helpers/dispatch-proof.js";
 
@@ -55,7 +57,7 @@ describe("createPoolServer().stop()", () => {
           "HTTP/1.1 101 Switching Protocols\r\n" +
             "Connection: Upgrade\r\nUpgrade: websocket\r\n\r\n",
         );
-        return "accepted";
+        return "accepted-local";
       },
       port: 0,
     });
@@ -382,9 +384,105 @@ describe("createPoolServer().stop()", () => {
     pool = null;
   });
 
+  it("relays a tunnelled WebSocket's own close frame instead of injecting one mid-frame", async () => {
+    // N90. A cross-pool tunnel (websocket-upgrade.ts proxyUpgradeToPool) is a frame-BLIND byte
+    // pipe: a frame relayed from the sibling pool routinely spans several TCP chunks, so at drain
+    // time this pool's client can hold a partially relayed frame whose header already promised
+    // more payload. Writing the 1001 frame that a locally owned socket gets would put close-frame
+    // bytes inside that payload — the client reads a header promising N bytes and gets 0x88 …
+    // instead. Real sockets and a real sibling server throughout: the corruption only exists at
+    // the byte level, and a mock pipe could not have shown it.
+    const partialFrame = Buffer.from([0x81, 0x08, 0x61, 0x62]); // header claims 8 bytes, 2 sent
+    const restOfFrame = Buffer.from("cdefgh");
+    const siblingGoingAway = Buffer.from([0x88, 0x02, 0x03, 0xe9]);
+    let siblingSocket: Duplex | undefined;
+    const sibling = createServer();
+    sibling.on("upgrade", (_req, socket) => {
+      siblingSocket = socket;
+      socket.on("error", () => undefined);
+      socket.write(
+        "HTTP/1.1 101 Switching Protocols\r\nConnection: Upgrade\r\nUpgrade: websocket\r\n\r\n",
+      );
+      socket.write(partialFrame);
+    });
+    await new Promise<void>((resolve) => sibling.listen(0, "127.0.0.1", () => resolve()));
+    const siblingAddress = sibling.address();
+    if (!siblingAddress || typeof siblingAddress === "string") {
+      throw new Error("missing sibling pool address");
+    }
+
+    pool = createPoolServer({
+      onRequest: () => undefined,
+      onUpgrade: (req, socket, head) =>
+        handleWebSocketUpgrade(
+          {
+            resolve: async () =>
+              ({ kind: "route", pool: "chat", matchedPathname: "/socket" }) as never,
+            handlerLoader: {
+              has: () => true,
+              get: () => ({ runtime: "nodejs", type: "APP_ROUTE" }),
+              loadUpgrade: async () => undefined,
+            } as never,
+            poolName: "default",
+            releaseName: "app",
+            buildId: "b1",
+            webSocketRegistryScope: {},
+            resolvePoolEndpoint: () => ({
+              hostname: "127.0.0.1",
+              port: siblingAddress.port,
+            }),
+          },
+          req,
+          socket,
+          head,
+        ),
+      port: 0,
+    });
+    const { port } = await pool.start();
+    const socket = net.createConnection({ host: "127.0.0.1", port });
+    const chunks: Buffer[] = [];
+    socket.on("data", (chunk) => chunks.push(Buffer.from(chunk)));
+    socket.on("error", () => undefined);
+    await new Promise<void>((resolve) => socket.once("connect", resolve));
+    socket.write(
+      "GET /socket HTTP/1.1\r\nHost: localhost\r\nConnection: Upgrade\r\n" +
+        "Upgrade: websocket\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n" +
+        "Sec-WebSocket-Version: 13\r\n\r\n",
+    );
+    await new Promise<void>((resolve) => socket.once("data", () => resolve()));
+
+    const readDrainLog = captureDrainLog();
+    const drain = pool.stop({ graceMs: 200 });
+    // The sibling pool drains too (a rollout SIGTERMs every pool of the build) and emits its own
+    // 1001 at a real frame boundary. The tunnel must still be open to relay it.
+    await new Promise<void>((resolve) => setTimeout(resolve, 40));
+    siblingSocket?.write(Buffer.concat([restOfFrame, siblingGoingAway]));
+    await drain;
+
+    const received = Buffer.concat(chunks);
+    const bodyAt = received.indexOf("\r\n\r\n") + 4;
+    expect(received.subarray(0, bodyAt).toString("latin1")).toContain("101 Switching Protocols");
+    // Exactly the relayed byte stream: the completed frame, then the sibling's close frame. An
+    // injected 1001 would appear between `ab` and `cdefgh` instead.
+    expect(received.subarray(bodyAt)).toEqual(
+      Buffer.concat([partialFrame, restOfFrame, siblingGoingAway]),
+    );
+
+    const counts = readDrainLog();
+    expect(counts.webSockets).toBe(1);
+    expect(counts.tunnelled).toBe(1);
+    expect(counts.signalled).toBe(0);
+    expect(counts.peerClosed).toBe(0);
+    expect(counts.wsForced).toBe(1);
+    socket.destroy();
+    siblingSocket?.destroy();
+    await new Promise<void>((resolve) => sibling.close(() => resolve()));
+    pool = null;
+  });
+
   it("does not report a server-rejected upgrade as a voluntary peer close", async () => {
-    let releaseUpgrade!: (disposition: "accepted" | "rejected") => void;
-    const disposition = new Promise<"accepted" | "rejected">((resolve) => {
+    let releaseUpgrade!: (disposition: "accepted-local" | "rejected") => void;
+    const disposition = new Promise<"accepted-local" | "rejected">((resolve) => {
       releaseUpgrade = resolve;
     });
     let upgradeEntered!: () => void;

--- a/tests/pool-server/websocket-frame-cursor.test.ts
+++ b/tests/pool-server/websocket-frame-cursor.test.ts
@@ -1,0 +1,122 @@
+// tests/pool-server/websocket-frame-cursor.test.ts
+// N91. The cursor is the whole basis for deciding whether shutdown may write a 1001 into a
+// cross-pool tunnel, so its answer has to be right for the byte splits a relay actually produces —
+// headers split across chunks, extended lengths, several frames in one chunk — and fail-closed for
+// anything it cannot account for. server-shutdown.test.ts covers the real-socket drain outcome;
+// this pins the parse itself, which that test can only reach one position at a time.
+import { describe, expect, it } from "vitest";
+import { PassThrough } from "node:stream";
+import {
+  injectTunnelCloseFrame,
+  trackTunnelFraming,
+} from "../../src/pool-server/websocket-frame-cursor.js";
+
+const GOING_AWAY = Buffer.from([0x88, 0x02, 0x03, 0xe9]);
+
+/** A tunnel's two ends, with the client end's writes captured as bytes. */
+function tunnel(relayedHead = Buffer.alloc(0)) {
+  const clientSocket = new PassThrough();
+  const poolSocket = new PassThrough();
+  const written: Buffer[] = [];
+  clientSocket.on("data", (chunk: Buffer) => written.push(Buffer.from(chunk)));
+  poolSocket.pipe(clientSocket);
+  trackTunnelFraming(clientSocket, poolSocket, relayedHead);
+  return {
+    /** Relay bytes from the peer pool and wait for them to reach the cursor. */
+    async relay(...chunks: Buffer[]) {
+      for (const chunk of chunks) {
+        poolSocket.write(chunk);
+        await new Promise((resolve) => setImmediate(resolve));
+      }
+    },
+    inject: () => injectTunnelCloseFrame(clientSocket, GOING_AWAY),
+    clientBytes: () => Buffer.concat(written),
+  };
+}
+
+describe("N91 tunnel frame cursor", () => {
+  it("accepts a close frame on a tunnel that never relayed a byte", async () => {
+    const relay = tunnel();
+    expect(relay.inject()).toBe(true);
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(relay.clientBytes()).toEqual(GOING_AWAY);
+  });
+
+  it("counts the upgrade response's own trailing frame bytes", async () => {
+    // proxyHead is written to the client before the pipe exists, so a cursor that ignored it would
+    // report a boundary while the client holds two of eight promised payload bytes.
+    const relay = tunnel(Buffer.from([0x81, 0x08, 0x61, 0x62]));
+    expect(relay.inject()).toBe(false);
+    await relay.relay(Buffer.from("cdefgh"));
+    expect(relay.inject()).toBe(true);
+  });
+
+  it.each<[string, Buffer[], boolean]>([
+    ["a complete short frame", [Buffer.from([0x81, 0x02, 0x68, 0x69])], true],
+    ["a frame missing its last payload byte", [Buffer.from([0x81, 0x02, 0x68])], false],
+    ["a lone first header byte", [Buffer.from([0x81])], false],
+    ["a header split across chunks, completed", [Buffer.from([0x81]), Buffer.from([0x00])], true],
+    [
+      "a 126-length header split before its extended length",
+      [Buffer.from([0x81, 0x7e]), Buffer.from([0x00])],
+      false,
+    ],
+    [
+      "a 126-length frame completed across chunks",
+      [Buffer.from([0x81, 0x7e, 0x01, 0x00]), Buffer.alloc(256, 0x61)],
+      true,
+    ],
+    [
+      "a 127-length header whose extended length is incomplete",
+      [Buffer.from([0x81, 0x7f, 0, 0, 0, 0, 0, 0, 0])],
+      false,
+    ],
+    [
+      "a 127-length frame completed across chunks",
+      [Buffer.from([0x81, 0x7f, 0, 0, 0, 0, 0, 0, 0, 0x04]), Buffer.from("abcd")],
+      true,
+    ],
+    [
+      "two frames and a partial third in one chunk",
+      [Buffer.from([0x81, 0x01, 0x61, 0x8a, 0x00, 0x81, 0x03, 0x62])],
+      false,
+    ],
+    [
+      "two whole frames in one chunk",
+      [Buffer.from([0x81, 0x01, 0x61, 0x8a, 0x00, 0x81, 0x01, 0x62])],
+      true,
+    ],
+    // Fail-closed cases. A mask bit is forbidden in the server→client direction (RFC 6455 §5.1),
+    // so seeing one means these bytes are not the frame stream the cursor thinks they are — no
+    // position in the stream can be trusted again, even once it looks aligned.
+    ["a masked frame, complete", [Buffer.from([0x81, 0x81, 0x00, 0x00, 0x00, 0x00, 0x61])], false],
+    [
+      "an unreasonable 64-bit length",
+      [Buffer.from([0x81, 0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff])],
+      false,
+    ],
+    // The peer already said goodbye at a real boundary: relaying that is the honest close, and a
+    // second 1001 of this pod's own invention adds nothing.
+    ["the peer pool's own close frame", [Buffer.from([0x88, 0x02, 0x03, 0xe9])], false],
+  ])("decides injection after relaying %s", async (_name, chunks, allowed) => {
+    const relay = tunnel();
+    await relay.relay(...chunks);
+    expect(relay.inject()).toBe(allowed);
+  });
+
+  it("stops relaying once it has injected, so the close frame is the client's last bytes", async () => {
+    const relay = tunnel();
+    await relay.relay(Buffer.from([0x81, 0x01, 0x61]));
+    expect(relay.inject()).toBe(true);
+    await relay.relay(Buffer.from([0x81, 0x01, 0x62]));
+    expect(relay.clientBytes()).toEqual(
+      Buffer.concat([Buffer.from([0x81, 0x01, 0x61]), GOING_AWAY]),
+    );
+    // And it stays injected-once: a second drain pass must not append a second frame.
+    expect(relay.inject()).toBe(false);
+  });
+
+  it("reports no boundary for a socket that was never tracked", () => {
+    expect(injectTunnelCloseFrame(new PassThrough(), GOING_AWAY)).toBe(false);
+  });
+});

--- a/tests/pool-server/websocket-upgrade.test.ts
+++ b/tests/pool-server/websocket-upgrade.test.ts
@@ -400,9 +400,12 @@ describe("handleWebSocketUpgrade", () => {
   });
 
   // S25. webSocketRequestAuthority derives the same-origin authority from the validated
-  // x-forwarded-proto witness, so which element of a multi-hop chain wins is now a security
-  // decision and not just a URL detail: the rightmost element is the one the trusted edge added,
-  // the leftmost is whatever the client sent. Nothing pinned that before.
+  // x-forwarded-proto witness, so which element of a multi-hop chain wins decides whether a
+  // browser's own `wss://` handshake is accepted, not just how a URL is spelled. Append
+  // conventions are client-first, so the leftmost element is the TLS-terminating outer hop's and
+  // the rightmost belongs to an inner hop that only saw the plaintext leg: reading the rightmost
+  // would 403 every wss handshake for an https app behind an appending intermediary. Nothing
+  // pinned that before.
   it.each([
     // [x-forwarded-proto, socket.encrypted, Origin, allowed, why]
     [undefined, false, "http://example.com", true, "no witness, plain socket → http authority"],
@@ -411,29 +414,38 @@ describe("handleWebSocketUpgrade", () => {
     ["https", false, "https://example.com", true, "TLS-terminating LB: the witness is the scheme"],
     ["HTTPS", false, "https://example.com", true, "case-insensitive witness"],
     ["http", false, "https://example.com", false, "edge witnessed plaintext"],
-    ["http,https", false, "https://example.com", true, "rightmost hop (the edge) said https"],
+    // The topology the ordering exists for: TLS-terminating outer LB plus an appending inner hop.
+    // The browser's own wss:// handshake must be accepted.
     [
       "https,http",
       false,
       "https://example.com",
-      false,
-      "client prepended https; the edge's own value still decides",
+      true,
+      "leftmost hop (the TLS terminator) said https",
     ],
     [
       ["https", "http"],
       false,
       "https://example.com",
-      false,
-      "repeated header instances are one chain, not an index-0 lookup",
+      true,
+      "repeated header instances are one chain, joined before the leftmost read",
     ],
+    ["http,https", false, "https://example.com", false, "the client-facing leg was plaintext"],
     ["javascript", false, "https://example.com", false, "garbage witness falls back to the socket"],
     ["javascript", false, "http://example.com", true, "garbage witness falls back to the socket"],
+    [
+      "javascript,https",
+      false,
+      "https://example.com",
+      false,
+      "garbage leftmost element does not fall further right",
+    ],
     [
       "https,javascript",
       false,
       "https://example.com",
-      false,
-      "garbage rightmost element does not fall further left",
+      true,
+      "junk appended by an inner hop cannot demote the outer hop's witness",
     ],
   ] as const)(
     "same-origin authority for x-forwarded-proto %j (encrypted=%s, Origin %s) allows=%s",

--- a/tests/pool-server/websocket-upgrade.test.ts
+++ b/tests/pool-server/websocket-upgrade.test.ts
@@ -100,7 +100,7 @@ describe("handleWebSocketUpgrade", () => {
     const { socket } = captureSocket();
     const head = Buffer.from("early-frame");
 
-    await expect(handleWebSocketUpgrade(deps, req, socket, head)).resolves.toBe("accepted");
+    await expect(handleWebSocketUpgrade(deps, req, socket, head)).resolves.toBe("accepted-local");
 
     expect(upgradeHandler).toHaveBeenCalledOnce();
     const [context, transport] = upgradeHandler.mock.calls[0]!;
@@ -177,7 +177,7 @@ describe("handleWebSocketUpgrade", () => {
     const { socket } = captureSocket();
 
     await expect(handleWebSocketUpgrade(deps, req, socket, Buffer.alloc(0))).resolves.toBe(
-      "accepted",
+      "accepted-local",
     );
     expect(resolve).not.toHaveBeenCalled();
     expect(upgradeHandler).toHaveBeenCalledOnce();
@@ -210,7 +210,7 @@ describe("handleWebSocketUpgrade", () => {
     const { socket } = captureSocket();
 
     await expect(handleWebSocketUpgrade(deps, req, socket, Buffer.alloc(0))).resolves.toBe(
-      "accepted",
+      "accepted-local",
     );
     expect(resolve).toHaveBeenCalledOnce();
     expect(req.headers["x-mw-request-headers"]).toBeUndefined();
@@ -284,7 +284,7 @@ describe("handleWebSocketUpgrade", () => {
         socket,
         Buffer.alloc(0),
       ),
-    ).resolves.toBe("accepted");
+    ).resolves.toBe("accepted-local");
     expect(resolve).toHaveBeenCalledOnce();
     expect(upgradeHandler).toHaveBeenCalledOnce();
     // Nothing is written by the adapter: the generated entrypoint owns the 101 and the extension
@@ -345,7 +345,7 @@ describe("handleWebSocketUpgrade", () => {
         acceptedSocket.socket,
         Buffer.alloc(0),
       ),
-    ).resolves.toBe("accepted");
+    ).resolves.toBe("accepted-local");
     expect(accepted.resolve).toHaveBeenCalledOnce();
     acceptedSocket.socket.destroy();
   });
@@ -371,7 +371,7 @@ describe("handleWebSocketUpgrade", () => {
         sameOriginSocket.socket,
         Buffer.alloc(0),
       ),
-    ).resolves.toBe("accepted");
+    ).resolves.toBe("accepted-local");
     expect(sameOrigin.deps.webSocketAllowedOrigins).toBeUndefined();
     expect(sameOrigin.resolve).toHaveBeenCalledOnce();
     sameOriginSocket.socket.destroy();
@@ -435,7 +435,7 @@ describe("handleWebSocketUpgrade", () => {
     const { socket } = captureSocket();
 
     await expect(handleWebSocketUpgrade(deps, req, socket, Buffer.alloc(0))).resolves.toBe(
-      "accepted",
+      "accepted-local",
     );
     expect(upgradeHandler).toHaveBeenCalledOnce();
     socket.destroy();
@@ -580,8 +580,10 @@ describe("handleWebSocketUpgrade", () => {
     });
 
     try {
+      // N90: a tunnel, not a locally owned socket — shutdown must not inject a close frame into
+      // this frame-blind pipe.
       await expect(handleWebSocketUpgrade(deps, clientRequest, socket, earlyFrame)).resolves.toBe(
-        "accepted",
+        "accepted-tunnel",
       );
       expect(siblingHeaders?.["x-output-id"]).toBe("/rooms/[room]");
       expect(siblingHeaders?.["x-mw-evaluated"]).toBe("ran");

--- a/tests/pool-server/websocket-upgrade.test.ts
+++ b/tests/pool-server/websocket-upgrade.test.ts
@@ -265,6 +265,59 @@ describe("handleWebSocketUpgrade", () => {
     }
   });
 
+  // N89. `next/dist/compiled/ws` exports only the transport classes, so `extension.parse` is
+  // undefined on every Next release the adapter has shipped against. Throwing then rejected the
+  // upgrade promise, whose handler in createPoolServer destroyed the socket without writing a
+  // byte — every browser handshake (they all offer permessage-deflate) died with no HTTP status.
+  it("completes a browser handshake when the pinned extension parser is unavailable", async () => {
+    const upgradeHandler = vi.fn(async () => ({ upgraded: true, statusCode: 101 }));
+    const { deps, resolve } = dependencies({ upgradeHandler });
+    deps.parseWebSocketExtensions = undefined;
+    const { socket, text } = captureSocket();
+
+    await expect(
+      handleWebSocketUpgrade(
+        deps,
+        request(undefined, {
+          "sec-websocket-extensions": "permessage-deflate; client_max_window_bits",
+        }),
+        socket,
+        Buffer.alloc(0),
+      ),
+    ).resolves.toBe("accepted");
+    expect(resolve).toHaveBeenCalledOnce();
+    expect(upgradeHandler).toHaveBeenCalledOnce();
+    // Nothing is written by the adapter: the generated entrypoint owns the 101 and the extension
+    // negotiation, exactly as it does for a handshake with no extensions offered at all.
+    expect(text()).toBe("");
+    socket.destroy();
+  });
+
+  it("still uses the pinned parser to reject a malformed extension offer when it exists", async () => {
+    const parseWebSocketExtensions = vi.fn((value: string) => {
+      if (value === "permessage-deflate; =") throw new SyntaxError("invalid extension");
+      return {};
+    });
+    const { deps, resolve } = dependencies({
+      upgradeHandler: async () => ({ upgraded: true, statusCode: 101 }),
+    });
+    deps.parseWebSocketExtensions = parseWebSocketExtensions;
+    const { socket, text } = captureSocket();
+
+    await expect(
+      handleWebSocketUpgrade(
+        deps,
+        request(undefined, { "sec-websocket-extensions": "permessage-deflate; =" }),
+        socket,
+        Buffer.alloc(0),
+      ),
+    ).resolves.toBe("rejected");
+    expect(parseWebSocketExtensions).toHaveBeenCalledWith("permessage-deflate; =");
+    expect(text()).toContain("HTTP/1.1 400");
+    expect(text()).toContain("Invalid Sec-WebSocket-Extensions header.");
+    expect(resolve).not.toHaveBeenCalled();
+  });
+
   it("enforces same-origin and configured cross-origin policy before routing", async () => {
     const denied = dependencies({
       upgradeHandler: async () => ({ upgraded: true, statusCode: 101 }),

--- a/tests/pool-server/websocket-upgrade.test.ts
+++ b/tests/pool-server/websocket-upgrade.test.ts
@@ -399,6 +399,71 @@ describe("handleWebSocketUpgrade", () => {
     expect(crossOrigin.resolve).not.toHaveBeenCalled();
   });
 
+  // S25. webSocketRequestAuthority derives the same-origin authority from the validated
+  // x-forwarded-proto witness, so which element of a multi-hop chain wins is now a security
+  // decision and not just a URL detail: the rightmost element is the one the trusted edge added,
+  // the leftmost is whatever the client sent. Nothing pinned that before.
+  it.each([
+    // [x-forwarded-proto, socket.encrypted, Origin, allowed, why]
+    [undefined, false, "http://example.com", true, "no witness, plain socket → http authority"],
+    [undefined, false, "https://example.com", false, "no witness cannot upgrade the authority"],
+    [undefined, true, "https://example.com", true, "direct TLS connection with no edge in front"],
+    ["https", false, "https://example.com", true, "TLS-terminating LB: the witness is the scheme"],
+    ["HTTPS", false, "https://example.com", true, "case-insensitive witness"],
+    ["http", false, "https://example.com", false, "edge witnessed plaintext"],
+    ["http,https", false, "https://example.com", true, "rightmost hop (the edge) said https"],
+    [
+      "https,http",
+      false,
+      "https://example.com",
+      false,
+      "client prepended https; the edge's own value still decides",
+    ],
+    [
+      ["https", "http"],
+      false,
+      "https://example.com",
+      false,
+      "repeated header instances are one chain, not an index-0 lookup",
+    ],
+    ["javascript", false, "https://example.com", false, "garbage witness falls back to the socket"],
+    ["javascript", false, "http://example.com", true, "garbage witness falls back to the socket"],
+    [
+      "https,javascript",
+      false,
+      "https://example.com",
+      false,
+      "garbage rightmost element does not fall further left",
+    ],
+  ] as const)(
+    "same-origin authority for x-forwarded-proto %j (encrypted=%s, Origin %s) allows=%s",
+    async (forwardedProto, encrypted, origin, allowed) => {
+      const { deps, resolve } = dependencies({
+        upgradeHandler: async () => ({ upgraded: true, statusCode: 101 }),
+      });
+      const req = request(undefined, { origin });
+      if (forwardedProto !== undefined) req.headers["x-forwarded-proto"] = forwardedProto;
+      req.rawHeaders = Object.entries(req.headers).flatMap(([name, value]) =>
+        Array.isArray(value) ? value.flatMap((entry) => [name, entry]) : [name, value],
+      );
+      req.socket = { encrypted };
+      const { socket, text } = captureSocket();
+
+      const disposition = await handleWebSocketUpgrade(deps, req, socket, Buffer.alloc(0));
+
+      if (allowed) {
+        expect(disposition).toBe("accepted-local");
+        expect(resolve).toHaveBeenCalledOnce();
+        socket.destroy();
+      } else {
+        expect(disposition).toBe("rejected");
+        expect(text()).toContain("HTTP/1.1 403 Forbidden");
+        expect(text()).toContain("WebSocket origin is not allowed.");
+        expect(resolve).not.toHaveBeenCalled();
+      }
+    },
+  );
+
   it("preserves only framework-authored middleware cookies into the generated request", async () => {
     const middlewareRequestHeaders = new Headers({
       host: "example.com",

--- a/tests/pool-server/websocket-upgrade.test.ts
+++ b/tests/pool-server/websocket-upgrade.test.ts
@@ -657,8 +657,8 @@ describe("handleWebSocketUpgrade", () => {
     });
 
     try {
-      // N90: a tunnel, not a locally owned socket — shutdown must not inject a close frame into
-      // this frame-blind pipe.
+      // N90: a tunnel, not a locally owned socket — shutdown may only write into this relayed pipe
+      // where the N91 cursor proves it sits between frames.
       await expect(handleWebSocketUpgrade(deps, clientRequest, socket, earlyFrame)).resolves.toBe(
         "accepted-tunnel",
       );


### PR DESCRIPTION
Follow-up to #47, from a two-pass audit of the merged WebSocket support.

## A1-WS-1 (high) — every browser handshake was destroyed

`src/pool-server/index.ts` wired `parseWebSocketExtensions` from `next/dist/compiled/ws`'s `extension?.parse`. That bundle exports no `extension` at all on the pinned Next 16.3.0 — verified directly:

```
exports: CONNECTING, OPEN, CLOSING, CLOSED, createWebSocketStream, Server, Receiver, Sender, WebSocket, WebSocketServer
extension: undefined
```

So the optional chain silently yielded `undefined`, and `validateWebSocketHandshake` **threw** for any handshake carrying `Sec-WebSocket-Extensions` — which every browser sends via `permessage-deflate`. Adapter-side extension validation now degrades when the pinned parser is absent, keeping the parser path for a future Next that exports it. Confirmed nothing in the adapter reads that header and that the newly reachable `permessage-deflate` path relays it in both directions.

This is masked today only because Next core still rejects `adapterPath` with WebSocket route handlers; it would have surfaced the moment upstream lands.

## A1-WS-2 (medium) — 1001 frame spliced into tunneled sockets

Drain wrote the raw close frame into every accepted socket. That is safe for locally handled routes (ws writes each frame synchronously under cork) but `proxyUpgradeToPool` tunnels are a frame-blind byte pipe, so a relayed frame spanning multiple TCP chunks got the close frame spliced into its payload. Mutation-verified as a real splice: `81 08 61 62 | 88 02 03 e9 | 63 64 65 66 67 68`.

Sockets now carry explicit ownership. Rather than only suppressing injection on tunnels — which traded a rare corruption for a common abnormal closure under per-pool HPA scale-down — a new frame cursor (`websocket-frame-cursor.ts`, N91) tracks the client-bound direction by payload length only, so a provably frame-aligned tunnel gets the same clean 1001 a local socket gets. Every uncertainty fails closed to no injection: untracked socket, mask bit set, partial header or payload, unrepresentable 64-bit length.

## A1-WS-3 — x-forwarded-proto element selection

The audit flagged the leftmost read as untested and assumption-dependent. The first attempt here switched to rightmost; the adversarial review caught that as **wrong** and it was reverted in `6130e7f`. Under RFC 7239 §4 and the `X-Forwarded-For` convention, elements are ordered client-first, so the TLS-terminating outermost hop contributes the **leftmost** element and an appending inner hop contributes the rightmost. The rightmost read derived `http` from `https,http` and would have 403'd every browser `wss://` handshake behind an appending intermediary.

Final state is a left-to-right read with the hardening kept (array shape joined not indexed, case-insensitive, empty elements skipped, garbage in the decisive position yields no witness). `docs/targets.md` now states the requirement the code actually imposes: the header must arrive single-valued, written by the hop that terminated TLS — a chain leaves *Next itself* reading `http` whatever the adapter picks.

## Verification

3066 passed, 4 skipped. `fmt:check`, `lint`, `tsc --noEmit`, `build` clean. 17 new frame-cursor cases, a 13-case forwarded-proto matrix, and two real-socket drain cases; the tunnel regression test is now an `it.each` over both timings because the original timing could not reproduce the splice it claimed.

## For the reviewer

- History contains `eb64496` (rightmost) followed by `6130e7f` reverting it to leftmost. Left in place rather than squashed so the reasoning is auditable; say the word and I will squash.
- Leftmost admits a spoof that is not reachable: the value is load-bearing only for the same-origin `Origin` check, and a hostile page cannot set a request header on a WebSocket handshake. A maintainer preferring "any chain → no witness" or a trusted-hop count should know the two test tables and one `docs/targets.md` paragraph are the only things that move.
- One reviewer finding (low, about which Envoy knob gates `x-forwarded-proto`) was **refuted** with citations from Envoy's own docs — `xff_num_trusted_hops`, not `use_remote_address`, gates that header. No change made.