### PR TITLE
Harden release foundations and remove dead PPR state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ E2E-FAILURE-RUNBOOK.md
 # Adapter build + deploy output (generated per build; machine-local state)
 .k8s-adapter/
 .playwright-mcp/
+# Local agent worktrees and session state are never package inputs.
+.claude/
 
 # Stray tsc declaration emit for tests/config (real declarations go to dist/ via build:types)
 tests/**/*.d.ts

--- a/fixtures/main/app/novel/[slug]/page.tsx
+++ b/fixtures/main/app/novel/[slug]/page.tsx
@@ -1,5 +1,4 @@
-// Shell-less PPR probe (spec rev-4 "Option D" — docs/superpowers/specs/
-// 2026-07-26-ppr-resume-shell-less-templates.md). Mirrors the structure of upstream's
+// Shell-less PPR probe for "Option D". Mirrors the structure of upstream's
 // cache-components-allow-otel-spans `[slug]/early-span`: a PARTIALLY_STATIC dynamic template
 // whose non-prerendered params render async work with NO Suspense boundary above it, so the
 // build's static shell is empty and demoted (`fallback: null`) while the template lands in

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@opentelemetry/sdk-metrics": "^2.10.0",
         "@opentelemetry/sdk-trace-base": "^2.10.0",
         "@types/node": "^25.5.0",
-        "esbuild": "^0.27.4",
+        "esbuild": "^0.28.2",
         "ioredis": "^5.11.1",
         "oxfmt": "^0.42.0",
         "oxlint": "1.73.0",
@@ -301,9 +301,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
-      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
       "cpu": [
         "ppc64"
       ],
@@ -318,9 +318,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
-      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
       "cpu": [
         "arm"
       ],
@@ -335,9 +335,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
-      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
       "cpu": [
         "arm64"
       ],
@@ -352,9 +352,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
-      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
       "cpu": [
         "x64"
       ],
@@ -369,9 +369,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
-      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
       "cpu": [
         "arm64"
       ],
@@ -386,9 +386,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
-      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
       "cpu": [
         "x64"
       ],
@@ -403,9 +403,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
       "cpu": [
         "arm64"
       ],
@@ -420,9 +420,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
-      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
       "cpu": [
         "x64"
       ],
@@ -437,9 +437,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
-      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
       "cpu": [
         "arm"
       ],
@@ -454,9 +454,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
-      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
       "cpu": [
         "arm64"
       ],
@@ -471,9 +471,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
-      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
       "cpu": [
         "ia32"
       ],
@@ -488,9 +488,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
-      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
       "cpu": [
         "loong64"
       ],
@@ -505,9 +505,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
-      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
       "cpu": [
         "mips64el"
       ],
@@ -522,9 +522,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
-      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
       "cpu": [
         "ppc64"
       ],
@@ -539,9 +539,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
-      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
       "cpu": [
         "riscv64"
       ],
@@ -556,9 +556,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
-      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
       "cpu": [
         "s390x"
       ],
@@ -573,9 +573,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
-      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
       "cpu": [
         "x64"
       ],
@@ -590,9 +590,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
       "cpu": [
         "arm64"
       ],
@@ -607,9 +607,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
       "cpu": [
         "x64"
       ],
@@ -624,9 +624,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
       "cpu": [
         "arm64"
       ],
@@ -641,9 +641,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
       "cpu": [
         "x64"
       ],
@@ -658,9 +658,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
-      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
       "cpu": [
         "arm64"
       ],
@@ -675,9 +675,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
-      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
       "cpu": [
         "x64"
       ],
@@ -692,9 +692,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
-      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
       "cpu": [
         "arm64"
       ],
@@ -709,9 +709,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
-      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
       "cpu": [
         "ia32"
       ],
@@ -726,9 +726,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
-      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
       "cpu": [
         "x64"
       ],
@@ -3034,9 +3034,9 @@
       "license": "MIT"
     },
     "node_modules/esbuild": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
-      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -3047,32 +3047,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.7",
-        "@esbuild/android-arm": "0.27.7",
-        "@esbuild/android-arm64": "0.27.7",
-        "@esbuild/android-x64": "0.27.7",
-        "@esbuild/darwin-arm64": "0.27.7",
-        "@esbuild/darwin-x64": "0.27.7",
-        "@esbuild/freebsd-arm64": "0.27.7",
-        "@esbuild/freebsd-x64": "0.27.7",
-        "@esbuild/linux-arm": "0.27.7",
-        "@esbuild/linux-arm64": "0.27.7",
-        "@esbuild/linux-ia32": "0.27.7",
-        "@esbuild/linux-loong64": "0.27.7",
-        "@esbuild/linux-mips64el": "0.27.7",
-        "@esbuild/linux-ppc64": "0.27.7",
-        "@esbuild/linux-riscv64": "0.27.7",
-        "@esbuild/linux-s390x": "0.27.7",
-        "@esbuild/linux-x64": "0.27.7",
-        "@esbuild/netbsd-arm64": "0.27.7",
-        "@esbuild/netbsd-x64": "0.27.7",
-        "@esbuild/openbsd-arm64": "0.27.7",
-        "@esbuild/openbsd-x64": "0.27.7",
-        "@esbuild/openharmony-arm64": "0.27.7",
-        "@esbuild/sunos-x64": "0.27.7",
-        "@esbuild/win32-arm64": "0.27.7",
-        "@esbuild/win32-ia32": "0.27.7",
-        "@esbuild/win32-x64": "0.27.7"
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
       }
     },
     "node_modules/estree-walker": {
@@ -3478,9 +3478,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@opentelemetry/sdk-metrics": "^2.10.0",
     "@opentelemetry/sdk-trace-base": "^2.10.0",
     "@types/node": "^25.5.0",
-    "esbuild": "^0.27.4",
+    "esbuild": "^0.28.2",
     "ioredis": "^5.11.1",
     "oxfmt": "^0.42.0",
     "oxlint": "1.73.0",
@@ -90,6 +90,9 @@
   },
   "peerDependencies": {
     "next": "^16.3.0"
+  },
+  "overrides": {
+    "nanoid": "3.3.18"
   },
   "engines": {
     "node": ">= 20.9.0"

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -153,78 +153,6 @@ function readDynamicRouteFallbackRootParams(distDir: string): Map<string, string
   return byRoute;
 }
 
-// The fields of a PRERENDER output this module reads. Declared structurally because synthetic
-// build contexts (unit tests) supply only these, and because `groupId` is typed `number` upstream
-// while a mock may key groups by any stable value.
-interface PrerenderView {
-  pathname: string;
-  groupId?: string | number;
-  fallback?: { filePath?: string; postponedState?: string } | null;
-}
-
-interface PrerenderGroup {
-  /** ANY member of the group carries a postponed state, i.e. this route's build render postponed. */
-  postpones: boolean;
-  /**
-   * Pathnames of members carrying a `fallback` object with NO `filePath` — the exact shape
-   * upstream uses for the `.rsc` PRERENDER sibling of a PARTIALLY_STATIC route
-   * (`filePath: undefined` at build-complete.js:989). Used only by the build-time assertion.
-   */
-  fileless: string[];
-}
-
-// N16b. Upstream records the postponed state of a PARTIALLY_STATIC route TEMPLATE on a SIBLING
-// output, not always on the template's own output. `build-complete.js` pushes the template with
-// `fallback.postponedState: undefined` and then pushes a `${dynamicRoute}.rsc` PRERENDER carrying
-// `postponedState: meta.postponed` (next@16.2.10
-// node_modules/next/dist/build/adapter/build-complete.js:986-991). A template that HAS a
-// build-emitted shell also ends up with the state on its own output, because `handleAppMeta`
-// mutates `initialOutput.fallback.postponedState` in place first (build-complete.js:596) — but
-// that mutation is guarded on `initialOutput.fallback` existing, so a template whose shell was
-// suppressed (`fallback: null` in the prerender manifest) keeps `fallback: undefined` and ONLY the
-// sibling records that the build render postponed. Reading `fallback.postponedState` off the
-// template alone therefore cannot tell "never postpones" from "postpones, shell suppressed" — and
-// types.ts documents those two flavours as needing OPPOSITE handling.
-//
-// Measured against a probe app on next 16.2.10:
-//   - empty root shell (`hasEmptyStaticShell`, build/index.js:1825) demotes the route to
-//     BLOCKING_STATIC_RENDER → template `fallback: undefined`, sibling postponedState PRESENT.
-//     This is the `/novel/early-span` class that was served as a bare 1,358-byte closed Suspense
-//     boundary where `next start` returns 7,658 bytes of resolved content.
-//   - a dynamic-segment route whose page never postpones keeps its shell but has NO postponed
-//     state anywhere in its group (the app-dir/fallback-shells `without-io` class, which MUST
-//     stay minimal).
-//
-// The join is on `groupId` — the build's own "revalidated together" grouping — never on munging
-// `.rsc` on/off ids. `rscParentCandidates` in dispatch.ts exists because suffix arithmetic on
-// these ids is error-prone; `groupId` is exact, since `prerenderGroupId` increments once per
-// template and once per concrete generateStaticParams route (verified: template `/p/[slug]` and
-// `/p/[slug].rsc` share group 3 while its concrete `/p/one` is group 2, so a concrete param can
-// never leak its postponed state into the template's flag).
-//
-// Every non-`.rsc` group member hardcodes `postponedState: undefined` (segment prerenders at
-// build-complete.js:634, data routes at 860/1027), so "some member of this group carries a
-// postponed state" is equivalent to "this route's build render postponed" without having to
-// identify WHICH member carried it.
-function indexPrerenderGroups(outputs: AdapterOutputs): Map<string | number, PrerenderGroup> {
-  const groups = new Map<string | number, PrerenderGroup>();
-  for (const output of outputs.prerenders as unknown as PrerenderView[]) {
-    const groupId = output.groupId;
-    // A synthetic output with no groupId must not join every other group-less output: an
-    // `undefined` key would make one such entry's postponed state answer for all of them.
-    if (groupId === undefined) continue;
-    let group = groups.get(groupId);
-    if (!group) {
-      group = { postpones: false, fileless: [] };
-      groups.set(groupId, group);
-    }
-    const fb = output.fallback;
-    if (fb?.postponedState) group.postpones = true;
-    if (fb && !fb.filePath) group.fileless.push(output.pathname);
-  }
-  return groups;
-}
-
 export function buildRoutingManifest({
   routing,
   outputs,
@@ -311,21 +239,8 @@ export function buildRoutingManifest({
   // unresolved ROOT params that stopped it. See the types.ts doc comment — the pool needs both
   // the membership (a PPR route, so keep it out of the emulated-SSG flip) and the root-param
   // flavour (the only flavour that must run NON-minimal).
-  const pprCapableRoutes: Record<
-    string,
-    { rootParams: string[]; wouldPostpone: boolean; allowQuery?: string[] }
-  > = {};
-  // Survey Tier 2 #7 (plans/lessons-from-sibling-adapters.md): PARTIALLY_STATIC prerenders whose
-  // fallback carries a postponedState but NO filePath — the shell-less `.rsc` postponed-state
-  // siblings (build-complete.js:986-991, the dynamic-RSC prefetch responses for PPR routes).
-  // `pprRoutes` requires a shell and `pprCapableRoutes` only admits route templates, so these
-  // were dropped from the manifest entirely and the resume implementation could not see them.
-  // Gated on `allowQuery === []` per the reference adapter (adapter-vercel outputs.ts:652-673):
-  // with no route-param variance the state is shareable across requests; with params (or with
-  // variance unknown) it is not and the route must cold-render instead.
-  const pprStatePrerenders: RoutingManifest["pprStatePrerenders"] = {};
+  const pprCapableRoutes: Record<string, { rootParams: string[]; allowQuery?: string[] }> = {};
   const dynamicRouteRootParams = readDynamicRouteFallbackRootParams(resolvedDistDir);
-  const prerenderGroups = indexPrerenderGroups(outputs);
   for (const prerender of outputs.prerenders) {
     const config = prerender.config as Record<string, unknown>;
     const fb = (
@@ -346,32 +261,11 @@ export function buildRoutingManifest({
     // prerenders (`/without-io/foo`) and `/_global-error` and flipped them non-minimal.
     const rootParams = dynamicRouteRootParams.get(prerender.pathname);
     if (config.renderingMode === "PARTIALLY_STATIC" && rootParams !== undefined) {
-      // N16b: the `.rsc` PRERENDER sibling is how the build reports that a template's render
-      // postponed (see indexPrerenderGroups). Assert it exists for every PARTIALLY_STATIC
-      // template — both flavours, since either could lose it — so an upstream change that stops
-      // emitting it FAILS THE BUILD instead of silently reclassifying every shell-less PPR
-      // template back to "never postpones", which is exactly the truncation this bit fixes.
-      // Only app-router routes reach PARTIALLY_STATIC (build/index.js only sets it under
-      // `isAppPPREnabled` for app pages), so the Pages-Router i18n branch of build-complete.js —
-      // the one path that emits no `.rsc` sibling — cannot trip this.
-      const groupId = (prerender as unknown as PrerenderView).groupId;
-      const group = groupId === undefined ? undefined : prerenderGroups.get(groupId);
-      // N16c. No build-time assertion on the sibling's presence. An earlier revision threw
-      // here when a PARTIALLY_STATIC template had no same-groupId `.rsc` sibling, to protect the
-      // `wouldPostpone` signal below — but that signal turned out not to discriminate (see the
-      // N16c note at the minimalMode gate in pool-server/dispatch.ts), so nothing consumes it in
-      // a load-bearing way and a hard throw could only fail builds for no benefit.
-      // N16c. Computed and carried, but NOT used to decide minimal mode — measured on the e2e
-      // suite, it classifies fallback-shells' never-postponing routes the same as a template that
-      // genuinely postpones, so using it regressed fallback-shells 13→8 passing. Kept (with its
-      // tests) so the next attempt starts from the measurement rather than re-deriving it.
-      const wouldPostpone = group?.postpones ?? false;
       // Shell-BEARING templates are handled via pprRoutes/handlerPprInfo and are deliberately
       // DISJOINT from this map, so keep the existing `fallback: null` restriction.
       if (!(fb?.postponedState && fb.filePath)) {
         pprCapableRoutes[prerender.pathname] = {
           rootParams,
-          wouldPostpone,
           // Shell-less templates partition the platform cache key too
           // (the with-root same-entry cells prove sharing through the header alone).
           ...(Array.isArray(config.allowQuery)
@@ -381,15 +275,6 @@ export function buildRoutingManifest({
             : {}),
         };
       }
-    }
-    if (
-      config.renderingMode === "PARTIALLY_STATIC" &&
-      fb?.postponedState &&
-      !fb.filePath &&
-      Array.isArray(config.allowQuery) &&
-      config.allowQuery.length === 0
-    ) {
-      pprStatePrerenders[prerender.pathname] = { postponedState: fb.postponedState };
     }
     if (config.renderingMode === "PARTIALLY_STATIC" && fb?.postponedState && fb.filePath) {
       // Shell cache tags come from the build's initialHeaders (x-next-cache-tags = the
@@ -499,10 +384,6 @@ export function buildRoutingManifest({
     ...(Object.keys(routeExecutionTimeouts).length > 0 ? { routeExecutionTimeouts } : {}),
     ...(Object.keys(poolResponseHeadTimeouts).length > 0 ? { poolResponseHeadTimeouts } : {}),
     pprRoutes,
-    // Sorted for byte-identical chart regeneration, like pprCapableRoutes below.
-    pprStatePrerenders: Object.fromEntries(
-      Object.entries(pprStatePrerenders).sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0)),
-    ),
     // Sorted so two chart generations of the same build are byte-identical.
     pprCapableRoutes: Object.fromEntries(
       Object.entries(pprCapableRoutes).sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0)),

--- a/src/pool-server/dispatch.ts
+++ b/src/pool-server/dispatch.ts
@@ -1089,8 +1089,7 @@ export async function invokeLocalHandlerOverHttp({
   /** Next output maxDuration. Unlike the head timeout, this remains active while streaming. */
   executionTimeoutMs?: number;
   /**
-   * Rev-4 "Option D" (docs/superpowers/specs/2026-07-26-ppr-resume-shell-less-templates.md):
-   * shell-less PPR-capable route running MINIMAL. Swap the inert onCacheEntryV2 stub for a
+   * Option D: for a shell-less PPR-capable route running minimal, swap the inert onCacheEntryV2 stub for a
    * capturing one (same signature, still returns false — the callback's PRESENCE is part of
    * the measured baseline and must never vary, only its body). If the render then postpones
    * (`x-nextjs-postponed: 1`), the pool performs the platform half itself: POST the captured
@@ -1864,18 +1863,11 @@ export interface DispatcherOptions {
     }
   >;
   /** N16: PPR-capable route templates with no build-emitted fallback shell (`fallback: null`),
-   * each tagged with the unresolved ROOT params that stopped the build from emitting one, plus
-   * (N16b) whether the build render postponed at all. See the RoutingManifest doc comment in
-   * types.ts — the root-param flavour and the would-postpone flavour each run NON-minimal for a
-   * DIFFERENT documented reason; the remainder merely need to be recognized as PPR so N13 leaves
-   * them alone.
-   * `wouldPostpone` is optional: manifests built before N16b carry only `rootParams`, and a
-   * missing bit must degrade to the pre-N16b behavior (minimal), never to non-minimal.
-   * `| undefined` is explicit: under exactOptionalPropertyTypes the index.ts wiring passes
-   * `routingManifest.pprCapableRoutes` straight through, and older manifests have no such key. */
-  pprCapableRoutes?:
-    | Record<string, { rootParams: string[]; wouldPostpone?: boolean; allowQuery?: string[] }>
-    | undefined;
+   * each tagged with unresolved root params. See the RoutingManifest doc comment in types.ts.
+   * Root-param templates run non-minimal. The no-root-param flavour stays minimal and completes
+   * a postponed response through the runtime capture-and-resume path. `| undefined` is explicit:
+   * older manifests have no such key. */
+  pprCapableRoutes?: Record<string, { rootParams: string[]; allowQuery?: string[] }> | undefined;
   /** Returns true if any of a PPR shell's baked cache tags have been revalidated since deploy (read
    * live from the shared Valkey manifest). Used only when NO classic incremental cacheHandler is
    * registered (e.g. an edge-middleware app): it withholds the stale build-time postponed token so
@@ -3911,15 +3903,10 @@ export function createDispatcher(options: DispatcherOptions) {
             // through the same registered handler.
             minimalMode: !(
               // N16: a shell-bearing PPR template, or one the build left shell-less because
-              // ROOT params were unresolved. N16b adds the third case: shell-less because the
-              // shell would have been EMPTY, which the build reports by putting the postponed
-              // state on the template's `.rsc` sibling — upstream prerenders and then resumes
-              // those, so minimal mode served them as an empty closed Suspense boundary (1,358 B
-              // vs 7,658 B from `next start`).
-              // Still NOT every shell-less PPR template: a route that never postponed at all
-              // (no Suspense boundary above the params access) is rendered dynamically by
-              // upstream, and running it non-minimal made Next resume a fallback shell upstream
-              // deliberately skips (app-dir/fallback-shells).
+              // root params were unresolved. Do not flip every shell-less route non-minimal:
+              // upstream dynamically renders the no-root-param flavour, and doing so regressed
+              // app-dir/fallback-shells. The capture-and-resume path below handles the subset
+              // that postpones at runtime without changing this gate.
               // Shell-bearing templates (handlerPprInfo) go non-minimal ONLY in emulate
               // mode, where the entrypoint's own filesystem cache holds the build shells
               // and Next resumes internally. Under a SHARED cache the entrypoints are
@@ -3947,23 +3934,16 @@ export function createDispatcher(options: DispatcherOptions) {
                   // window-expired, missing file, Server Action) falls through to Next's
                   // non-minimal complete render. Shell-less routes keep their own rungs.
                   (incrementalCacheShared && (!handlerPprInfo || !pprShellInjected))) &&
-                  // N16c. `pprCapableRoutes[route].wouldPostpone` is DELIBERATELY NOT a rung
-                  // here, and is not even read into a local. The manifest computes it
-                  // (manifest.ts) and it is real — the build does put a postponed state on a
-                  // PARTIALLY_STATIC template's same-group `.rsc` sibling — but MEASURED on the
-                  // e2e suite it does not DISCRIMINATE, so adding it here is indistinguishable
-                  // from the blunter
-                  // `|| handlerPprCapable` that was rejected earlier:
+                  // The build-time `.rsc` sibling postponed state is deliberately not a rung
+                  // here. It does not discriminate, so using it is indistinguishable from the
+                  // blunter `|| handlerPprCapable` that was rejected earlier:
                   //   with the rung:    fallback-shells 8 passed / 5 failed
                   //   without the rung: fallback-shells 13 passed / 0 failed
                   // and in both cases otel-spans stays 3/1 — `early-span` starts passing
                   // while `prerendering at runtime` starts failing, because flipping those
                   // routes non-minimal also changes their MISS→HIT caching.
-                  // fallback-shells' `without-io` / `not wrapped in Suspense` routes carry a
-                  // sibling postponed state too, so the signal cannot separate "upstream
-                  // prerenders then resumes this" from "upstream renders this dynamically".
-                  // The truncation bug it was meant to fix is therefore still open; see
-                  // docs/superpowers/specs/2026-07-26-ppr-resume-shell-less-templates.md.
+                  // Runtime capture supplies the missing discriminator. Only a render that
+                  // returns x-nextjs-postponed and a captured cache entry starts a resume.
                   (!!handlerPprInfo || handlerPprRootParams)) ||
                 ((emulatePlatformCache || incrementalCacheShared) &&
                   !!dispatchStaticAsset?.prerender &&

--- a/src/types.ts
+++ b/src/types.ts
@@ -335,15 +335,6 @@ export interface RoutingManifest {
     }
   >;
   /**
-   * Shell-less PARTIALLY_STATIC prerenders carrying ONLY a postponed state (the `.rsc`
-   * postponed-state siblings, build-complete.js:986-991), keyed by output pathname. Registered
-   * only when the build's `allowQuery` is empty — no route-param variance, so the state is
-   * shareable across requests (adapter-vercel outputs.ts:652-673). Disjoint from `pprRoutes`
-   * (those have shells) and from `pprCapableRoutes` (those are route templates). Reserved for
-   * the resume implementation; nothing consumes it yet.
-   */
-  pprStatePrerenders?: Record<string, { postponedState: string }>;
-  /**
    * PPR-capable route TEMPLATES (`renderingMode: PARTIALLY_STATIC`) whose build emitted NO
    * fallback shell (`fallback: null`), keyed by template pathname. Disjoint from `pprRoutes`,
    * which carries only the shell-BEARING templates.
@@ -361,33 +352,13 @@ export interface RoutingManifest {
    * Membership of EITHER flavour also marks the route as PPR, which keeps it out of the
    * emulated-SSG non-minimal flip (dispatch.ts N13).
    *
-   * `wouldPostpone` (N16b) records whether the BUILD render of this template postponed, derived
-   * from the same-`groupId` `.rsc` PRERENDER sibling — the only output carrying the postponed
-   * state when the template's own shell was suppressed (`hasEmptyStaticShell` demotes the route to
-   * BLOCKING_STATIC_RENDER). See `indexPrerenderGroups` in manifest.ts for the upstream
-   * references. The flag is per-TEMPLATE: concrete generateStaticParams params live in their own
-   * prerender groups and are answered by their own `pprRoutes` entry at higher precedence, so the
-   * template-level bit could only ever have decided requests for params with no build artifact of
-   * their own.
-   *
-   * N16c: IT IS NOT CONSUMED. It was added as a third rung of the minimalMode gate, to fix
-   * `/[slug]/early-span` (1,358 bytes with an empty closed `<!--$--><!--/$-->` boundary against
-   * 7,658 bytes of resolved content from `next start` on the same build) — then MEASURED against
-   * upstream and removed:
-   *   with the rung:    app-dir/fallback-shells  8 passed / 5 failed
-   *   without the rung: app-dir/fallback-shells 13 passed / 0 failed
-   * i.e. the bit does not discriminate the two flavours. fallback-shells' never-postponing routes
-   * carry sibling postponed state as well, so flipping non-minimal on it re-breaks them in exactly
-   * the way the blunt `|| handlerPprCapable` fix did. Truncation on shell-less PPR templates is
-   * therefore STILL OPEN, and the remaining fix is to implement the platform's half of the resume
-   * rather than to delegate it — docs/superpowers/specs/2026-07-26-ppr-resume-shell-less-templates.md.
-   * Kept on the manifest because it is a correct, cheap build-time observation that option B needs;
-   * do not re-wire it into the gate without re-running the two suites above.
+   * A route with no unresolved root params stays minimal. If that render postpones, the pool
+   * observes the live cache entry through Next's `onCacheEntryV2` callback and completes the
+   * response through the generated entrypoint's canonical `POST` resume contract. The runtime
+   * result is the discriminator: the build-time `.rsc` sibling state also appears on routes that
+   * must not resume, so it cannot select this behavior safely.
    */
-  pprCapableRoutes?: Record<
-    string,
-    { rootParams: string[]; wouldPostpone: boolean; allowQuery?: string[] }
-  >;
+  pprCapableRoutes?: Record<string, { rootParams: string[]; allowQuery?: string[] }>;
   nextVersion: string;
 }
 

--- a/tests/e2e/live/deployed.test.ts
+++ b/tests/e2e/live/deployed.test.ts
@@ -436,9 +436,8 @@ describe("Cloud CDN", () => {
   // registry with NO byte replay in production (replay is emulatePlatformCache-only), so the
   // test passed while proving nothing; the deterministic body hid the re-renders. Real cached
   // plain-SSG evidence lives in tests/e2e/live/edge.test.ts (byte markers, fixtures/edge).
-  // The shell-less-template caching story is tracked by
-  // docs/superpowers/specs/2026-07-26-ppr-resume-shell-less-templates.md; when that lands,
-  // replace this smoke check with a byte-marker cache assertion.
+  // The resolved-content contract has its own assertion below. This remains a smoke check until
+  // the fixture has a byte marker that can distinguish cache replay from a fresh render.
   it("serves a shell-less PPR-capable template instance (smoke, caching NOT asserted)", async () => {
     const slug = `live-probe-${Date.now().toString(36)}`;
     const first = await req(`/isr-template/${slug}`);

--- a/tests/manifest.test.ts
+++ b/tests/manifest.test.ts
@@ -748,7 +748,7 @@ describe("buildRoutingManifest", () => {
       writePrerenderManifest({ dynamicRoutes: { "/x/[id]": { fallbackRootParams: [] } } });
       const manifest = build([template("/x/[id]", 1), rscSibling("/x/[id]", 1, undefined)]);
       expect(manifest.pprCapableRoutes).toEqual({
-        "/x/[id]": { rootParams: [], wouldPostpone: false },
+        "/x/[id]": { rootParams: [] },
       });
       expect(manifest.pprRoutes["/x/[id]"]).toBeUndefined();
     });
@@ -765,7 +765,7 @@ describe("buildRoutingManifest", () => {
         rscSibling("/[lang]/x/[id]", 1, undefined),
       ]);
       expect(manifest.pprCapableRoutes).toEqual({
-        "/[lang]/x/[id]": { rootParams: ["lang"], wouldPostpone: false },
+        "/[lang]/x/[id]": { rootParams: ["lang"] },
       });
     });
 
@@ -818,7 +818,7 @@ describe("buildRoutingManifest", () => {
         }),
       ]);
       expect(manifest.pprCapableRoutes).toEqual({
-        "/x/[id]": { rootParams: [], wouldPostpone: false },
+        "/x/[id]": { rootParams: [] },
       });
     });
 
@@ -835,189 +835,6 @@ describe("buildRoutingManifest", () => {
     it("is empty when the prerender manifest is absent", () => {
       const manifest = build([template("/x/[id]", 1)]);
       expect(manifest.pprCapableRoutes).toEqual({});
-    });
-
-    // N16b. `rootParams: []` conflated two behaviours that need OPPOSITE handling. The bit that
-    // separates them is the same-groupId `.rsc` sibling's postponedState: the build suppressed
-    // the shell of `/novel/early-span` only because it would have been EMPTY, yet the render DID
-    // postpone — served minimal, that route returned 1,358 bytes with an empty closed
-    // `<!--$--><!--/$-->` boundary where `next start` returns 7,658 bytes of resolved content.
-    describe("wouldPostpone (N16b)", () => {
-      it("is true when the same-groupId .rsc sibling carries a postponed state", () => {
-        writePrerenderManifest({ dynamicRoutes: { "/x/[id]": { fallbackRootParams: [] } } });
-        const manifest = build([template("/x/[id]", 7), rscSibling("/x/[id]", 7, "postponed-abc")]);
-        expect(manifest.pprCapableRoutes).toEqual({
-          "/x/[id]": { rootParams: [], wouldPostpone: true },
-        });
-        // Still DISJOINT from pprRoutes: there is no shell file to prepend, so nothing may be
-        // injected — the whole point is that Next owns the shell lifecycle for these.
-        expect(manifest.pprRoutes["/x/[id]"]).toBeUndefined();
-      });
-
-      it("is false when the sibling exists but carries no postponed state", () => {
-        writePrerenderManifest({ dynamicRoutes: { "/x/[id]": { fallbackRootParams: [] } } });
-        const manifest = build([template("/x/[id]", 7), rscSibling("/x/[id]", 7, undefined)]);
-        expect(manifest.pprCapableRoutes).toEqual({
-          "/x/[id]": { rootParams: [], wouldPostpone: false },
-        });
-      });
-
-      // The `without-io` flavour as the build really emits it: the template KEEPS its shell file
-      // (so `fallback` is not null) but nothing in its group ever postponed. Measured on a probe
-      // app: `/i/[slug]` fallback file present + postponedState absent, sibling postponedState
-      // absent. This must stay minimal (app-dir/fallback-shells).
-      it("is false for a shell-bearing-but-never-postponing template (without-io shape)", () => {
-        writePrerenderManifest({ dynamicRoutes: { "/x/[id]": { fallbackRootParams: [] } } });
-        const manifest = build([
-          template("/x/[id]", 7, {
-            fallback: { filePath: "/app/dist/x.html", postponedState: undefined } as any,
-          }),
-          rscSibling("/x/[id]", 7, undefined),
-        ]);
-        expect(manifest.pprCapableRoutes).toEqual({
-          "/x/[id]": { rootParams: [], wouldPostpone: false },
-        });
-      });
-
-      // The join must be on groupId, never on suffix arithmetic: a postponed state belonging to a
-      // DIFFERENT group — here a concrete generateStaticParams instance whose id happens to sit
-      // under the same route prefix — must not answer for the template.
-      it("ignores a postponed state from a different group", () => {
-        writePrerenderManifest({
-          dynamicRoutes: { "/x/[id]": { fallbackRootParams: [] } },
-          routes: { "/x/foo": {} },
-        });
-        const manifest = build([
-          template("/x/[id]", 7),
-          rscSibling("/x/[id]", 7, undefined),
-          mockPrerender({
-            pathname: "/x/foo",
-            sourcePage: "/x/[id]",
-            // @ts-ignore - mock property
-            groupId: 8,
-            fallback: { filePath: "/app/dist/x/foo.html", postponedState: "concrete" },
-            config: { renderingMode: "PARTIALLY_STATIC" as any },
-          }),
-          rscSibling("/x/foo", 8, "concrete"),
-        ]);
-        expect(manifest.pprCapableRoutes).toEqual({
-          "/x/[id]": { rootParams: [], wouldPostpone: false },
-        });
-      });
-
-      // Prerequisite-2 finding, pinned: two CONCRETE params of one template can disagree about
-      // postponing (measured on a probe app — `/h/dyn` postponed, `/h/stat` did not). That does
-      // NOT make the per-template flag wrong, because each concrete param sits in its own group
-      // and is answered by its own artifact; the template's flag describes only the template
-      // render, which is the only evidence available for a param with no build artifact.
-      it("is unaffected by concrete params that disagree about postponing", () => {
-        writePrerenderManifest({
-          dynamicRoutes: { "/x/[id]": { fallbackRootParams: [] } },
-          routes: { "/x/dyn": {}, "/x/stat": {} },
-        });
-        const manifest = build([
-          template("/x/[id]", 7),
-          rscSibling("/x/[id]", 7, "template-postponed"),
-          mockPrerender({
-            pathname: "/x/dyn",
-            sourcePage: "/x/[id]",
-            // @ts-ignore - mock property
-            groupId: 8,
-            fallback: { filePath: "/app/dist/x/dyn.html", postponedState: "dyn-postponed" },
-            config: { renderingMode: "PARTIALLY_STATIC" as any },
-          }),
-          rscSibling("/x/dyn", 8, "dyn-postponed"),
-          mockPrerender({
-            pathname: "/x/stat",
-            sourcePage: "/x/[id]",
-            // @ts-ignore - mock property
-            groupId: 9,
-            fallback: { filePath: "/app/dist/x/stat.html", postponedState: undefined } as any,
-            config: { renderingMode: "PARTIALLY_STATIC" as any },
-          }),
-          rscSibling("/x/stat", 9, undefined),
-        ]);
-        // Only the template is keyed; both concrete params keep their own artifacts.
-        expect(manifest.pprCapableRoutes).toEqual({
-          "/x/[id]": { rootParams: [], wouldPostpone: true },
-        });
-        expect(manifest.pprRoutes["/x/dyn"]).toBeDefined();
-        expect(manifest.pprRoutes["/x/stat"]).toBeUndefined();
-      });
-
-      // The build-time assertion. Losing the sibling upstream would silently reclassify every
-      // shell-less PPR template as "never postpones" and bring the truncation back, so it must be
-      // a loud build failure instead.
-      // N16c: this used to THROW, to protect the `wouldPostpone` signal. The signal turned out
-      // not to discriminate (see the N16c notes in manifest.ts and the minimalMode gate), so
-      // nothing load-bearing consumes it and a hard throw could only fail builds for no benefit.
-      // A missing sibling now classifies as "does not postpone" and the build proceeds.
-      it("does NOT throw when a PARTIALLY_STATIC template has no same-groupId .rsc sibling", () => {
-        writePrerenderManifest({ dynamicRoutes: { "/x/[id]": { fallbackRootParams: [] } } });
-        const manifest = build([template("/x/[id]", 7)]);
-        expect(manifest.pprCapableRoutes?.["/x/[id]"]?.wouldPostpone).toBe(false);
-      });
-
-      // A same-group member that is NOT the sibling does not satisfy the assertion: segment
-      // prerenders share the groupId but carry their own fallback FILE and hardcode
-      // `postponedState: undefined` (build-complete.js:634).
-      // N16c: both of these used to THROW for the same reason as above, and no longer do.
-      // Kept as regression cover that a missing/segment-only sibling is CLASSIFIED (as
-      // not-postponing) rather than fatal.
-      it("classifies rather than throws when the only same-group members are segment prerenders", () => {
-        writePrerenderManifest({ dynamicRoutes: { "/x/[id]": { fallbackRootParams: [] } } });
-        const manifest = build([
-          template("/x/[id]", 7),
-          mockPrerender({
-            pathname: "/x/[id].segments/_tree.segment.rsc",
-            sourcePage: "/x/[id]",
-            // @ts-ignore - mock property
-            groupId: 7,
-            fallback: { filePath: "/app/dist/x/_tree.segment.rsc", postponedState: undefined },
-            config: { renderingMode: "PARTIALLY_STATIC" as any },
-          }),
-        ]);
-        expect(manifest.pprCapableRoutes?.["/x/[id]"]?.wouldPostpone).toBe(false);
-      });
-
-      it("does not throw for a shell-bearing PARTIALLY_STATIC template with no sibling", () => {
-        writePrerenderManifest({ dynamicRoutes: { "/x/[id]": { fallbackRootParams: [] } } });
-        expect(() =>
-          build([
-            template("/x/[id]", 7, {
-              fallback: { filePath: "/app/dist/x.html", postponedState: "abc" },
-            }),
-          ]),
-        ).not.toThrow();
-      });
-
-      // The assertion covers the shell-BEARING flavour too: it is the same upstream contract, and
-      // a break there is the earliest signal that the discriminator is gone.
-      // Concrete instances and `.segments/` variants are NOT prerender-manifest `dynamicRoutes`
-      // members, so the assertion must not fire for them — they legitimately have no sibling of
-      // their own in some builds, and an over-broad assertion would break every build.
-      it("does not assert on outputs that are not route templates", () => {
-        writePrerenderManifest({
-          dynamicRoutes: { "/x/[id]": { fallbackRootParams: [] } },
-          routes: { "/x/foo": {} },
-        });
-        const manifest = build([
-          template("/x/[id]", 7),
-          rscSibling("/x/[id]", 7, undefined),
-          mockPrerender({
-            pathname: "/x/foo",
-            sourcePage: "/x/[id]",
-            // @ts-ignore - mock property
-            groupId: 8,
-            // @ts-ignore - mock property
-            fallback: null,
-            config: { renderingMode: "PARTIALLY_STATIC" as any },
-          }),
-        ]);
-        expect(manifest.pprCapableRoutes).toEqual({
-          "/x/[id]": { rootParams: [], wouldPostpone: false },
-        });
-      });
     });
   });
 
@@ -1040,82 +857,6 @@ describe("buildRoutingManifest", () => {
     expect(manifest.routeGraph.rsc).toBeDefined();
     expect(manifest.routeGraph.rsc.header).toBe("RSC");
     expect((manifest as any).rsc).toBeUndefined();
-  });
-});
-
-// Survey Tier 2 #7 (plans/lessons-from-sibling-adapters.md): the build emits PARTIALLY_STATIC
-// PRERENDER outputs whose fallback carries a postponedState but NO filePath — the shell-less
-// `.rsc` postponed-state siblings (dynamic-RSC prefetch responses for PPR routes,
-// build-complete.js:986-991). `pprRoutes` deliberately requires a shell and `pprCapableRoutes`
-// only admits route TEMPLATES (prerender-manifest dynamicRoutes members), so these outputs were
-// dropped from the manifest entirely — the resume implementation cannot see them. The Vercel
-// adapter registers them gated on `allowQuery.length === 0` (outputs.ts:652-673): with no
-// route-param variance the postponed state is shareable across requests; with params it is not
-// and must cold-render.
-describe("pprStatePrerenders (survey Tier 2 #7)", () => {
-  function manifestWith(prerender: Record<string, unknown>) {
-    const outputs = mockOutputs({
-      appPages: [mockAppPage({ pathname: "/novel" })],
-      prerenders: [mockPrerender(prerender as any)],
-    });
-    const pools = new Map<string, PoolDefinition>([
-      ["ssr", { name: "ssr", outputs: [outputs.appPages[0]!], config: { routes: ["appPages"] } }],
-    ]);
-    return buildRoutingManifest({
-      routing: mockRouting(),
-      outputs,
-      pools,
-      buildId: "test123",
-      basePath: "",
-      i18n: null,
-      nextVersion: "16.2.0",
-      projectDir: "/app",
-    });
-  }
-
-  it("registers a filePath-less postponed-state prerender when allowQuery is empty", () => {
-    const manifest = manifestWith({
-      pathname: "/novel.rsc",
-      groupId: 7,
-      fallback: { postponedState: "ppr-state-bytes" },
-      config: { renderingMode: "PARTIALLY_STATIC" as any, allowQuery: [] },
-    });
-    expect((manifest as any).pprStatePrerenders).toEqual({
-      "/novel.rsc": { postponedState: "ppr-state-bytes" },
-    });
-    // Disjoint from the shell-bearing map — nothing here has a shell to serve.
-    expect(manifest.pprRoutes["/novel.rsc"]).toBeUndefined();
-  });
-
-  it("refuses one whose allowQuery names route params (state is param-dependent, must cold-render)", () => {
-    const manifest = manifestWith({
-      pathname: "/novel/[id].rsc",
-      groupId: 8,
-      fallback: { postponedState: "param-dependent-state" },
-      config: { renderingMode: "PARTIALLY_STATIC" as any, allowQuery: ["id"] },
-    });
-    expect((manifest as any).pprStatePrerenders ?? {}).toEqual({});
-  });
-
-  it("refuses one with no allowQuery at all (variance unknown — conservative)", () => {
-    const manifest = manifestWith({
-      pathname: "/novel.rsc",
-      groupId: 9,
-      fallback: { postponedState: "state" },
-      config: { renderingMode: "PARTIALLY_STATIC" as any },
-    });
-    expect((manifest as any).pprStatePrerenders ?? {}).toEqual({});
-  });
-
-  it("leaves shell-bearing prerenders in pprRoutes only", () => {
-    const manifest = manifestWith({
-      pathname: "/dashboard",
-      groupId: 10,
-      fallback: { filePath: "/app/dist/dashboard.html", postponedState: "abc" },
-      config: { renderingMode: "PARTIALLY_STATIC" as any, allowQuery: [] },
-    });
-    expect(manifest.pprRoutes["/dashboard"]).toBeDefined();
-    expect((manifest as any).pprStatePrerenders ?? {}).toEqual({});
   });
 });
 

--- a/tests/pool-server/dispatch-invocation.test.ts
+++ b/tests/pool-server/dispatch-invocation.test.ts
@@ -829,23 +829,18 @@ describe("PPR minimal-mode gate with a registered classic cacheHandler", () => {
       expect(calls[0].minimalMode).toBe(true);
     });
 
-    // N16c: `wouldPostpone` is recorded on `pprCapableRoutes` entries (manifest.ts
-    // indexPrerenderGroups reads the same-groupId `.rsc` sibling's `fallback.postponedState`) but
-    // it is DELIBERATELY NOT a rung of the minimalMode gate. It was added as one, to fix
-    // `/novel/early-span` (1,358 bytes ending in an empty closed `<!--$--><!--/$-->` boundary,
-    // where `next start` returns 7,658 bytes of resolved content) — and MEASURED against upstream:
+    // Manifests emitted during the N16b experiment carried an inert `wouldPostpone` property.
+    // Rolling upgrades may still load one. Keep proving that the old property cannot change the
+    // root-param gate: the build-time state did not discriminate the two runtime behaviors.
     //
     //   with the rung:    app-dir/fallback-shells  8 passed / 5 failed
     //   without the rung: app-dir/fallback-shells 13 passed / 0 failed
     //   (and cache-components-allow-otel-spans stayed 3/1 either way — the rung only traded
     //    `early-span` for `prerendering at runtime` in the same file.)
     //
-    // So the signal does not discriminate: fallback-shells' never-postponing routes carry sibling
-    // postponed state too, and flipping non-minimal on it re-breaks them exactly like the blunt
-    // `|| handlerPprCapable` fix that preceded it. The truth table below pins that the bit is
-    // INERT at the gate; the real fix has to implement the platform's half of the resume
-    // (docs/superpowers/specs/2026-07-26-ppr-resume-shell-less-templates.md, option B).
-    describe("wouldPostpone truth table (N16c: inert at the gate)", () => {
+    // The current manifest no longer emits the property. Option D uses the live render result
+    // instead, while this table pins compatibility with an outgoing build.
+    describe("legacy wouldPostpone entries are ignored", () => {
       // (has build shell, has root params, wouldPostpone) → expected minimalMode.
       // A build never emits shell-bearing AND pprCapableRoutes for the same template — manifest.ts
       // keeps the two maps disjoint and tests that — but the rows are included anyway to pin that
@@ -888,7 +883,7 @@ describe("PPR minimal-mode gate with a registered classic cacheHandler", () => {
               : {},
             pprCapableRoutes: {
               "/x/[id]": { rootParams: hasRootParams ? ["lang"] : [], wouldPostpone },
-            },
+            } as any,
             incrementalCacheShared: true,
             rscConfig,
             localHandlerInvoker: invoker as any,
@@ -915,7 +910,7 @@ describe("PPR minimal-mode gate with a registered classic cacheHandler", () => {
           buildId: "test123",
           staticAssets: [],
           pprRoutes: {},
-          pprCapableRoutes: { "/x/[id]": { rootParams: [], wouldPostpone: true } },
+          pprCapableRoutes: { "/x/[id]": { rootParams: [], wouldPostpone: true } } as any,
           entrypointOwnsPprShell: true,
           rscConfig,
           localHandlerInvoker: invoker as any,
@@ -939,7 +934,7 @@ describe("PPR minimal-mode gate with a registered classic cacheHandler", () => {
           buildId: "test123",
           staticAssets: [],
           pprRoutes: {},
-          pprCapableRoutes: { "/x/[id]": { rootParams: [], wouldPostpone: true } },
+          pprCapableRoutes: { "/x/[id]": { rootParams: [], wouldPostpone: true } } as any,
           incrementalCacheShared: false,
           entrypointOwnsPprShell: false,
           rscConfig,
@@ -988,7 +983,7 @@ describe("PPR minimal-mode gate with a registered classic cacheHandler", () => {
           buildId: "test123",
           staticAssets: [],
           pprRoutes: {},
-          pprCapableRoutes: { "/x/[id]": { rootParams: [], wouldPostpone: true } },
+          pprCapableRoutes: { "/x/[id]": { rootParams: [], wouldPostpone: true } } as any,
           incrementalCacheShared: true,
           rscConfig,
           localHandlerInvoker: invoker as any,

--- a/tests/pool-server/dispatch-ppr-capable-resume.test.ts
+++ b/tests/pool-server/dispatch-ppr-capable-resume.test.ts
@@ -1,5 +1,4 @@
-// Shell-less PPR template resume — spec rev 4 "Option D"
-// (docs/superpowers/specs/2026-07-26-ppr-resume-shell-less-templates.md).
+// Shell-less PPR template resume, "Option D".
 //
 // The class: routes in `pprCapableRoutes` with `rootParams: []` run MINIMAL (correctly — the
 // fallback-shells `without-io` flavour must stay minimal), but when such a render POSTPONES,

--- a/tests/pool-server/valkey-cache/resp-client.test.ts
+++ b/tests/pool-server/valkey-cache/resp-client.test.ts
@@ -41,6 +41,9 @@ interface FakeServer {
   commands: string[][];
   /** Total connections the server has accepted (used to observe reconnects). */
   connectionCount: () => number;
+  /** Connections that carried at least one complete RESP command. Ambient localhost probes may
+   * connect to a random test port, but they cannot manufacture the client's command stream. */
+  commandConnectionCount: () => number;
   close: () => Promise<void>;
 }
 
@@ -59,6 +62,7 @@ function startFakeValkey(
 ): Promise<FakeServer> {
   const commands: string[][] = [];
   const sockets = new Set<net.Socket>();
+  const commandSockets = new Set<net.Socket>();
   let connections = 0;
   const onConnection = (socket: net.Socket) => {
     connections++;
@@ -71,6 +75,7 @@ function startFakeValkey(
       for (;;) {
         const parsed = parseCommand(buf);
         if (!parsed) break;
+        commandSockets.add(socket);
         commands.push(parsed.args);
         buf = buf.subarray(parsed.consumed);
         const reply = respond(parsed.args, socket);
@@ -98,6 +103,7 @@ function startFakeValkey(
         port,
         commands,
         connectionCount: () => connections,
+        commandConnectionCount: () => commandSockets.size,
         close: () =>
           new Promise<void>((r) => {
             for (const s of sockets) s.destroy();
@@ -835,12 +841,12 @@ describe("L17: circuit breaker after a failure (fail fast, probe later)", () => 
     try {
       // Trip the breaker: the command times out and the connection is destroyed.
       await expect(client.get("hang")).rejects.toThrow(/timed out/);
-      const connsAfterTrip = server.connectionCount();
+      const connsAfterTrip = server.commandConnectionCount();
       // Within the window, commands reject with the breaker error and make NO reconnect attempt
       // (a reconnect would bump the server's accepted-connection count).
       await expect(client.get("k")).rejects.toThrow(/circuit breaker/);
       await expect(client.get("k")).rejects.toThrow(/circuit breaker/);
-      expect(server.connectionCount()).toBe(connsAfterTrip);
+      expect(server.commandConnectionCount()).toBe(connsAfterTrip);
     } finally {
       await client.quit();
       await server.close();
@@ -857,10 +863,10 @@ describe("L17: circuit breaker after a failure (fail fast, probe later)", () => 
     });
     try {
       await expect(client.get("hang")).rejects.toThrow(/timed out/);
-      const connsAfterTrip = server.connectionCount();
+      const connsAfterTrip = server.commandConnectionCount();
       await sleep(800);
       expect(await client.get("k")).toBe("v");
-      expect(server.connectionCount()).toBe(connsAfterTrip + 1);
+      expect(server.commandConnectionCount()).toBe(connsAfterTrip + 1);
     } finally {
       await client.quit();
       await server.close();


### PR DESCRIPTION
## Summary

- Update the build toolchain and dependency overrides so the release graph audits cleanly.
- Tighten release and test gates, including the Valkey reconnect regression path.
- Remove unused shell-less PPR build-state machinery while retaining the exercised runtime resume contract.
- Keep generated secrets and local agent state outside commits.

## Testing

- `npm test`
- `npm audit --audit-level=low`
